### PR TITLE
feat(serialization): initial common (de)serializers for C++ structs and ROS 2 msgs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         env:
           - ICI_JOB_NAME: gcc
             ROS_DISTRO: jazzy
+            UPSTREAM_WORKSPACE: 'github:ros-industrial/vda5050_interfaces#throwaway/remove-serde'
           - ICI_JOB_NAME: clang
             ROS_DISTRO: jazzy
             ADDITIONAL_DEBS: clang lld

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,14 @@ jobs:
           - ICI_JOB_NAME: gcc
             ROS_DISTRO: jazzy
             UPSTREAM_WORKSPACE: 'github:ros-industrial/vda5050_interfaces#throwaway/remove-serde'
+            TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'
           - ICI_JOB_NAME: clang
             ROS_DISTRO: jazzy
+            UPSTREAM_WORKSPACE: 'github:ros-industrial/vda5050_interfaces#throwaway/remove-serde'
             ADDITIONAL_DEBS: clang lld
             CC: "clang"
             CXX: "clang++"
+            TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'
     env:
       ISOLATION: "shell"
     runs-on: ubuntu-latest

--- a/vda5050_json_utils/CMakeLists.txt
+++ b/vda5050_json_utils/CMakeLists.txt
@@ -80,13 +80,9 @@ if(BUILD_TESTING)
   set(cpplint_filters
     "-whitespace/newline"
   )
-  set(cpplint_root_paths
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/"
-  )
 
   ament_cpplint(
     FILTERS "${cpplint_filters}"
-    ROOT "${cpplint_root_paths}"
   )
 
   find_package(ament_cmake_clang_format REQUIRED)

--- a/vda5050_json_utils/CMakeLists.txt
+++ b/vda5050_json_utils/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 3.20)
+project(vda5050_json_utils)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(vda5050_types REQUIRED)
+find_package(nlohmann_json REQUIRED)
+find_package(vda5050_msgs REQUIRED)
+
+include(GNUInstallDirs)
+
+option(ENABLE_ROS2 "Enable ROS 2 message support in JSON utilities" OFF)
+
+if(ENABLE_ROS2)
+  message(STATUS "Building vda5050_json_utils with ROS 2 support")
+  find_package(vda5050_msgs REQUIRED)
+else()
+  message(STATUS "Building vda5050_json_utils without ROS 2 support")
+endif()
+
+add_library(vda5050_json_utils INTERFACE)
+
+target_link_libraries(vda5050_json_utils
+  INTERFACE
+    vda5050_types::vda5050_types
+)
+
+target_include_directories(vda5050_json_utils
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+if(ENABLE_ROS2)
+  target_link_libraries(vda5050_json_utils
+    INTERFACE
+      ${vda5050_msgs_LIBRARIES}
+  )
+
+  target_include_directories(vda5050_json_utils
+    INTERFACE
+      ${vda5050_msgs_INCLUDE_DIRS}
+  )
+
+  target_compile_definitions(vda5050_json_utils INTERFACE ENABLE_ROS2)
+endif()
+
+install(
+  DIRECTORY include/vda5050_json_utils
+  DESTINATION include
+)
+
+install(
+  TARGETS vda5050_json_utils
+  EXPORT export_vda5050_json_utils
+)
+
+ament_export_include_directories(include)
+ament_export_targets(export_vda5050_json_utils HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  nlohmann_json
+  vda5050_types
+  vda5050_msgs
+)
+
+if(ENABLE_ROS2)
+  ament_export_dependencies(vda5050_msgs)
+endif()
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_cppcheck REQUIRED)
+  ament_cppcheck()
+
+  find_package(ament_cmake_cpplint REQUIRED)
+  ament_cpplint()
+
+  find_package(ament_cmake_clang_format REQUIRED)
+  ament_clang_format(
+    CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
+  )
+
+  find_package(ament_cmake_copyright REQUIRED)
+  ament_copyright()
+endif()
+
+ament_package()

--- a/vda5050_json_utils/CMakeLists.txt
+++ b/vda5050_json_utils/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(vda5050_json_utils INTERFACE)
 target_link_libraries(vda5050_json_utils
   INTERFACE
     vda5050_types::vda5050_types
+    nlohmann_json::nlohmann_json
 )
 
 target_include_directories(vda5050_json_utils
@@ -75,7 +76,18 @@ if(BUILD_TESTING)
   ament_cppcheck()
 
   find_package(ament_cmake_cpplint REQUIRED)
-  ament_cpplint()
+
+  set(cpplint_filters
+    "-whitespace/newline"
+  )
+  set(cpplint_root_paths
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+  )
+
+  ament_cpplint(
+    FILTERS "${cpplint_filters}"
+    ROOT "${cpplint_root_paths}"
+  )
 
   find_package(ament_cmake_clang_format REQUIRED)
   ament_clang_format(
@@ -84,6 +96,25 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_copyright REQUIRED)
   ament_copyright()
+
+  find_package(ament_cmake_gtest REQUIRED)
+
+  set(tests test/test_json_utils.cpp)
+  if(ENABLE_ROS2)
+    list(APPEND tests test/test_json_utils_ros2.cpp)
+  endif()
+
+  ament_add_gtest(json_utils_struct_test ${tests})
+
+  target_include_directories(json_utils_struct_test
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+
+  target_link_libraries(json_utils_struct_test
+      vda5050_json_utils
+  )
 endif()
 
 ament_package()

--- a/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
@@ -19,14 +19,18 @@
 #ifndef VDA5050_JSON_UTILS__SERIALIZATION_HPP_
 #define VDA5050_JSON_UTILS__SERIALIZATION_HPP_
 
-#include <iostream>
+#include <string>
 
 #include <nlohmann/json.hpp>
 
+#include <vda5050_types/connection.hpp>
 #include <vda5050_types/header.hpp>
+#include <vda5050_types/state.hpp>
 
 #ifdef ENABLE_ROS2
+#include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/header.hpp>
+#include <vda5050_msgs/msg/state.hpp>
 #endif  // ENABLE_ROS2
 
 #include "traits.hpp"
@@ -39,7 +43,7 @@ namespace header_detail {
 template <typename HeaderT>
 void to_json(nlohmann::json& j, const HeaderT& msg)
 {
-  using namespace vda5050_json_utils;
+  using vda5050_json_utils::timestamp_traits;
 
   j = nlohmann::json{
     {"headerId", msg.header_id},
@@ -54,7 +58,7 @@ void to_json(nlohmann::json& j, const HeaderT& msg)
 template <typename HeaderT>
 void from_json(const nlohmann::json& j, HeaderT& msg)
 {
-  using namespace vda5050_json_utils;
+  using vda5050_json_utils::timestamp_traits;
 
   msg.header_id = j.at("headerId").get<uint32_t>();
   msg.timestamp = timestamp_traits<decltype(msg.timestamp)>::from_string(
@@ -66,11 +70,13 @@ void from_json(const nlohmann::json& j, HeaderT& msg)
 
 }  // namespace header_detail
 
+//=============================================================================
 inline void to_json(nlohmann::json& j, const Header& msg)
 {
   vda5050_types::header_detail::to_json(j, msg);
 }
 
+//=============================================================================
 inline void from_json(const nlohmann::json& j, Header& msg)
 {
   vda5050_types::header_detail::from_json(j, msg);
@@ -82,7 +88,7 @@ namespace connection_detail {
 template <typename ConnectionT>
 void to_json(nlohmann::json& j, const ConnectionT& msg)
 {
-  using namespace vda5050_json_utils;
+  using vda5050_json_utils::connection_state_traits;
 
   header_detail::to_json(j, msg.header);
 
@@ -95,7 +101,7 @@ void to_json(nlohmann::json& j, const ConnectionT& msg)
 template <typename ConnectionT>
 void from_json(const nlohmann::json& j, ConnectionT& msg)
 {
-  using namespace vda5050_json_utils;
+  using vda5050_json_utils::connection_state_traits;
 
   header_detail::from_json(j, msg.header);
 
@@ -106,14 +112,71 @@ void from_json(const nlohmann::json& j, ConnectionT& msg)
 
 }  // namespace connection_detail
 
+//=============================================================================
 inline void to_json(nlohmann::json& j, const Connection& msg)
 {
   vda5050_types::connection_detail::to_json(j, msg);
 }
 
+//=============================================================================
 inline void from_json(const nlohmann::json& j, Connection& msg)
 {
   vda5050_types::connection_detail::from_json(j, msg);
+}
+
+namespace state_detail {
+
+//=============================================================================
+template <typename StateT>
+void to_json(nlohmann::json& j, const StateT& msg)
+{
+  using vda5050_json_utils::operating_mode_traits;
+
+  header_detail::to_json(j, msg.header);
+
+  j["orderId"] = msg.order_id;
+  j["orderUpdateId"] = msg.order_update_id;
+  j["lastNodeId"] = msg.last_node_id;
+  j["lastNodeSequenceId"] = msg.last_node_sequence_id;
+  j["driving"] = msg.driving;
+
+  j["operatingMode"] =
+    operating_mode_traits<decltype(msg.operating_mode)>::to_string(
+      msg.operating_mode);
+}
+
+//=============================================================================
+template <typename StateT>
+void from_json(const nlohmann::json& j, StateT& msg)
+{
+  using vda5050_json_utils::operating_mode_traits;
+  using vda5050_types::header_detail::from_json;
+
+  header_detail::from_json(j, msg.header);
+
+  msg.order_id = j.at("orderId").get<std::string>();
+  msg.order_update_id = j.at("orderUpdateId").get<uint32_t>();
+  msg.last_node_id = j.at("lastNodeId").get<std::string>();
+  msg.last_node_sequence_id = j.at("lastNodeSequenceId").get<uint32_t>();
+  msg.driving = j.at("driving").get<bool>();
+
+  msg.operating_mode =
+    operating_mode_traits<decltype(msg.operating_mode)>::from_string(
+      j.at("operatingMode").get<std::string>());
+}
+
+}  // namespace state_detail
+
+//=============================================================================
+inline void to_json(nlohmann::json& j, const State& msg)
+{
+  vda5050_types::state_detail::to_json(j, msg);
+}
+
+//=============================================================================
+inline void from_json(const nlohmann::json& j, State& msg)
+{
+  vda5050_types::state_detail::from_json(j, msg);
 }
 
 }  // namespace vda5050_types
@@ -142,6 +205,16 @@ inline void to_json(nlohmann::json& j, const Connection& msg)
 inline void from_json(const nlohmann::json& j, Connection& msg)
 {
   vda5050_types::connection_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const State& msg)
+{
+  vda5050_types::state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, State& msg)
+{
+  vda5050_types::state_detail::from_json(j, msg);
 }
 
 }  // namespace msg

--- a/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
@@ -25,11 +25,15 @@
 
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/header.hpp>
+#include <vda5050_types/node_position.hpp>
+#include <vda5050_types/node_state.hpp>
 #include <vda5050_types/state.hpp>
 
 #ifdef ENABLE_ROS2
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/header.hpp>
+#include <vda5050_msgs/msg/node_position.hpp>
+#include <vda5050_msgs/msg/node_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #endif  // ENABLE_ROS2
 
@@ -70,18 +74,6 @@ void from_json(const nlohmann::json& j, HeaderT& msg)
 
 }  // namespace header_detail
 
-//=============================================================================
-inline void to_json(nlohmann::json& j, const Header& msg)
-{
-  vda5050_types::header_detail::to_json(j, msg);
-}
-
-//=============================================================================
-inline void from_json(const nlohmann::json& j, Header& msg)
-{
-  vda5050_types::header_detail::from_json(j, msg);
-}
-
 namespace connection_detail {
 
 //=============================================================================
@@ -89,8 +81,9 @@ template <typename ConnectionT>
 void to_json(nlohmann::json& j, const ConnectionT& msg)
 {
   using vda5050_json_utils::connection_state_traits;
+  using vda5050_types::header_detail::to_json;
 
-  header_detail::to_json(j, msg.header);
+  to_json(j, msg.header);
 
   j["connectionState"] =
     connection_state_traits<decltype(msg.connection_state)>::to_string(
@@ -102,8 +95,9 @@ template <typename ConnectionT>
 void from_json(const nlohmann::json& j, ConnectionT& msg)
 {
   using vda5050_json_utils::connection_state_traits;
+  using vda5050_types::header_detail::from_json;
 
-  header_detail::from_json(j, msg.header);
+  from_json(j, msg.header);
 
   msg.connection_state =
     connection_state_traits<decltype(msg.connection_state)>::from_string(
@@ -112,17 +106,147 @@ void from_json(const nlohmann::json& j, ConnectionT& msg)
 
 }  // namespace connection_detail
 
+namespace node_position_detail {
+
 //=============================================================================
-inline void to_json(nlohmann::json& j, const Connection& msg)
+template <typename NodePositionT>
+void to_json(nlohmann::json& j, const NodePositionT& msg)
 {
-  vda5050_types::connection_detail::to_json(j, msg);
+  using theta_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.theta)>;
+  using allowed_deviation_x_y_trait = vda5050_json_utils::optional_field_traits<
+    decltype(msg.allowed_deviation_x_y)>;
+  using allowed_deviation_theta_trait =
+    vda5050_json_utils::optional_field_traits<
+      decltype(msg.allowed_deviation_theta)>;
+  using map_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.map_description)>;
+
+  j["x"] = msg.x;
+  j["y"] = msg.y;
+  j["mapId"] = msg.map_id;
+
+  if (theta_trait::has_value(msg.theta))
+  {
+    j["theta"] = theta_trait::get(msg.theta);
+  }
+
+  if (allowed_deviation_x_y_trait::has_value(msg.allowed_deviation_x_y))
+  {
+    j["allowedDeviationXY"] =
+      allowed_deviation_x_y_trait::get(msg.allowed_deviation_x_y);
+  }
+
+  if (allowed_deviation_theta_trait::has_value(msg.allowed_deviation_theta))
+  {
+    j["allowedDeviationTheta"] =
+      allowed_deviation_theta_trait::get(msg.allowed_deviation_theta);
+  }
+
+  if (map_description_trait::has_value(msg.map_description))
+  {
+    j["mapDescription"] = map_description_trait::get(msg.map_description);
+  }
 }
 
 //=============================================================================
-inline void from_json(const nlohmann::json& j, Connection& msg)
+template <typename NodePositionT>
+void from_json(const nlohmann::json& j, NodePositionT& msg)
 {
-  vda5050_types::connection_detail::from_json(j, msg);
+  using theta_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.theta)>;
+  using allowed_deviation_x_y_trait = vda5050_json_utils::optional_field_traits<
+    decltype(msg.allowed_deviation_x_y)>;
+  using allowed_deviation_theta_trait =
+    vda5050_json_utils::optional_field_traits<
+      decltype(msg.allowed_deviation_theta)>;
+  using map_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.map_description)>;
+
+  msg.x = j.at("x").get<double>();
+  msg.y = j.at("y").get<double>();
+  msg.map_id = j.at("mapId").get<std::string>();
+
+  if (j.contains("theta"))
+  {
+    theta_trait::set(msg.theta, j.at("theta").get<double>());
+  }
+
+  if (j.contains("allowedDeviationXY"))
+  {
+    allowed_deviation_x_y_trait::set(
+      msg.allowed_deviation_x_y, j.at("allowedDeviationXY").get<double>());
+  }
+
+  if (j.contains("allowedDeviationTheta"))
+  {
+    allowed_deviation_theta_trait::set(
+      msg.allowed_deviation_theta, j.at("allowedDeviationTheta").get<double>());
+  }
+
+  if (j.contains("mapDescription"))
+  {
+    map_description_trait::set(
+      msg.map_description, j.at("mapDescription").get<std::string>());
+  }
 }
+
+}  // namespace node_position_detail
+
+namespace node_state_detail {
+
+//=============================================================================
+template <typename NodeStateT>
+void to_json(nlohmann::json& j, const NodeStateT& msg)
+{
+  using vda5050_types::node_position_detail::to_json;
+  using node_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.node_description)>;
+  using node_position_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.node_position)>;
+
+  j["nodeId"] = msg.node_id;
+  j["sequenceId"] = msg.sequence_id;
+  j["released"] = msg.released;
+
+  if (node_description_trait::has_value(msg.node_description))
+  {
+    j["nodeDescription"] = node_description_trait::get(msg.node_description);
+  }
+
+  if (node_position_trait::has_value(msg.node_position))
+  {
+    j["nodePosition"] = node_position_trait::get(msg.node_position);
+  }
+}
+
+//=============================================================================
+template <typename NodeStateT>
+void from_json(const nlohmann::json& j, NodeStateT& msg)
+{
+  using vda5050_types::node_position_detail::to_json;
+  using node_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.node_description)>;
+  using node_position_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.node_position)>;
+
+  msg.node_id = j.at("nodeId").get<std::string>();
+  msg.sequence_id = j.at("sequenceId").get<uint32_t>();
+  msg.released = j.at("released").get<bool>();
+
+  if (j.contains("nodeDescription"))
+  {
+    node_description_trait::set(
+      msg.node_description, j.at("nodeDescription").get<std::string>());
+  }
+
+  if (j.contains("nodePosition"))
+  {
+    node_position_trait::set(msg.node_position, j.at("nodePosition"));
+  }
+}
+
+}  // namespace node_state_detail
 
 namespace state_detail {
 
@@ -131,8 +255,10 @@ template <typename StateT>
 void to_json(nlohmann::json& j, const StateT& msg)
 {
   using vda5050_json_utils::operating_mode_traits;
+  using vda5050_types::header_detail::to_json;
+  using vda5050_types::node_state_detail::to_json;
 
-  header_detail::to_json(j, msg.header);
+  to_json(j, msg.header);
 
   j["orderId"] = msg.order_id;
   j["orderUpdateId"] = msg.order_update_id;
@@ -143,6 +269,8 @@ void to_json(nlohmann::json& j, const StateT& msg)
   j["operatingMode"] =
     operating_mode_traits<decltype(msg.operating_mode)>::to_string(
       msg.operating_mode);
+
+  j["nodeStates"] = msg.node_states;
 }
 
 //=============================================================================
@@ -151,8 +279,9 @@ void from_json(const nlohmann::json& j, StateT& msg)
 {
   using vda5050_json_utils::operating_mode_traits;
   using vda5050_types::header_detail::from_json;
+  using vda5050_types::node_state_detail::from_json;
 
-  header_detail::from_json(j, msg.header);
+  from_json(j, msg.header);
 
   msg.order_id = j.at("orderId").get<std::string>();
   msg.order_update_id = j.at("orderUpdateId").get<uint32_t>();
@@ -163,17 +292,61 @@ void from_json(const nlohmann::json& j, StateT& msg)
   msg.operating_mode =
     operating_mode_traits<decltype(msg.operating_mode)>::from_string(
       j.at("operatingMode").get<std::string>());
+
+  msg.node_states = j.at("nodeStates");
 }
 
 }  // namespace state_detail
 
-//=============================================================================
+}  // namespace vda5050_types
+
+namespace vda5050_types {
+
+inline void to_json(nlohmann::json& j, const Header& msg)
+{
+  vda5050_types::header_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Header& msg)
+{
+  vda5050_types::header_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Connection& msg)
+{
+  vda5050_types::connection_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Connection& msg)
+{
+  vda5050_types::connection_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const NodePosition& msg)
+{
+  vda5050_types::node_position_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, NodePosition& msg)
+{
+  vda5050_types::node_position_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const NodeState& msg)
+{
+  vda5050_types::node_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, NodeState& msg)
+{
+  vda5050_types::node_state_detail::from_json(j, msg);
+}
+
 inline void to_json(nlohmann::json& j, const State& msg)
 {
   vda5050_types::state_detail::to_json(j, msg);
 }
 
-//=============================================================================
 inline void from_json(const nlohmann::json& j, State& msg)
 {
   vda5050_types::state_detail::from_json(j, msg);
@@ -205,6 +378,26 @@ inline void to_json(nlohmann::json& j, const Connection& msg)
 inline void from_json(const nlohmann::json& j, Connection& msg)
 {
   vda5050_types::connection_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const NodePosition& msg)
+{
+  vda5050_types::node_position_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, NodePosition& msg)
+{
+  vda5050_types::node_position_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const NodeState& msg)
+{
+  vda5050_types::node_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, NodeState& msg)
+{
+  vda5050_types::node_state_detail::from_json(j, msg);
 }
 
 inline void to_json(nlohmann::json& j, const State& msg)

--- a/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2025 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_JSON_UTILS__SERIALIZATION_HPP_
+#define VDA5050_JSON_UTILS__SERIALIZATION_HPP_
+
+#include <iostream>
+
+#include <nlohmann/json.hpp>
+
+#include <vda5050_types/header.hpp>
+
+#ifdef ENABLE_ROS2
+#include <vda5050_msgs/msg/header.hpp>
+#endif  // ENABLE_ROS2
+
+#include "traits.hpp"
+
+namespace vda5050_types {
+
+namespace header_detail {
+
+//=============================================================================
+template <typename HeaderT>
+void to_json(nlohmann::json& j, const HeaderT& msg)
+{
+  using namespace vda5050_json_utils;
+
+  j = nlohmann::json{
+    {"headerId", msg.header_id},
+    {"timestamp",
+     timestamp_traits<decltype(msg.timestamp)>::to_string(msg.timestamp)},
+    {"version", msg.version},
+    {"manufacturer", msg.manufacturer},
+    {"serialNumber", msg.serial_number}};
+}
+
+//=============================================================================
+template <typename HeaderT>
+void from_json(const nlohmann::json& j, HeaderT& msg)
+{
+  using namespace vda5050_json_utils;
+
+  msg.header_id = j.at("headerId").get<uint32_t>();
+  msg.timestamp = timestamp_traits<decltype(msg.timestamp)>::from_string(
+    j.at("timestamp").get<std::string>());
+  msg.version = j.at("version").get<std::string>();
+  msg.manufacturer = j.at("manufacturer").get<std::string>();
+  msg.serial_number = j.at("serialNumber").get<std::string>();
+}
+
+}  // namespace header_detail
+
+inline void to_json(nlohmann::json& j, const Header& msg)
+{
+  vda5050_types::header_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Header& msg)
+{
+  vda5050_types::header_detail::from_json(j, msg);
+}
+
+namespace connection_detail {
+
+//=============================================================================
+template <typename ConnectionT>
+void to_json(nlohmann::json& j, const ConnectionT& msg)
+{
+  using namespace vda5050_json_utils;
+
+  header_detail::to_json(j, msg.header);
+
+  j["connectionState"] =
+    connection_state_traits<decltype(msg.connection_state)>::to_string(
+      msg.connection_state);
+}
+
+//=============================================================================
+template <typename ConnectionT>
+void from_json(const nlohmann::json& j, ConnectionT& msg)
+{
+  using namespace vda5050_json_utils;
+
+  header_detail::from_json(j, msg.header);
+
+  msg.connection_state =
+    connection_state_traits<decltype(msg.connection_state)>::from_string(
+      j.at("connectionState").get<std::string>());
+}
+
+}  // namespace connection_detail
+
+inline void to_json(nlohmann::json& j, const Connection& msg)
+{
+  vda5050_types::connection_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Connection& msg)
+{
+  vda5050_types::connection_detail::from_json(j, msg);
+}
+
+}  // namespace vda5050_types
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+namespace vda5050_msgs {
+
+namespace msg {
+
+inline void to_json(nlohmann::json& j, const Header& msg)
+{
+  vda5050_types::header_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Header& msg)
+{
+  vda5050_types::header_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Connection& msg)
+{
+  vda5050_types::connection_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Connection& msg)
+{
+  vda5050_types::connection_detail::from_json(j, msg);
+}
+
+}  // namespace msg
+
+}  // namespace vda5050_msgs
+#endif  // ENABLE_ROS2
+
+#endif  // VDA5050_JSON_UTILS__SERIALIZATION_HPP_

--- a/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
@@ -19,17 +19,21 @@
 #ifndef VDA5050_JSON_UTILS__SERIALIZATION_HPP_
 #define VDA5050_JSON_UTILS__SERIALIZATION_HPP_
 
+#include <iostream>
 #include <string>
 #include <vector>
 
 #include <nlohmann/json.hpp>
 
+#include <vda5050_types/action.hpp>
+#include <vda5050_types/action_parameter.hpp>
 #include <vda5050_types/action_state.hpp>
 #include <vda5050_types/agv_position.hpp>
 #include <vda5050_types/battery_state.hpp>
 #include <vda5050_types/bounding_box_reference.hpp>
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/control_point.hpp>
+#include <vda5050_types/edge.hpp>
 #include <vda5050_types/edge_state.hpp>
 #include <vda5050_types/error.hpp>
 #include <vda5050_types/error_reference.hpp>
@@ -37,8 +41,10 @@
 #include <vda5050_types/info.hpp>
 #include <vda5050_types/info_reference.hpp>
 #include <vda5050_types/load.hpp>
+#include <vda5050_types/node.hpp>
 #include <vda5050_types/node_position.hpp>
 #include <vda5050_types/node_state.hpp>
+#include <vda5050_types/order.hpp>
 #include <vda5050_types/safety_state.hpp>
 #include <vda5050_types/state.hpp>
 #include <vda5050_types/trajectory.hpp>
@@ -59,6 +65,7 @@
 #include <vda5050_msgs/msg/load.hpp>
 #include <vda5050_msgs/msg/node_position.hpp>
 #include <vda5050_msgs/msg/node_state.hpp>
+#include <vda5050_msgs/msg/order.hpp>
 #include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #include <vda5050_msgs/msg/trajectory.hpp>
@@ -1193,6 +1200,386 @@ void from_json(const nlohmann::json& j, StateT& msg)
 
 }  // namespace state_detail
 
+namespace action_parameter_detail {
+
+//=============================================================================
+template <typename ActionParameterT>
+void to_json(nlohmann::json& j, const ActionParameterT& msg)
+{
+  j["key"] = msg.key;
+  j["value"] = msg.value;
+}
+
+//=============================================================================
+template <typename ActionParameterT>
+void from_json(const nlohmann::json& j, ActionParameterT& msg)
+{
+  msg.key = j.at("key").get<std::string>();
+  msg.value = j.at("value").get<std::string>();
+}
+
+}  // namespace action_parameter_detail
+
+namespace action_detail {
+
+//=============================================================================
+template <typename ActionT>
+void to_json(nlohmann::json& j, const ActionT& msg)
+{
+  using vda5050_json_utils::blocking_type_traits;
+  using vda5050_json_utils::optional_field_traits;
+
+  using action_description_trait =
+    optional_field_traits<decltype(msg.action_description)>;
+  using action_parameters_trait =
+    optional_field_traits<decltype(msg.action_parameters)>;
+
+  j["actionType"] = msg.action_type;
+  j["actionId"] = msg.action_id;
+
+  j["blockingType"] =
+    blocking_type_traits<decltype(msg.blocking_type)>::to_string(
+      msg.blocking_type);
+
+  if (action_description_trait::has_value(msg.action_description))
+  {
+    j["actionDescription"] =
+      action_description_trait::get(msg.action_description);
+  }
+
+  if (action_parameters_trait::has_value(msg.action_parameters))
+  {
+    j["actionParameters"] = action_parameters_trait::get(msg.action_parameters);
+  }
+}
+
+//=============================================================================
+template <typename ActionT>
+void from_json(const nlohmann::json& j, ActionT& msg)
+{
+  using vda5050_json_utils::blocking_type_traits;
+  using vda5050_json_utils::optional_field_traits;
+
+  using action_description_trait =
+    optional_field_traits<decltype(msg.action_description)>;
+  using action_parameters_trait =
+    optional_field_traits<decltype(msg.action_parameters)>;
+
+  msg.action_type = j.at("actionType").get<std::string>();
+  msg.action_id = j.at("actionId").get<std::string>();
+  msg.blocking_type =
+    blocking_type_traits<decltype(msg.blocking_type)>::from_string(
+      j.at("blockingType").get<std::string>());
+
+  if (j.contains("actionDescription"))
+  {
+    action_description_trait::set(
+      msg.action_description, j.at("actionDescription").get<std::string>());
+  }
+
+  if (j.contains("actionParameters"))
+  {
+    action_parameters_trait::set(
+      msg.action_parameters, j.at("actionParameters"));
+  }
+}
+
+}  // namespace action_detail
+
+namespace node_detail {
+
+//=============================================================================
+template <typename NodeT>
+void to_json(nlohmann::json& j, const NodeT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using node_position_trait =
+    optional_field_traits<decltype(msg.node_position)>;
+  using node_description_trait =
+    optional_field_traits<decltype(msg.node_description)>;
+
+  j["nodeId"] = msg.node_id;
+  j["sequenceId"] = msg.sequence_id;
+  j["released"] = msg.released;
+  j["actions"] = msg.actions;
+
+  if (node_position_trait::has_value(msg.node_position))
+  {
+    j["nodePosition"] = node_position_trait::get(msg.node_position);
+  }
+
+  if (node_description_trait::has_value(msg.node_description))
+  {
+    j["nodeDescription"] = node_description_trait::get(msg.node_description);
+  }
+}
+
+//=============================================================================
+template <typename NodeT>
+void from_json(const nlohmann::json& j, NodeT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using node_position_trait =
+    optional_field_traits<decltype(msg.node_position)>;
+  using node_description_trait =
+    optional_field_traits<decltype(msg.node_description)>;
+
+  msg.node_id = j.at("nodeId").get<std::string>();
+  msg.sequence_id = j.at("sequenceId").get<uint32_t>();
+  msg.released = j.at("released").get<bool>();
+  msg.actions = j.at("actions");
+
+  if (j.contains("nodePosition"))
+  {
+    node_position_trait::set(msg.node_position, j.at("nodePosition"));
+  }
+
+  if (j.contains("nodeDescription"))
+  {
+    node_description_trait::set(
+      msg.node_description, j.at("nodeDescription").get<std::string>());
+  }
+}
+
+}  // namespace node_detail
+
+namespace edge_detail {
+
+//=============================================================================
+template <typename EdgeT>
+void to_json(nlohmann::json& j, const EdgeT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+  using vda5050_json_utils::orientation_type_traits;
+
+  using edge_description_trait =
+    optional_field_traits<decltype(msg.edge_description)>;
+  using max_speed_trait = optional_field_traits<decltype(msg.max_speed)>;
+  using max_height_trait = optional_field_traits<decltype(msg.max_height)>;
+  using min_height_trait = optional_field_traits<decltype(msg.min_height)>;
+  using orientation_trait = optional_field_traits<decltype(msg.orientation)>;
+  using orientation_type_trait =
+    optional_field_traits<decltype(msg.orientation_type)>;
+  using direction_trait = optional_field_traits<decltype(msg.direction)>;
+  using rotation_allowed_trait =
+    optional_field_traits<decltype(msg.rotation_allowed)>;
+  using max_rotation_speed_trait =
+    optional_field_traits<decltype(msg.max_rotation_speed)>;
+  using trajectory_trait = optional_field_traits<decltype(msg.trajectory)>;
+  using length_trait = optional_field_traits<decltype(msg.length)>;
+
+  j["edgeId"] = msg.edge_id;
+  j["sequenceId"] = msg.sequence_id;
+  j["startNodeId"] = msg.start_node_id;
+  j["endNodeId"] = msg.end_node_id;
+  j["released"] = msg.released;
+  j["actions"] = msg.actions;
+
+  if (edge_description_trait::has_value(msg.edge_description))
+  {
+    j["edgeDescription"] = edge_description_trait::get(msg.edge_description);
+  }
+
+  if (max_speed_trait::has_value(msg.max_speed))
+  {
+    j["maxSpeed"] = max_speed_trait::get(msg.max_speed);
+  }
+
+  if (max_height_trait::has_value(msg.max_height))
+  {
+    j["maxHeight"] = max_height_trait::get(msg.max_height);
+  }
+
+  if (min_height_trait::has_value(msg.min_height))
+  {
+    j["minHeight"] = min_height_trait::get(msg.min_height);
+  }
+
+  if (orientation_trait::has_value(msg.orientation))
+  {
+    j["orientation"] = orientation_trait::get(msg.orientation);
+  }
+
+  if (orientation_type_trait::has_value(msg.orientation_type))
+  {
+    using inner_t = typename orientation_type_trait::value_type;
+
+    inner_t value = orientation_type_trait::get(msg.orientation_type);
+    j["orientationType"] =
+      orientation_type_traits<decltype(value)>::to_string(value);
+  }
+
+  if (direction_trait::has_value(msg.direction))
+  {
+    j["direction"] = direction_trait::get(msg.direction);
+  }
+
+  if (rotation_allowed_trait::has_value(msg.rotation_allowed))
+  {
+    j["rotationAllowed"] = rotation_allowed_trait::get(msg.rotation_allowed);
+  }
+
+  if (max_rotation_speed_trait::has_value(msg.max_rotation_speed))
+  {
+    j["maxRotationSpeed"] =
+      max_rotation_speed_trait::get(msg.max_rotation_speed);
+  }
+
+  if (trajectory_trait::has_value(msg.trajectory))
+  {
+    j["trajectory"] = trajectory_trait::get(msg.trajectory);
+  }
+
+  if (length_trait::has_value(msg.length))
+  {
+    j["length"] = length_trait::get(msg.length);
+  }
+}
+
+//=============================================================================
+template <typename EdgeT>
+void from_json(const nlohmann::json& j, EdgeT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+  using vda5050_json_utils::orientation_type_traits;
+
+  using edge_description_trait =
+    optional_field_traits<decltype(msg.edge_description)>;
+  using max_speed_trait = optional_field_traits<decltype(msg.max_speed)>;
+  using max_height_trait = optional_field_traits<decltype(msg.max_height)>;
+  using min_height_trait = optional_field_traits<decltype(msg.min_height)>;
+  using orientation_trait = optional_field_traits<decltype(msg.orientation)>;
+  using orientation_type_trait =
+    optional_field_traits<decltype(msg.orientation_type)>;
+  using direction_trait = optional_field_traits<decltype(msg.direction)>;
+  using rotation_allowed_trait =
+    optional_field_traits<decltype(msg.rotation_allowed)>;
+  using max_rotation_speed_trait =
+    optional_field_traits<decltype(msg.max_rotation_speed)>;
+  using trajectory_trait = optional_field_traits<decltype(msg.trajectory)>;
+  using length_trait = optional_field_traits<decltype(msg.length)>;
+
+  msg.edge_id = j.at("edgeId").get<std::string>();
+  msg.sequence_id = j.at("sequenceId").get<int32_t>();
+  msg.start_node_id = j.at("startNodeId").get<std::string>();
+  msg.end_node_id = j.at("endNodeId").get<std::string>();
+  msg.released = j.at("released").get<bool>();
+  msg.actions = j.at("actions");
+
+  if (j.contains("edgeDescription"))
+  {
+    edge_description_trait::set(
+      msg.edge_description, j.at("edgeDescription").get<std::string>());
+  }
+
+  if (j.contains("maxSpeed"))
+  {
+    max_speed_trait::set(msg.max_speed, j.at("maxSpeed").get<double>());
+  }
+
+  if (j.contains("maxHeight"))
+  {
+    max_height_trait::set(msg.max_height, j.at("maxHeight").get<double>());
+  }
+
+  if (j.contains("minHeight"))
+  {
+    min_height_trait::set(msg.min_height, j.at("minHeight").get<double>());
+  }
+
+  if (j.contains("orientation"))
+  {
+    orientation_trait::set(msg.orientation, j.at("orientation").get<double>());
+  }
+
+  if (j.contains("orientationType"))
+  {
+    using inner_t = typename orientation_type_trait::value_type;
+
+    inner_t value = orientation_type_traits<inner_t>::from_string(
+      j.at("orientationType").get<std::string>());
+    orientation_type_trait::set(msg.orientation_type, value);
+  }
+
+  if (j.contains("direction"))
+  {
+    direction_trait::set(msg.direction, j.at("direction").get<std::string>());
+  }
+
+  if (j.contains("rotationAllowed"))
+  {
+    rotation_allowed_trait::set(
+      msg.rotation_allowed, j.at("rotationAllowed").get<bool>());
+  }
+
+  if (j.contains("maxRotationSpeed"))
+  {
+    max_rotation_speed_trait::set(
+      msg.max_rotation_speed, j.at("maxRotationSpeed").get<double>());
+  }
+
+  if (j.contains("trajectory"))
+  {
+    trajectory_trait::set(msg.trajectory, j.at("trajectory"));
+  }
+
+  if (j.contains("length"))
+  {
+    length_trait::set(msg.length, j.at("length").get<double>());
+  }
+}
+
+}  // namespace edge_detail
+
+namespace order_detail {
+
+//=============================================================================
+template <typename OrderT>
+void to_json(nlohmann::json& j, const OrderT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using zone_set_id_trait = optional_field_traits<decltype(msg.zone_set_id)>;
+
+  to_json(j, msg.header);
+
+  j["orderId"] = msg.order_id;
+  j["orderUpdateId"] = msg.order_update_id;
+  j["nodes"] = msg.nodes;
+  j["edges"] = msg.edges;
+
+  if (zone_set_id_trait::has_value(msg.zone_set_id))
+  {
+    j["zoneSetId"] = zone_set_id_trait::get(msg.zone_set_id);
+  }
+}
+
+//=============================================================================
+template <typename OrderT>
+void from_json(const nlohmann::json& j, OrderT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using zone_set_id_trait = optional_field_traits<decltype(msg.zone_set_id)>;
+
+  from_json(j, msg.header);
+
+  msg.order_id = j.at("orderId").get<std::string>();
+  msg.order_update_id = j.at("orderUpdateId").get<uint32_t>();
+  msg.nodes = j.at("nodes");
+  msg.edges = j.at("edges");
+
+  if (j.contains("zoneSetId"))
+  {
+    zone_set_id_trait::set(
+      msg.zone_set_id, j.at("zoneSetId").get<std::string>());
+  }
+}
+
+}  // namespace order_detail
+
 }  // namespace vda5050_types
 
 //=============================================================================
@@ -1396,6 +1783,56 @@ inline void to_json(nlohmann::json& j, const State& msg)
 inline void from_json(const nlohmann::json& j, State& msg)
 {
   vda5050_types::state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const ActionParameter& msg)
+{
+  vda5050_types::action_parameter_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, ActionParameter& msg)
+{
+  vda5050_types::action_parameter_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Action& msg)
+{
+  vda5050_types::action_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Action& msg)
+{
+  vda5050_types::action_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Node& msg)
+{
+  vda5050_types::node_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Node& msg)
+{
+  vda5050_types::node_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Edge& msg)
+{
+  vda5050_types::edge_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Edge& msg)
+{
+  vda5050_types::edge_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Order& msg)
+{
+  vda5050_types::order_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Order& msg)
+{
+  vda5050_types::order_detail::from_json(j, msg);
 }
 
 }  // namespace vda5050_types
@@ -1604,6 +2041,56 @@ inline void to_json(nlohmann::json& j, const State& msg)
 inline void from_json(const nlohmann::json& j, State& msg)
 {
   vda5050_types::state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const ActionParameter& msg)
+{
+  vda5050_types::action_parameter_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, ActionParameter& msg)
+{
+  vda5050_types::action_parameter_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Action& msg)
+{
+  vda5050_types::action_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Action& msg)
+{
+  vda5050_types::action_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Node& msg)
+{
+  vda5050_types::node_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Node& msg)
+{
+  vda5050_types::node_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Edge& msg)
+{
+  vda5050_types::edge_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Edge& msg)
+{
+  vda5050_types::edge_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Order& msg)
+{
+  vda5050_types::order_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Order& msg)
+{
+  vda5050_types::order_detail::from_json(j, msg);
 }
 
 }  // namespace msg

--- a/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
@@ -20,21 +20,34 @@
 #define VDA5050_JSON_UTILS__SERIALIZATION_HPP_
 
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
+#include <vda5050_types/action_state.hpp>
 #include <vda5050_types/connection.hpp>
+#include <vda5050_types/edge_state.hpp>
+#include <vda5050_types/error.hpp>
+#include <vda5050_types/error_reference.hpp>
 #include <vda5050_types/header.hpp>
 #include <vda5050_types/node_position.hpp>
 #include <vda5050_types/node_state.hpp>
+#include <vda5050_types/safety_state.hpp>
 #include <vda5050_types/state.hpp>
+#include <vda5050_types/trajectory.hpp>
 
 #ifdef ENABLE_ROS2
+#include <vda5050_msgs/msg/action_state.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
+#include <vda5050_msgs/msg/edge_state.hpp>
+#include <vda5050_msgs/msg/error.hpp>
+#include <vda5050_msgs/msg/error_reference.hpp>
 #include <vda5050_msgs/msg/header.hpp>
 #include <vda5050_msgs/msg/node_position.hpp>
 #include <vda5050_msgs/msg/node_state.hpp>
+#include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
+#include <vda5050_msgs/msg/trajectory.hpp>
 #endif  // ENABLE_ROS2
 
 #include "traits.hpp"
@@ -81,7 +94,6 @@ template <typename ConnectionT>
 void to_json(nlohmann::json& j, const ConnectionT& msg)
 {
   using vda5050_json_utils::connection_state_traits;
-  using vda5050_types::header_detail::to_json;
 
   to_json(j, msg.header);
 
@@ -95,7 +107,6 @@ template <typename ConnectionT>
 void from_json(const nlohmann::json& j, ConnectionT& msg)
 {
   using vda5050_json_utils::connection_state_traits;
-  using vda5050_types::header_detail::from_json;
 
   from_json(j, msg.header);
 
@@ -199,7 +210,6 @@ namespace node_state_detail {
 template <typename NodeStateT>
 void to_json(nlohmann::json& j, const NodeStateT& msg)
 {
-  using vda5050_types::node_position_detail::to_json;
   using node_description_trait =
     vda5050_json_utils::optional_field_traits<decltype(msg.node_description)>;
   using node_position_trait =
@@ -224,7 +234,6 @@ void to_json(nlohmann::json& j, const NodeStateT& msg)
 template <typename NodeStateT>
 void from_json(const nlohmann::json& j, NodeStateT& msg)
 {
-  using vda5050_types::node_position_detail::to_json;
   using node_description_trait =
     vda5050_json_utils::optional_field_traits<decltype(msg.node_description)>;
   using node_position_trait =
@@ -248,6 +257,353 @@ void from_json(const nlohmann::json& j, NodeStateT& msg)
 
 }  // namespace node_state_detail
 
+namespace control_point_detail {
+
+//=============================================================================
+template <typename ControlPointT>
+void to_json(nlohmann::json& j, const ControlPointT& msg)
+{
+  j["x"] = msg.x;
+  j["y"] = msg.y;
+  j["weight"] = msg.weight;
+}
+
+//=============================================================================
+template <typename ControlPointT>
+void from_json(const nlohmann::json& j, ControlPointT& msg)
+{
+  msg.x = j.at("x").get<double>();
+  msg.y = j.at("y").get<double>();
+
+  if (j.contains("weight"))
+  {
+    msg.weight = j.at("weight").get<double>();
+  }
+}
+
+}  // namespace control_point_detail
+
+namespace trajectory_detail {
+
+//=============================================================================
+template <typename TrajectoryT>
+void to_json(nlohmann::json& j, const TrajectoryT& msg)
+{
+  j["knotVector"] = msg.knot_vector;
+  j["controlPoints"] = msg.control_points;
+  j["degree"] = msg.degree;
+}
+
+//=============================================================================
+template <typename TrajectoryT>
+void from_json(const nlohmann::json& j, TrajectoryT& msg)
+{
+  msg.knot_vector = j.at("knotVector").get<std::vector<double>>();
+  msg.control_points = j.at("controlPoints");
+  msg.degree = j.at("degree").get<double>();
+}
+
+}  // namespace trajectory_detail
+
+namespace edge_state_detail {
+
+//=============================================================================
+template <typename EdgeStateT>
+void to_json(nlohmann::json& j, const EdgeStateT& msg)
+{
+  using edge_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.edge_description)>;
+  using trajectory_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.trajectory)>;
+
+  j["edgeId"] = msg.edge_id;
+  j["sequenceId"] = msg.sequence_id;
+  j["released"] = msg.released;
+
+  if (edge_description_trait::has_value(msg.edge_description))
+  {
+    j["edgeDescription"] = edge_description_trait::get(msg.edge_description);
+  }
+
+  if (trajectory_trait::has_value(msg.trajectory))
+  {
+    j["trajectory"] = trajectory_trait::get(msg.trajectory);
+  }
+}
+
+//=============================================================================
+template <typename EdgeStateT>
+void from_json(const nlohmann::json& j, EdgeStateT& msg)
+{
+  using edge_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.edge_description)>;
+  using trajectory_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.trajectory)>;
+
+  msg.edge_id = j.at("edgeId").get<std::string>();
+  msg.sequence_id = j.at("sequenceId").get<uint32_t>();
+  msg.released = j.at("released").get<bool>();
+
+  if (j.contains("edgeDescription"))
+  {
+    edge_description_trait::set(
+      msg.edge_description, j.at("edgeDescription").get<std::string>());
+  }
+
+  if (j.contains("trajectory"))
+  {
+    trajectory_trait::set(msg.trajectory, j.at("trajectory"));
+  }
+}
+
+}  // namespace edge_state_detail
+
+namespace action_state_detail {
+
+//=============================================================================
+template <typename ActionStateT>
+void to_json(nlohmann::json& j, const ActionStateT& msg)
+{
+  using vda5050_json_utils::action_status_traits;
+  using action_type_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.action_type)>;
+  using action_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.action_description)>;
+  using result_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.result_description)>;
+
+  j["actionId"] = msg.action_id;
+
+  j["actionStatus"] =
+    action_status_traits<decltype(msg.action_status)>::to_string(
+      msg.action_status);
+
+  if (action_type_trait::has_value(msg.action_type))
+  {
+    j["actionType"] = action_type_trait::get(msg.action_type);
+  }
+
+  if (action_description_trait::has_value(msg.action_description))
+  {
+    j["actionDescription"] =
+      action_description_trait::get(msg.action_description);
+  }
+
+  if (result_description_trait::has_value(msg.result_description))
+  {
+    j["resultDescription"] =
+      result_description_trait::get(msg.result_description);
+  }
+}
+
+//=============================================================================
+template <typename ActionStateT>
+void from_json(const nlohmann::json& j, ActionStateT& msg)
+{
+  using vda5050_json_utils::action_status_traits;
+  using action_type_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.action_type)>;
+  using action_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.action_description)>;
+  using result_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.result_description)>;
+  msg.action_id = j.at("actionId").get<std::string>();
+
+  msg.action_status =
+    action_status_traits<decltype(msg.action_status)>::from_string(
+      j.at("actionStatus").get<std::string>());
+
+  if (j.contains("actionType"))
+  {
+    action_type_trait::set(
+      msg.action_type, j.at("actionType").get<std::string>());
+  }
+
+  if (j.contains("actionDescription"))
+  {
+    action_description_trait::set(
+      msg.action_description, j.at("actionDescription").get<std::string>());
+  }
+
+  if (j.contains("resultDescription"))
+  {
+    result_description_trait::set(
+      msg.result_description, j.at("resultDescription").get<std::string>());
+  }
+}
+
+}  // namespace action_state_detail
+
+namespace error_reference_detail {
+
+//=============================================================================
+template <typename ErrorReferenceT>
+void to_json(nlohmann::json& j, const ErrorReferenceT& msg)
+{
+  j["referenceKey"] = msg.reference_key;
+  j["referenceValue"] = msg.reference_value;
+}
+
+//=============================================================================
+template <typename ErrorReferenceT>
+void from_json(const nlohmann::json& j, ErrorReferenceT& msg)
+{
+  msg.reference_key = j.at("referenceKey").get<std::string>();
+  msg.reference_value = j.at("referenceValue").get<std::string>();
+}
+
+}  // namespace error_reference_detail
+
+namespace error_detail {
+
+//=============================================================================
+template <typename ErrorT>
+void to_json(nlohmann::json& j, const ErrorT& msg)
+{
+  using vda5050_json_utils::error_level_traits;
+  using error_reference_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.error_references)>;
+  using error_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.error_description)>;
+
+  j["errorType"] = msg.error_type;
+
+  j["errorLevel"] =
+    error_level_traits<decltype(msg.error_level)>::to_string(msg.error_level);
+
+  if (error_reference_trait::has_value(msg.error_references))
+  {
+    j["errorReferences"] = error_reference_trait::get(msg.error_references);
+  }
+
+  if (error_description_trait::has_value(msg.error_description))
+  {
+    j["errorDescription"] = error_description_trait::get(msg.error_description);
+  }
+}
+
+//=============================================================================
+template <typename ErrorT>
+void from_json(const nlohmann::json& j, ErrorT& msg)
+{
+  using vda5050_json_utils::error_level_traits;
+  using error_reference_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.error_references)>;
+  using error_description_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.error_description)>;
+
+  msg.error_type = j.at("errorType").get<std::string>();
+
+  msg.error_level = error_level_traits<decltype(msg.error_level)>::from_string(
+    j.at("errorLevel").get<std::string>());
+
+  if (j.contains("errorReferences"))
+  {
+    error_reference_trait::set(msg.error_references, j.at("errorReferences"));
+  }
+
+  if (j.contains("errorDescription"))
+  {
+    error_description_trait::set(
+      msg.error_description, j.at("errorDescription").get<std::string>());
+  }
+}
+
+}  // namespace error_detail
+
+namespace battery_state_detail {
+
+//=============================================================================
+template <typename BatteryStateT>
+void to_json(nlohmann::json& j, const BatteryStateT& msg)
+{
+  using battery_voltage_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.battery_voltage)>;
+  using battery_health_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.battery_health)>;
+  using reach_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.reach)>;
+
+  j["batteryCharge"] = msg.battery_charge;
+  j["charging"] = msg.charging;
+
+  if (battery_voltage_trait::has_value(msg.battery_voltage))
+  {
+    j["batteryVoltage"] = battery_voltage_trait::get(msg.battery_voltage);
+  }
+
+  if (battery_health_trait::has_value(msg.battery_health))
+  {
+    j["batteryHealth"] = battery_health_trait::get(msg.battery_health);
+  }
+
+  if (reach_trait::has_value(msg.reach))
+  {
+    j["reach"] = reach_trait::get(msg.reach);
+  }
+}
+
+//=============================================================================
+template <typename BatteryStateT>
+void from_json(const nlohmann::json& j, BatteryStateT& msg)
+{
+  using battery_voltage_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.battery_voltage)>;
+  using battery_health_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.battery_health)>;
+  using reach_trait =
+    vda5050_json_utils::optional_field_traits<decltype(msg.reach)>;
+
+  msg.battery_charge = j.at("batteryCharge").get<double>();
+  msg.charging = j.at("charging").get<bool>();
+
+  if (j.contains("batteryVoltage"))
+  {
+    battery_voltage_trait::set(
+      msg.battery_voltage, j.at("batteryVoltage").get<double>());
+  }
+
+  if (j.contains("batteryHealth"))
+  {
+    battery_health_trait::set(
+      msg.battery_health, j.at("batteryHealth").get<int8_t>());
+  }
+
+  if (j.contains("reach"))
+  {
+    reach_trait::set(msg.reach, j.at("reach").get<uint32_t>());
+  }
+}
+
+}  // namespace battery_state_detail
+
+namespace safety_state_detail {
+
+//=============================================================================
+template <typename SafetyStateT>
+void to_json(nlohmann::json& j, const SafetyStateT& msg)
+{
+  using vda5050_json_utils::e_stop_traits;
+
+  j["eStop"] = e_stop_traits<decltype(msg.e_stop)>::to_string(msg.e_stop);
+
+  j["fieldViolation"] = msg.field_violation;
+}
+
+//=============================================================================
+template <typename SafetyStateT>
+void from_json(const nlohmann::json& j, SafetyStateT& msg)
+{
+  using vda5050_json_utils::e_stop_traits;
+
+  msg.e_stop = e_stop_traits<decltype(msg.e_stop)>::from_string(
+    j.at("eStop").get<std::string>());
+
+  msg.field_violation = j.at("fieldViolation").get<bool>();
+}
+
+}  // namespace safety_state_detail
+
 namespace state_detail {
 
 //=============================================================================
@@ -255,8 +611,6 @@ template <typename StateT>
 void to_json(nlohmann::json& j, const StateT& msg)
 {
   using vda5050_json_utils::operating_mode_traits;
-  using vda5050_types::header_detail::to_json;
-  using vda5050_types::node_state_detail::to_json;
 
   to_json(j, msg.header);
 
@@ -271,6 +625,11 @@ void to_json(nlohmann::json& j, const StateT& msg)
       msg.operating_mode);
 
   j["nodeStates"] = msg.node_states;
+  j["edgeStates"] = msg.edge_states;
+  j["actionStates"] = msg.action_states;
+  j["errors"] = msg.errors;
+  j["batteryState"] = msg.battery_state;
+  j["safetyState"] = msg.safety_state;
 }
 
 //=============================================================================
@@ -278,8 +637,6 @@ template <typename StateT>
 void from_json(const nlohmann::json& j, StateT& msg)
 {
   using vda5050_json_utils::operating_mode_traits;
-  using vda5050_types::header_detail::from_json;
-  using vda5050_types::node_state_detail::from_json;
 
   from_json(j, msg.header);
 
@@ -294,12 +651,18 @@ void from_json(const nlohmann::json& j, StateT& msg)
       j.at("operatingMode").get<std::string>());
 
   msg.node_states = j.at("nodeStates");
+  msg.edge_states = j.at("edgeStates");
+  msg.action_states = j.at("actionStates");
+  msg.errors = j.at("errors");
+  msg.battery_state = j.at("batteryState");
+  msg.safety_state = j.at("safetyState");
 }
 
 }  // namespace state_detail
 
 }  // namespace vda5050_types
 
+//=============================================================================
 namespace vda5050_types {
 
 inline void to_json(nlohmann::json& j, const Header& msg)
@@ -340,6 +703,86 @@ inline void to_json(nlohmann::json& j, const NodeState& msg)
 inline void from_json(const nlohmann::json& j, NodeState& msg)
 {
   vda5050_types::node_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const ControlPoint& msg)
+{
+  vda5050_types::control_point_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, ControlPoint& msg)
+{
+  vda5050_types::control_point_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Trajectory& msg)
+{
+  vda5050_types::trajectory_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Trajectory& msg)
+{
+  vda5050_types::trajectory_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const EdgeState& msg)
+{
+  vda5050_types::edge_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, EdgeState& msg)
+{
+  vda5050_types::edge_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const ActionState& msg)
+{
+  vda5050_types::action_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, ActionState& msg)
+{
+  vda5050_types::action_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const ErrorReference& msg)
+{
+  vda5050_types::error_reference_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, ErrorReference& msg)
+{
+  vda5050_types::error_reference_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Error& msg)
+{
+  vda5050_types::error_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Error& msg)
+{
+  vda5050_types::error_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const BatteryState& msg)
+{
+  vda5050_types::battery_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, BatteryState& msg)
+{
+  vda5050_types::battery_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const SafetyState& msg)
+{
+  vda5050_types::safety_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, SafetyState& msg)
+{
+  vda5050_types::safety_state_detail::from_json(j, msg);
 }
 
 inline void to_json(nlohmann::json& j, const State& msg)
@@ -398,6 +841,86 @@ inline void to_json(nlohmann::json& j, const NodeState& msg)
 inline void from_json(const nlohmann::json& j, NodeState& msg)
 {
   vda5050_types::node_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const ControlPoint& msg)
+{
+  vda5050_types::control_point_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, ControlPoint& msg)
+{
+  vda5050_types::control_point_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Trajectory& msg)
+{
+  vda5050_types::trajectory_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Trajectory& msg)
+{
+  vda5050_types::trajectory_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const EdgeState& msg)
+{
+  vda5050_types::edge_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, EdgeState& msg)
+{
+  vda5050_types::edge_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const ActionState& msg)
+{
+  vda5050_types::action_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, ActionState& msg)
+{
+  vda5050_types::action_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const ErrorReference& msg)
+{
+  vda5050_types::error_reference_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, ErrorReference& msg)
+{
+  vda5050_types::error_reference_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Error& msg)
+{
+  vda5050_types::error_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Error& msg)
+{
+  vda5050_types::error_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const BatteryState& msg)
+{
+  vda5050_types::battery_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, BatteryState& msg)
+{
+  vda5050_types::battery_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const SafetyState& msg)
+{
+  vda5050_types::safety_state_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, SafetyState& msg)
+{
+  vda5050_types::safety_state_detail::from_json(j, msg);
 }
 
 inline void to_json(nlohmann::json& j, const State& msg)

--- a/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
@@ -25,29 +25,44 @@
 #include <nlohmann/json.hpp>
 
 #include <vda5050_types/action_state.hpp>
+#include <vda5050_types/agv_position.hpp>
+#include <vda5050_types/battery_state.hpp>
+#include <vda5050_types/bounding_box_reference.hpp>
 #include <vda5050_types/connection.hpp>
+#include <vda5050_types/control_point.hpp>
 #include <vda5050_types/edge_state.hpp>
 #include <vda5050_types/error.hpp>
 #include <vda5050_types/error_reference.hpp>
 #include <vda5050_types/header.hpp>
+#include <vda5050_types/info.hpp>
+#include <vda5050_types/info_reference.hpp>
+#include <vda5050_types/load.hpp>
 #include <vda5050_types/node_position.hpp>
 #include <vda5050_types/node_state.hpp>
 #include <vda5050_types/safety_state.hpp>
 #include <vda5050_types/state.hpp>
 #include <vda5050_types/trajectory.hpp>
+#include <vda5050_types/velocity.hpp>
 
 #ifdef ENABLE_ROS2
 #include <vda5050_msgs/msg/action_state.hpp>
+#include <vda5050_msgs/msg/agv_position.hpp>
+#include <vda5050_msgs/msg/battery_state.hpp>
+#include <vda5050_msgs/msg/bounding_box_reference.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/edge_state.hpp>
 #include <vda5050_msgs/msg/error.hpp>
 #include <vda5050_msgs/msg/error_reference.hpp>
 #include <vda5050_msgs/msg/header.hpp>
+#include <vda5050_msgs/msg/info.hpp>
+#include <vda5050_msgs/msg/info_reference.hpp>
+#include <vda5050_msgs/msg/load.hpp>
 #include <vda5050_msgs/msg/node_position.hpp>
 #include <vda5050_msgs/msg/node_state.hpp>
 #include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #include <vda5050_msgs/msg/trajectory.hpp>
+#include <vda5050_msgs/msg/velocity.hpp>
 #endif  // ENABLE_ROS2
 
 #include "traits.hpp"
@@ -123,15 +138,15 @@ namespace node_position_detail {
 template <typename NodePositionT>
 void to_json(nlohmann::json& j, const NodePositionT& msg)
 {
-  using theta_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.theta)>;
-  using allowed_deviation_x_y_trait = vda5050_json_utils::optional_field_traits<
-    decltype(msg.allowed_deviation_x_y)>;
+  using vda5050_json_utils::optional_field_traits;
+
+  using theta_trait = optional_field_traits<decltype(msg.theta)>;
+  using allowed_deviation_x_y_trait =
+    optional_field_traits<decltype(msg.allowed_deviation_x_y)>;
   using allowed_deviation_theta_trait =
-    vda5050_json_utils::optional_field_traits<
-      decltype(msg.allowed_deviation_theta)>;
+    optional_field_traits<decltype(msg.allowed_deviation_theta)>;
   using map_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.map_description)>;
+    optional_field_traits<decltype(msg.map_description)>;
 
   j["x"] = msg.x;
   j["y"] = msg.y;
@@ -164,15 +179,15 @@ void to_json(nlohmann::json& j, const NodePositionT& msg)
 template <typename NodePositionT>
 void from_json(const nlohmann::json& j, NodePositionT& msg)
 {
-  using theta_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.theta)>;
-  using allowed_deviation_x_y_trait = vda5050_json_utils::optional_field_traits<
-    decltype(msg.allowed_deviation_x_y)>;
+  using vda5050_json_utils::optional_field_traits;
+
+  using theta_trait = optional_field_traits<decltype(msg.theta)>;
+  using allowed_deviation_x_y_trait =
+    optional_field_traits<decltype(msg.allowed_deviation_x_y)>;
   using allowed_deviation_theta_trait =
-    vda5050_json_utils::optional_field_traits<
-      decltype(msg.allowed_deviation_theta)>;
+    optional_field_traits<decltype(msg.allowed_deviation_theta)>;
   using map_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.map_description)>;
+    optional_field_traits<decltype(msg.map_description)>;
 
   msg.x = j.at("x").get<double>();
   msg.y = j.at("y").get<double>();
@@ -210,10 +225,12 @@ namespace node_state_detail {
 template <typename NodeStateT>
 void to_json(nlohmann::json& j, const NodeStateT& msg)
 {
+  using vda5050_json_utils::optional_field_traits;
+
   using node_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.node_description)>;
+    optional_field_traits<decltype(msg.node_description)>;
   using node_position_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.node_position)>;
+    optional_field_traits<decltype(msg.node_position)>;
 
   j["nodeId"] = msg.node_id;
   j["sequenceId"] = msg.sequence_id;
@@ -234,10 +251,12 @@ void to_json(nlohmann::json& j, const NodeStateT& msg)
 template <typename NodeStateT>
 void from_json(const nlohmann::json& j, NodeStateT& msg)
 {
+  using vda5050_json_utils::optional_field_traits;
+
   using node_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.node_description)>;
+    optional_field_traits<decltype(msg.node_description)>;
   using node_position_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.node_position)>;
+    optional_field_traits<decltype(msg.node_position)>;
 
   msg.node_id = j.at("nodeId").get<std::string>();
   msg.sequence_id = j.at("sequenceId").get<uint32_t>();
@@ -311,10 +330,11 @@ namespace edge_state_detail {
 template <typename EdgeStateT>
 void to_json(nlohmann::json& j, const EdgeStateT& msg)
 {
+  using vda5050_json_utils::optional_field_traits;
+
   using edge_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.edge_description)>;
-  using trajectory_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.trajectory)>;
+    optional_field_traits<decltype(msg.edge_description)>;
+  using trajectory_trait = optional_field_traits<decltype(msg.trajectory)>;
 
   j["edgeId"] = msg.edge_id;
   j["sequenceId"] = msg.sequence_id;
@@ -335,10 +355,11 @@ void to_json(nlohmann::json& j, const EdgeStateT& msg)
 template <typename EdgeStateT>
 void from_json(const nlohmann::json& j, EdgeStateT& msg)
 {
+  using vda5050_json_utils::optional_field_traits;
+
   using edge_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.edge_description)>;
-  using trajectory_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.trajectory)>;
+    optional_field_traits<decltype(msg.edge_description)>;
+  using trajectory_trait = optional_field_traits<decltype(msg.trajectory)>;
 
   msg.edge_id = j.at("edgeId").get<std::string>();
   msg.sequence_id = j.at("sequenceId").get<uint32_t>();
@@ -365,12 +386,13 @@ template <typename ActionStateT>
 void to_json(nlohmann::json& j, const ActionStateT& msg)
 {
   using vda5050_json_utils::action_status_traits;
-  using action_type_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.action_type)>;
+  using vda5050_json_utils::optional_field_traits;
+
+  using action_type_trait = optional_field_traits<decltype(msg.action_type)>;
   using action_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.action_description)>;
+    optional_field_traits<decltype(msg.action_description)>;
   using result_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.result_description)>;
+    optional_field_traits<decltype(msg.result_description)>;
 
   j["actionId"] = msg.action_id;
 
@@ -401,12 +423,14 @@ template <typename ActionStateT>
 void from_json(const nlohmann::json& j, ActionStateT& msg)
 {
   using vda5050_json_utils::action_status_traits;
-  using action_type_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.action_type)>;
+  using vda5050_json_utils::optional_field_traits;
+
+  using action_type_trait = optional_field_traits<decltype(msg.action_type)>;
   using action_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.action_description)>;
+    optional_field_traits<decltype(msg.action_description)>;
   using result_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.result_description)>;
+    optional_field_traits<decltype(msg.result_description)>;
+
   msg.action_id = j.at("actionId").get<std::string>();
 
   msg.action_status =
@@ -461,19 +485,21 @@ template <typename ErrorT>
 void to_json(nlohmann::json& j, const ErrorT& msg)
 {
   using vda5050_json_utils::error_level_traits;
-  using error_reference_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.error_references)>;
+  using vda5050_json_utils::optional_field_traits;
+
+  using error_references_trait =
+    optional_field_traits<decltype(msg.error_references)>;
   using error_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.error_description)>;
+    optional_field_traits<decltype(msg.error_description)>;
 
   j["errorType"] = msg.error_type;
 
   j["errorLevel"] =
     error_level_traits<decltype(msg.error_level)>::to_string(msg.error_level);
 
-  if (error_reference_trait::has_value(msg.error_references))
+  if (error_references_trait::has_value(msg.error_references))
   {
-    j["errorReferences"] = error_reference_trait::get(msg.error_references);
+    j["errorReferences"] = error_references_trait::get(msg.error_references);
   }
 
   if (error_description_trait::has_value(msg.error_description))
@@ -487,10 +513,12 @@ template <typename ErrorT>
 void from_json(const nlohmann::json& j, ErrorT& msg)
 {
   using vda5050_json_utils::error_level_traits;
-  using error_reference_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.error_references)>;
+  using vda5050_json_utils::optional_field_traits;
+
+  using error_references_trait =
+    optional_field_traits<decltype(msg.error_references)>;
   using error_description_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.error_description)>;
+    optional_field_traits<decltype(msg.error_description)>;
 
   msg.error_type = j.at("errorType").get<std::string>();
 
@@ -499,7 +527,7 @@ void from_json(const nlohmann::json& j, ErrorT& msg)
 
   if (j.contains("errorReferences"))
   {
-    error_reference_trait::set(msg.error_references, j.at("errorReferences"));
+    error_references_trait::set(msg.error_references, j.at("errorReferences"));
   }
 
   if (j.contains("errorDescription"))
@@ -517,12 +545,13 @@ namespace battery_state_detail {
 template <typename BatteryStateT>
 void to_json(nlohmann::json& j, const BatteryStateT& msg)
 {
+  using vda5050_json_utils::optional_field_traits;
+
   using battery_voltage_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.battery_voltage)>;
+    optional_field_traits<decltype(msg.battery_voltage)>;
   using battery_health_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.battery_health)>;
-  using reach_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.reach)>;
+    optional_field_traits<decltype(msg.battery_health)>;
+  using reach_trait = optional_field_traits<decltype(msg.reach)>;
 
   j["batteryCharge"] = msg.battery_charge;
   j["charging"] = msg.charging;
@@ -547,12 +576,13 @@ void to_json(nlohmann::json& j, const BatteryStateT& msg)
 template <typename BatteryStateT>
 void from_json(const nlohmann::json& j, BatteryStateT& msg)
 {
+  using vda5050_json_utils::optional_field_traits;
+
   using battery_voltage_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.battery_voltage)>;
+    optional_field_traits<decltype(msg.battery_voltage)>;
   using battery_health_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.battery_health)>;
-  using reach_trait =
-    vda5050_json_utils::optional_field_traits<decltype(msg.reach)>;
+    optional_field_traits<decltype(msg.battery_health)>;
+  using reach_trait = optional_field_traits<decltype(msg.reach)>;
 
   msg.battery_charge = j.at("batteryCharge").get<double>();
   msg.charging = j.at("charging").get<bool>();
@@ -604,6 +634,400 @@ void from_json(const nlohmann::json& j, SafetyStateT& msg)
 
 }  // namespace safety_state_detail
 
+namespace agv_position_detail {
+
+//=============================================================================
+template <typename AGVPositionT>
+void to_json(nlohmann::json& j, const AGVPositionT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using map_description_trait =
+    optional_field_traits<decltype(msg.map_description)>;
+  using localization_score_trait =
+    optional_field_traits<decltype(msg.localization_score)>;
+  using deviation_range_trait =
+    optional_field_traits<decltype(msg.deviation_range)>;
+
+  j["x"] = msg.x;
+  j["y"] = msg.y;
+  j["theta"] = msg.theta;
+  j["mapId"] = msg.map_id;
+  j["positionInitialized"] = msg.position_initialized;
+
+  if (map_description_trait::has_value(msg.map_description))
+  {
+    j["mapDescription"] = map_description_trait::get(msg.map_description);
+  }
+
+  if (localization_score_trait::has_value(msg.localization_score))
+  {
+    j["localizationScore"] =
+      localization_score_trait::get(msg.localization_score);
+  }
+
+  if (deviation_range_trait::has_value(msg.deviation_range))
+  {
+    j["deviationRange"] = deviation_range_trait::get(msg.deviation_range);
+  }
+}
+
+//=============================================================================
+template <typename AGVPositionT>
+void from_json(const nlohmann::json& j, AGVPositionT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using map_description_trait =
+    optional_field_traits<decltype(msg.map_description)>;
+  using localization_score_trait =
+    optional_field_traits<decltype(msg.localization_score)>;
+  using deviation_range_trait =
+    optional_field_traits<decltype(msg.deviation_range)>;
+
+  msg.x = j.at("x").get<double>();
+  msg.y = j.at("y").get<double>();
+  msg.theta = j.at("theta").get<double>();
+  msg.map_id = j.at("mapId").get<std::string>();
+  msg.position_initialized = j.at("positionInitialized").get<bool>();
+
+  if (j.contains("mapDescription"))
+  {
+    map_description_trait::set(
+      msg.map_description, j.at("mapDescription").get<std::string>());
+  }
+
+  if (j.contains("localizationScore"))
+  {
+    localization_score_trait::set(
+      msg.localization_score, j.at("localizationScore").get<double>());
+  }
+
+  if (j.contains("deviationRange"))
+  {
+    deviation_range_trait::set(
+      msg.deviation_range, j.at("deviationRange").get<double>());
+  }
+}
+
+}  // namespace agv_position_detail
+
+namespace velocity_detail {
+
+//=============================================================================
+template <typename VelocityT>
+void to_json(nlohmann::json& j, const VelocityT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using vx_trait = optional_field_traits<decltype(msg.vx)>;
+  using vy_trait = optional_field_traits<decltype(msg.vy)>;
+  using omega_trait = optional_field_traits<decltype(msg.omega)>;
+
+  if (vx_trait::has_value(msg.vx))
+  {
+    j["vx"] = vx_trait::get(msg.vx);
+  }
+
+  if (vy_trait::has_value(msg.vy))
+  {
+    j["vy"] = vy_trait::get(msg.vy);
+  }
+
+  if (omega_trait::has_value(msg.omega))
+  {
+    j["omega"] = omega_trait::get(msg.omega);
+  }
+}
+
+//=============================================================================
+template <typename VelocityT>
+void from_json(const nlohmann::json& j, VelocityT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using vx_trait = optional_field_traits<decltype(msg.vx)>;
+  using vy_trait = optional_field_traits<decltype(msg.vy)>;
+  using omega_trait = optional_field_traits<decltype(msg.omega)>;
+
+  if (j.contains("vx"))
+  {
+    vx_trait::set(msg.vx, j.at("vx").get<double>());
+  }
+
+  if (j.contains("vy"))
+  {
+    vy_trait::set(msg.vy, j.at("vy").get<double>());
+  }
+
+  if (j.contains("omega"))
+  {
+    omega_trait::set(msg.omega, j.at("omega").get<double>());
+  }
+}
+
+}  // namespace velocity_detail
+
+namespace bounding_box_reference_detail {
+
+//=============================================================================
+template <typename BoundingBoxReferenceT>
+void to_json(nlohmann::json& j, const BoundingBoxReferenceT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using theta_trait = optional_field_traits<decltype(msg.theta)>;
+
+  j["x"] = msg.x;
+  j["y"] = msg.y;
+  j["z"] = msg.z;
+
+  if (theta_trait::has_value(msg.theta))
+  {
+    j["theta"] = theta_trait::get(msg.theta);
+  }
+}
+
+//=============================================================================
+template <typename BoundingBoxReferenceT>
+void from_json(const nlohmann::json& j, BoundingBoxReferenceT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using theta_trait = optional_field_traits<decltype(msg.theta)>;
+
+  msg.x = j.at("x").get<double>();
+  msg.y = j.at("y").get<double>();
+  msg.z = j.at("z").get<double>();
+
+  if (j.contains("theta"))
+  {
+    theta_trait::set(msg.theta, j.at("theta").get<double>());
+  }
+}
+
+}  // namespace bounding_box_reference_detail
+
+namespace load_dimensions_detail {
+
+//=============================================================================
+template <typename LoadDimensionsT>
+void to_json(nlohmann::json& j, const LoadDimensionsT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using height_trait = optional_field_traits<decltype(msg.height)>;
+
+  j["length"] = msg.length;
+  j["width"] = msg.width;
+
+  if (height_trait::has_value(msg.height))
+  {
+    j["height"] = height_trait::get(msg.height);
+  }
+}
+
+//=============================================================================
+template <typename LoadDimensionsT>
+void from_json(const nlohmann::json& j, LoadDimensionsT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using height_trait = optional_field_traits<decltype(msg.height)>;
+
+  msg.length = j.at("length").get<double>();
+  msg.width = j.at("width").get<double>();
+
+  if (j.contains("height"))
+  {
+    height_trait::set(msg.height, j.at("height").get<double>());
+  }
+}
+
+}  // namespace load_dimensions_detail
+
+namespace load_detail {
+
+//=============================================================================
+template <typename LoadT>
+void to_json(nlohmann::json& j, const LoadT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using load_id_trait = optional_field_traits<decltype(msg.load_id)>;
+  using load_type_trait = optional_field_traits<decltype(msg.load_type)>;
+  using load_position_trait =
+    optional_field_traits<decltype(msg.load_position)>;
+  using bounding_box_reference_trait =
+    optional_field_traits<decltype(msg.bounding_box_reference)>;
+  using load_dimensions_trait =
+    optional_field_traits<decltype(msg.load_dimensions)>;
+  using weight_trait = optional_field_traits<decltype(msg.weight)>;
+
+  if (load_id_trait::has_value(msg.load_id))
+  {
+    j["loadId"] = load_id_trait::get(msg.load_id);
+  }
+
+  if (load_type_trait::has_value(msg.load_type))
+  {
+    j["loadType"] = load_type_trait::get(msg.load_type);
+  }
+
+  if (load_position_trait::has_value(msg.load_position))
+  {
+    j["loadPosition"] = load_position_trait::get(msg.load_position);
+  }
+
+  if (bounding_box_reference_trait::has_value(msg.bounding_box_reference))
+  {
+    j["boundingBoxReference"] =
+      bounding_box_reference_trait::get(msg.bounding_box_reference);
+  }
+
+  if (load_dimensions_trait::has_value(msg.load_dimensions))
+  {
+    j["loadDimensions"] = load_dimensions_trait::get(msg.load_dimensions);
+  }
+
+  if (weight_trait::has_value(msg.weight))
+  {
+    j["weight"] = weight_trait::get(msg.weight);
+  }
+}
+
+//=============================================================================
+template <typename LoadT>
+void from_json(const nlohmann::json& j, LoadT& msg)
+{
+  using vda5050_json_utils::optional_field_traits;
+
+  using load_id_trait = optional_field_traits<decltype(msg.load_id)>;
+  using load_type_trait = optional_field_traits<decltype(msg.load_type)>;
+  using load_position_trait =
+    optional_field_traits<decltype(msg.load_position)>;
+  using bounding_box_reference_trait =
+    optional_field_traits<decltype(msg.bounding_box_reference)>;
+  using load_dimensions_trait =
+    optional_field_traits<decltype(msg.load_dimensions)>;
+  using weight_trait = optional_field_traits<decltype(msg.weight)>;
+
+  if (j.contains("loadId"))
+  {
+    load_id_trait::set(msg.load_id, j.at("loadId").get<std::string>());
+  }
+
+  if (j.contains("loadType"))
+  {
+    load_type_trait::set(msg.load_type, j.at("loadType").get<std::string>());
+  }
+
+  if (j.contains("loadPosition"))
+  {
+    load_position_trait::set(
+      msg.load_position, j.at("loadPosition").get<std::string>());
+  }
+
+  if (j.contains("boundingBoxReference"))
+  {
+    bounding_box_reference_trait::set(
+      msg.bounding_box_reference, j.at("boundingBoxReference"));
+  }
+
+  if (j.contains("loadDimensions"))
+  {
+    load_dimensions_trait::set(msg.load_dimensions, j.at("loadDimensions"));
+  }
+
+  if (j.contains("weight"))
+  {
+    weight_trait::set(msg.weight, j.at("weight").get<double>());
+  }
+}
+
+}  // namespace load_detail
+
+namespace info_reference_detail {
+
+//=============================================================================
+template <typename InfoReferenceT>
+void to_json(nlohmann::json& j, const InfoReferenceT& msg)
+{
+  j["referenceKey"] = msg.reference_key;
+  j["referenceValue"] = msg.reference_value;
+}
+
+//=============================================================================
+template <typename InfoReferenceT>
+void from_json(const nlohmann::json& j, InfoReferenceT& msg)
+{
+  msg.reference_key = j.at("referenceKey").get<std::string>();
+  msg.reference_value = j.at("referenceValue").get<std::string>();
+}
+
+}  // namespace info_reference_detail
+
+namespace info_detail {
+
+//=============================================================================
+template <typename InfoT>
+void to_json(nlohmann::json& j, const InfoT& msg)
+{
+  using vda5050_json_utils::info_level_traits;
+  using vda5050_json_utils::optional_field_traits;
+
+  using info_references_trait =
+    optional_field_traits<decltype(msg.info_references)>;
+  using info_description_trait =
+    optional_field_traits<decltype(msg.info_description)>;
+
+  j["infoType"] = msg.info_type;
+
+  j["infoLevel"] =
+    info_level_traits<decltype(msg.info_level)>::to_string(msg.info_level);
+
+  if (info_references_trait::has_value(msg.info_references))
+  {
+    j["infoReferences"] = info_references_trait::get(msg.info_references);
+  }
+
+  if (info_description_trait::has_value(msg.info_description))
+  {
+    j["infoDescription"] = info_description_trait::get(msg.info_description);
+  }
+}
+
+//=============================================================================
+template <typename InfoT>
+void from_json(const nlohmann::json& j, InfoT& msg)
+{
+  using vda5050_json_utils::info_level_traits;
+  using vda5050_json_utils::optional_field_traits;
+
+  using info_references_trait =
+    optional_field_traits<decltype(msg.info_references)>;
+  using info_description_trait =
+    optional_field_traits<decltype(msg.info_description)>;
+
+  msg.info_type = j.at("infoType").get<std::string>();
+
+  msg.info_level = info_level_traits<decltype(msg.info_level)>::from_string(
+    j.at("infoLevel").get<std::string>());
+
+  if (j.contains("infoReferences"))
+  {
+    info_references_trait::set(msg.info_references, j.at("infoReferences"));
+  }
+
+  if (j.contains("infoDescription"))
+  {
+    info_description_trait::set(
+      msg.info_description, j.at("infoDescription").get<std::string>());
+  }
+}
+
+}  // namespace info_detail
+
 namespace state_detail {
 
 //=============================================================================
@@ -611,6 +1035,18 @@ template <typename StateT>
 void to_json(nlohmann::json& j, const StateT& msg)
 {
   using vda5050_json_utils::operating_mode_traits;
+  using vda5050_json_utils::optional_field_traits;
+
+  using zone_set_id_trait = optional_field_traits<decltype(msg.zone_set_id)>;
+  using paused_trait = optional_field_traits<decltype(msg.paused)>;
+  using new_base_request_trait =
+    optional_field_traits<decltype(msg.new_base_request)>;
+  using distance_since_last_node_trait =
+    optional_field_traits<decltype(msg.distance_since_last_node)>;
+  using agv_position_trait = optional_field_traits<decltype(msg.agv_position)>;
+  using velocity_trait = optional_field_traits<decltype(msg.velocity)>;
+  using loads_trait = optional_field_traits<decltype(msg.loads)>;
+  using information_traits = optional_field_traits<decltype(msg.information)>;
 
   to_json(j, msg.header);
 
@@ -630,6 +1066,47 @@ void to_json(nlohmann::json& j, const StateT& msg)
   j["errors"] = msg.errors;
   j["batteryState"] = msg.battery_state;
   j["safetyState"] = msg.safety_state;
+
+  if (zone_set_id_trait::has_value(msg.zone_set_id))
+  {
+    j["zoneSetId"] = zone_set_id_trait::get(msg.zone_set_id);
+  }
+
+  if (paused_trait::has_value(msg.paused))
+  {
+    j["paused"] = paused_trait::get(msg.paused);
+  }
+
+  if (new_base_request_trait::has_value(msg.new_base_request))
+  {
+    j["newBaseRequest"] = new_base_request_trait::get(msg.new_base_request);
+  }
+
+  if (distance_since_last_node_trait::has_value(msg.distance_since_last_node))
+  {
+    j["distanceSinceLastNode"] =
+      distance_since_last_node_trait::get(msg.distance_since_last_node);
+  }
+
+  if (agv_position_trait::has_value(msg.agv_position))
+  {
+    j["agvPosition"] = agv_position_trait::get(msg.agv_position);
+  }
+
+  if (velocity_trait::has_value(msg.velocity))
+  {
+    j["velocity"] = velocity_trait::get(msg.velocity);
+  }
+
+  if (loads_trait::has_value(msg.loads))
+  {
+    j["loads"] = loads_trait::get(msg.loads);
+  }
+
+  if (information_traits::has_value(msg.information))
+  {
+    j["information"] = information_traits::get(msg.information);
+  }
 }
 
 //=============================================================================
@@ -637,6 +1114,18 @@ template <typename StateT>
 void from_json(const nlohmann::json& j, StateT& msg)
 {
   using vda5050_json_utils::operating_mode_traits;
+  using vda5050_json_utils::optional_field_traits;
+
+  using zone_set_id_trait = optional_field_traits<decltype(msg.zone_set_id)>;
+  using paused_trait = optional_field_traits<decltype(msg.paused)>;
+  using new_base_request_trait =
+    optional_field_traits<decltype(msg.new_base_request)>;
+  using distance_since_last_node_trait =
+    optional_field_traits<decltype(msg.distance_since_last_node)>;
+  using agv_position_trait = optional_field_traits<decltype(msg.agv_position)>;
+  using velocity_trait = optional_field_traits<decltype(msg.velocity)>;
+  using loads_trait = optional_field_traits<decltype(msg.loads)>;
+  using information_traits = optional_field_traits<decltype(msg.information)>;
 
   from_json(j, msg.header);
 
@@ -656,6 +1145,50 @@ void from_json(const nlohmann::json& j, StateT& msg)
   msg.errors = j.at("errors");
   msg.battery_state = j.at("batteryState");
   msg.safety_state = j.at("safetyState");
+
+  if (j.contains("zoneSetId"))
+  {
+    zone_set_id_trait::set(
+      msg.zone_set_id, j.at("zoneSetId").get<std::string>());
+  }
+
+  if (j.contains("paused"))
+  {
+    paused_trait::set(msg.paused, j.at("paused").get<bool>());
+  }
+
+  if (j.contains("newBaseRequest"))
+  {
+    new_base_request_trait::set(
+      msg.new_base_request, j.at("newBaseRequest").get<bool>());
+  }
+
+  if (j.contains("distanceSinceLastNode"))
+  {
+    distance_since_last_node_trait::set(
+      msg.distance_since_last_node,
+      j.at("distanceSinceLastNode").get<double>());
+  }
+
+  if (j.contains("agvPosition"))
+  {
+    agv_position_trait::set(msg.agv_position, j.at("agvPosition"));
+  }
+
+  if (j.contains("velocity"))
+  {
+    velocity_trait::set(msg.velocity, j.at("velocity"));
+  }
+
+  if (j.contains("loads"))
+  {
+    loads_trait::set(msg.loads, j.at("loads"));
+  }
+
+  if (j.contains("information"))
+  {
+    information_traits::set(msg.information, j.at("information"));
+  }
 }
 
 }  // namespace state_detail
@@ -783,6 +1316,76 @@ inline void to_json(nlohmann::json& j, const SafetyState& msg)
 inline void from_json(const nlohmann::json& j, SafetyState& msg)
 {
   vda5050_types::safety_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const AGVPosition& msg)
+{
+  vda5050_types::agv_position_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, AGVPosition& msg)
+{
+  vda5050_types::agv_position_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Velocity& msg)
+{
+  vda5050_types::velocity_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Velocity& msg)
+{
+  vda5050_types::velocity_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const BoundingBoxReference& msg)
+{
+  vda5050_types::bounding_box_reference_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, BoundingBoxReference& msg)
+{
+  vda5050_types::bounding_box_reference_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const LoadDimensions& msg)
+{
+  vda5050_types::load_dimensions_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, LoadDimensions& msg)
+{
+  vda5050_types::load_dimensions_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Load& msg)
+{
+  vda5050_types::load_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Load& msg)
+{
+  vda5050_types::load_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const InfoReference& msg)
+{
+  vda5050_types::info_reference_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, InfoReference& msg)
+{
+  vda5050_types::info_reference_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Info& msg)
+{
+  vda5050_types::info_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Info& msg)
+{
+  vda5050_types::info_detail::from_json(j, msg);
 }
 
 inline void to_json(nlohmann::json& j, const State& msg)
@@ -921,6 +1524,76 @@ inline void to_json(nlohmann::json& j, const SafetyState& msg)
 inline void from_json(const nlohmann::json& j, SafetyState& msg)
 {
   vda5050_types::safety_state_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const AGVPosition& msg)
+{
+  vda5050_types::agv_position_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, AGVPosition& msg)
+{
+  vda5050_types::agv_position_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Velocity& msg)
+{
+  vda5050_types::velocity_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Velocity& msg)
+{
+  vda5050_types::velocity_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const BoundingBoxReference& msg)
+{
+  vda5050_types::bounding_box_reference_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, BoundingBoxReference& msg)
+{
+  vda5050_types::bounding_box_reference_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const LoadDimensions& msg)
+{
+  vda5050_types::load_dimensions_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, LoadDimensions& msg)
+{
+  vda5050_types::load_dimensions_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Load& msg)
+{
+  vda5050_types::load_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Load& msg)
+{
+  vda5050_types::load_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const InfoReference& msg)
+{
+  vda5050_types::info_reference_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, InfoReference& msg)
+{
+  vda5050_types::info_reference_detail::from_json(j, msg);
+}
+
+inline void to_json(nlohmann::json& j, const Info& msg)
+{
+  vda5050_types::info_detail::to_json(j, msg);
+}
+
+inline void from_json(const nlohmann::json& j, Info& msg)
+{
+  vda5050_types::info_detail::from_json(j, msg);
 }
 
 inline void to_json(nlohmann::json& j, const State& msg)

--- a/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
@@ -29,19 +29,97 @@
 #include <string>
 #include <utility>
 
+#include <vda5050_types/action_status.hpp>
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/connection_state.hpp>
+#include <vda5050_types/e_stop.hpp>
+#include <vda5050_types/error_level.hpp>
 #include <vda5050_types/header.hpp>
 #include <vda5050_types/operating_mode.hpp>
 
 #ifdef ENABLE_ROS2
 #include <rosidl_runtime_cpp/bounded_vector.hpp>
+#include <vda5050_msgs/msg/action_state.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
+#include <vda5050_msgs/msg/error.hpp>
+#include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #endif  // ENABLE_ROS2
 
 namespace vda5050_json_utils {
 
+//=============================================================================
+template <typename T>
+struct optional_field_traits;
+
+//=============================================================================
+template <typename T>
+struct optional_field_traits<std::optional<T>>
+{
+  static bool has_value(const std::optional<T>& opt)
+  {
+    return opt.has_value();
+  }
+
+  static const T& get(const std::optional<T>& opt)
+  {
+    return opt.value();
+  }
+
+  static void set(std::optional<T>& opt, T&& val)
+  {
+    opt = std::move(val);
+  }
+};
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+template <typename T, typename Alloc>
+struct optional_field_traits<rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>>
+{
+  static bool has_value(
+    const rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>& opt)
+  {
+    return !opt.empty();
+  }
+
+  static const T& get(const rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>& opt)
+  {
+    return opt.front();
+  }
+
+  static void set(rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>& opt, T&& val)
+  {
+    opt.clear();
+    opt.push_back(std::move(val));
+  }
+};
+
+template <typename T, std::size_t Max, typename Alloc>
+struct optional_field_traits<rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>>
+{
+  static bool has_value(
+    const rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt)
+  {
+    return !opt.empty();
+  }
+
+  static const rosidl_runtime_cpp::BoundedVector<T, Max, Alloc> get(
+    const rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt)
+  {
+    return opt;
+  }
+
+  static void set(
+    rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt,
+    rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>&& val)
+  {
+    opt = std::move(val);
+  }
+};
+#endif  // ENABLE_ROS2
+
+//=============================================================================
 using TimePoint = std::chrono::time_point<std::chrono::system_clock>;
 
 //=============================================================================
@@ -307,50 +385,220 @@ struct operating_mode_traits<std::string>
 
 //=============================================================================
 template <typename T>
-struct optional_field_traits;
+struct action_status_traits;
 
 //=============================================================================
-template <typename T>
-struct optional_field_traits<std::optional<T>>
+template <>
+struct action_status_traits<vda5050_types::ActionStatus>
 {
-  static bool has_value(const std::optional<T>& opt)
+  static std::string to_string(const vda5050_types::ActionStatus& status)
   {
-    return opt.has_value();
+    using vda5050_types::ActionStatus;
+
+    switch (status)
+    {
+      case ActionStatus::WAITING:
+        return "WAITING";
+      case ActionStatus::INITIALIZING:
+        return "INITIALIZING";
+      case ActionStatus::RUNNING:
+        return "RUNNING";
+      case ActionStatus::PAUSED:
+        return "PAUSED";
+      case ActionStatus::FINISHED:
+        return "FINISHED";
+      case ActionStatus::FAILED:
+        return "FAILED";
+      default:
+        throw std::runtime_error("Invalid ActionStatus enum value");
+    }
   }
 
-  static const T& get(const std::optional<T>& opt)
+  static vda5050_types::ActionStatus from_string(const std::string& status)
   {
-    return opt.value();
-  }
+    using vda5050_types::ActionStatus;
 
-  static void set(std::optional<T>& opt, T&& val)
-  {
-    opt = std::move(val);
+    if (status == "WAITING") return ActionStatus::WAITING;
+    if (status == "INITIALIZING") return ActionStatus::INITIALIZING;
+    if (status == "RUNNING") return ActionStatus::RUNNING;
+    if (status == "PAUSED") return ActionStatus::PAUSED;
+    if (status == "FINISHED") return ActionStatus::FINISHED;
+    if (status == "FAILED") return ActionStatus::FAILED;
+    throw std::runtime_error("Invalid actionStatus string");
   }
 };
 
 //=============================================================================
 #ifdef ENABLE_ROS2
-template <typename T, std::size_t Max, typename Alloc>
-struct optional_field_traits<rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>>
+template <>
+struct action_status_traits<std::string>
 {
-  static bool has_value(
-    const rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt)
+  static std::string to_string(const std::string& status)
   {
-    return !opt.empty();
+    using vda5050_msgs::msg::ActionState;
+    if (
+      status == ActionState::ACTION_STATUS_WAITING ||
+      status == ActionState::ACTION_STATUS_INITIALIZING ||
+      status == ActionState::ACTION_STATUS_RUNNING ||
+      status == ActionState::ACTION_STATUS_PAUSED ||
+      status == ActionState::ACTION_STATUS_FINISHED ||
+      status == ActionState::ACTION_STATUS_FAILED)
+    {
+      return status;
+    }
+    throw std::runtime_error("Invalid action_status value");
   }
 
-  static const T& get(
-    const rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt)
+  static std::string from_string(const std::string& status)
   {
-    return opt.front();
+    using vda5050_msgs::msg::ActionState;
+
+    if (
+      status == ActionState::ACTION_STATUS_WAITING ||
+      status == ActionState::ACTION_STATUS_INITIALIZING ||
+      status == ActionState::ACTION_STATUS_RUNNING ||
+      status == ActionState::ACTION_STATUS_PAUSED ||
+      status == ActionState::ACTION_STATUS_FINISHED ||
+      status == ActionState::ACTION_STATUS_FAILED)
+    {
+      return status;
+    }
+    throw std::runtime_error("Invalid actionStatus string");
+  }
+};
+#endif  // ENABLE_ROS2
+
+//=============================================================================
+template <typename T>
+struct error_level_traits;
+
+//=============================================================================
+template <>
+struct error_level_traits<vda5050_types::ErrorLevel>
+{
+  static std::string to_string(const vda5050_types::ErrorLevel& level)
+  {
+    using vda5050_types::ErrorLevel;
+
+    switch (level)
+    {
+      case ErrorLevel::WARNING:
+        return "WARNING";
+      case ErrorLevel::FATAL:
+        return "FATAL";
+      default:
+        throw std::runtime_error("Invalid ErrorLevel enum value");
+    }
   }
 
-  static void set(
-    rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt, T&& val)
+  static vda5050_types::ErrorLevel from_string(const std::string& level)
   {
-    opt.clear();
-    opt.push_back(std::move(val));
+    using vda5050_types::ErrorLevel;
+
+    if (level == "WARNING") return ErrorLevel::WARNING;
+    if (level == "FATAL") return ErrorLevel::FATAL;
+    throw std::runtime_error("Invalid errorLevel string");
+  }
+};
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+template <>
+struct error_level_traits<std::string>
+{
+  static std::string to_string(const std::string& level)
+  {
+    using vda5050_msgs::msg::Error;
+    if (
+      level == Error::ERROR_LEVEL_WARNING || level == Error::ERROR_LEVEL_FATAL)
+    {
+      return level;
+    }
+    throw std::runtime_error("Invalid error_level value");
+  }
+
+  static std::string from_string(const std::string& level)
+  {
+    using vda5050_msgs::msg::Error;
+    if (
+      level == Error::ERROR_LEVEL_WARNING || level == Error::ERROR_LEVEL_FATAL)
+    {
+      return level;
+    }
+    throw std::runtime_error("Invalid errorLevel string");
+  }
+};
+#endif  // ENABLE_ROS2
+
+//=============================================================================
+template <typename T>
+struct e_stop_traits;
+
+//=============================================================================
+template <>
+struct e_stop_traits<vda5050_types::EStop>
+{
+  static std::string to_string(const vda5050_types::EStop& type)
+  {
+    using vda5050_types::EStop;
+
+    switch (type)
+    {
+      case EStop::AUTOACK:
+        return "AUTOACK";
+      case EStop::MANUAL:
+        return "MANUAL";
+      case EStop::REMOTE:
+        return "REMOTE";
+      case EStop::NONE:
+        return "NONE";
+      default:
+        throw std::runtime_error("Invalid EStop enum value");
+    }
+  }
+
+  static vda5050_types::EStop from_string(const std::string& type)
+  {
+    using vda5050_types::EStop;
+
+    if (type == "AUTOACK") return EStop::AUTOACK;
+    if (type == "MANUAL") return EStop::MANUAL;
+    if (type == "REMOTE") return EStop::REMOTE;
+    if (type == "NONE") return EStop::NONE;
+    throw std::runtime_error("Invalid eStop string");
+  }
+};
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+template <>
+struct e_stop_traits<std::string>
+{
+  static std::string to_string(const std::string& type)
+  {
+    using vda5050_msgs::msg::SafetyState;
+
+    if (
+      type == SafetyState::E_STOP_AUTOACK ||
+      type == SafetyState::E_STOP_MANUAL ||
+      type == SafetyState::E_STOP_REMOTE || type == SafetyState::E_STOP_NONE)
+    {
+      return type;
+    }
+    throw std::runtime_error("Invalid e_stop value");
+  }
+
+  static std::string from_string(const std::string& type)
+  {
+    using vda5050_msgs::msg::SafetyState;
+    if (
+      type == SafetyState::E_STOP_AUTOACK ||
+      type == SafetyState::E_STOP_MANUAL ||
+      type == SafetyState::E_STOP_REMOTE || type == SafetyState::E_STOP_NONE)
+    {
+      return type;
+    }
+    throw std::runtime_error("Invalid eStop string");
   }
 };
 #endif  // ENABLE_ROS2

--- a/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
@@ -30,6 +30,7 @@
 #include <utility>
 
 #include <vda5050_types/action_status.hpp>
+#include <vda5050_types/blocking_type.hpp>
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/connection_state.hpp>
 #include <vda5050_types/e_stop.hpp>
@@ -37,11 +38,14 @@
 #include <vda5050_types/header.hpp>
 #include <vda5050_types/info_level.hpp>
 #include <vda5050_types/operating_mode.hpp>
+#include <vda5050_types/orientation_type.hpp>
 
 #ifdef ENABLE_ROS2
 #include <rosidl_runtime_cpp/bounded_vector.hpp>
+#include <vda5050_msgs/msg/action.hpp>
 #include <vda5050_msgs/msg/action_state.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
+#include <vda5050_msgs/msg/edge.hpp>
 #include <vda5050_msgs/msg/error.hpp>
 #include <vda5050_msgs/msg/info.hpp>
 #include <vda5050_msgs/msg/safety_state.hpp>
@@ -58,6 +62,8 @@ struct optional_field_traits;
 template <typename T>
 struct optional_field_traits<std::optional<T>>
 {
+  using value_type = T;
+
   static bool has_value(const std::optional<T>& opt)
   {
     return opt.has_value();
@@ -68,9 +74,10 @@ struct optional_field_traits<std::optional<T>>
     return opt.value();
   }
 
-  static void set(std::optional<T>& opt, T&& val)
+  template <typename U>
+  static void set(std::optional<T>& opt, U&& val)
   {
-    opt = std::move(val);
+    opt = std::forward<U>(val);
   }
 };
 
@@ -79,6 +86,8 @@ struct optional_field_traits<std::optional<T>>
 template <typename T, typename Alloc>
 struct optional_field_traits<rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>>
 {
+  using value_type = T;
+
   static bool has_value(
     const rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>& opt)
   {
@@ -90,16 +99,19 @@ struct optional_field_traits<rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>>
     return opt.front();
   }
 
-  static void set(rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>& opt, T&& val)
+  template <typename U>
+  static void set(rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>& opt, U&& val)
   {
     opt.clear();
-    opt.push_back(std::move(val));
+    opt.push_back(std::forward<U>(val));
   }
 };
 
 template <typename T, std::size_t Max, typename Alloc>
 struct optional_field_traits<rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>>
 {
+  using value_type = T;
+
   static bool has_value(
     const rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt)
   {
@@ -112,11 +124,11 @@ struct optional_field_traits<rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>>
     return opt;
   }
 
+  template <typename U>
   static void set(
-    rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt,
-    rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>&& val)
+    rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt, U&& val)
   {
-    opt = std::move(val);
+    opt = std::forward<U>(val);
   }
 };
 #endif  // ENABLE_ROS2
@@ -667,6 +679,141 @@ struct info_level_traits<std::string>
       return level;
     }
     throw std::runtime_error("Invalid infoLevel string");
+  }
+};
+#endif  // ENABLE_ROS2
+
+//=============================================================================
+template <typename T>
+struct blocking_type_traits;
+
+//=============================================================================
+template <>
+struct blocking_type_traits<vda5050_types::BlockingType>
+{
+  static std::string to_string(const vda5050_types::BlockingType& type)
+  {
+    using vda5050_types::BlockingType;
+
+    switch (type)
+    {
+      case BlockingType::NONE:
+        return "NONE";
+      case BlockingType::SOFT:
+        return "SOFT";
+      case BlockingType::HARD:
+        return "HARD";
+      default:
+        throw std::runtime_error("Invalid BlockingType enum value");
+    }
+  }
+
+  static vda5050_types::BlockingType from_string(const std::string& type)
+  {
+    using vda5050_types::BlockingType;
+
+    if (type == "NONE") return BlockingType::NONE;
+    if (type == "SOFT") return BlockingType::SOFT;
+    if (type == "HARD") return BlockingType::HARD;
+    throw std::runtime_error("Invalid blockingType string");
+  }
+};
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+template <>
+struct blocking_type_traits<std::string>
+{
+  static std::string to_string(const std::string& type)
+  {
+    using vda5050_msgs::msg::Action;
+
+    if (
+      type == Action::BLOCKING_TYPE_NONE ||
+      type == Action::BLOCKING_TYPE_SOFT || type == Action::BLOCKING_TYPE_HARD)
+    {
+      return type;
+    }
+    throw std::runtime_error("Invalid blocking_type value");
+  }
+
+  static std::string from_string(const std::string& type)
+  {
+    using vda5050_msgs::msg::Action;
+
+    if (
+      type == Action::BLOCKING_TYPE_NONE ||
+      type == Action::BLOCKING_TYPE_SOFT || type == Action::BLOCKING_TYPE_HARD)
+    {
+      return type;
+    }
+    throw std::runtime_error("Invalid blockingType string");
+  }
+};
+#endif  // ENABLE_ROS2
+
+//=============================================================================
+template <typename T>
+struct orientation_type_traits;
+
+//=============================================================================
+template <>
+struct orientation_type_traits<vda5050_types::OrientationType>
+{
+  static std::string to_string(const vda5050_types::OrientationType& type)
+  {
+    using vda5050_types::OrientationType;
+
+    switch (type)
+    {
+      case OrientationType::GLOBAL:
+        return "GLOBAL";
+      case OrientationType::TANGENTIAL:
+        return "TANGENTIAL";
+      default:
+        throw std::runtime_error("Invalid OrientationType enum value");
+    }
+  }
+
+  static vda5050_types::OrientationType from_string(const std::string& type)
+  {
+    using vda5050_types::OrientationType;
+
+    if (type == "GLOBAL") return OrientationType::GLOBAL;
+    if (type == "TANGENTIAL") return OrientationType::TANGENTIAL;
+    throw std::runtime_error("Invalid orientationType string");
+  }
+};
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+template <>
+struct orientation_type_traits<std::string>
+{
+  static std::string to_string(const std::string& type)
+  {
+    using vda5050_msgs::msg::Edge;
+
+    if (
+      type == Edge::ORIENTATION_TYPE_TANGENTIAL ||
+      type == Edge::ORIENTATION_TYPE_GLOBAL)
+    {
+      return type;
+    }
+    throw std::runtime_error("Invalid orientation_type value");
+  }
+
+  static std::string from_string(const std::string& type)
+  {
+    using vda5050_msgs::msg::Edge;
+
+    if (
+      type == Edge::ORIENTATION_TYPE_TANGENTIAL ||
+      type == Edge::ORIENTATION_TYPE_GLOBAL)
+    {
+      return type;
+    }
+    throw std::runtime_error("Invalid orientationType string");
   }
 };
 #endif  // ENABLE_ROS2

--- a/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
@@ -23,9 +23,11 @@
 #include <ctime>
 #include <iomanip>
 #include <limits>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/connection_state.hpp>
@@ -33,6 +35,7 @@
 #include <vda5050_types/operating_mode.hpp>
 
 #ifdef ENABLE_ROS2
+#include <rosidl_runtime_cpp/bounded_vector.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #endif  // ENABLE_ROS2
@@ -298,6 +301,56 @@ struct operating_mode_traits<std::string>
       return mode;
     }
     throw std::runtime_error("Invalid operatingMode string");
+  }
+};
+#endif  // ENABLE_ROS2
+
+//=============================================================================
+template <typename T>
+struct optional_field_traits;
+
+//=============================================================================
+template <typename T>
+struct optional_field_traits<std::optional<T>>
+{
+  static bool has_value(const std::optional<T>& opt)
+  {
+    return opt.has_value();
+  }
+
+  static const T& get(const std::optional<T>& opt)
+  {
+    return opt.value();
+  }
+
+  static void set(std::optional<T>& opt, T&& val)
+  {
+    opt = std::move(val);
+  }
+};
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+template <typename T, std::size_t Max, typename Alloc>
+struct optional_field_traits<rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>>
+{
+  static bool has_value(
+    const rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt)
+  {
+    return !opt.empty();
+  }
+
+  static const T& get(
+    const rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt)
+  {
+    return opt.front();
+  }
+
+  static void set(
+    rosidl_runtime_cpp::BoundedVector<T, Max, Alloc>& opt, T&& val)
+  {
+    opt.clear();
+    opt.push_back(std::move(val));
   }
 };
 #endif  // ENABLE_ROS2

--- a/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
@@ -30,9 +30,11 @@
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/connection_state.hpp>
 #include <vda5050_types/header.hpp>
+#include <vda5050_types/operating_mode.hpp>
 
 #ifdef ENABLE_ROS2
 #include <vda5050_msgs/msg/connection.hpp>
+#include <vda5050_msgs/msg/state.hpp>
 #endif  // ENABLE_ROS2
 
 namespace vda5050_json_utils {
@@ -134,7 +136,7 @@ struct timestamp_traits<int64_t>
 {
   static std::string to_string(const int64_t& millisec)
   {
-    using namespace std::chrono;
+    using std::chrono::milliseconds;
 
     TimePoint time_point{milliseconds(millisec)};
     return to_iso8601(time_point);
@@ -142,7 +144,8 @@ struct timestamp_traits<int64_t>
 
   static int64_t from_string(const std::string& time_string)
   {
-    using namespace std::chrono;
+    using std::chrono::duration_cast;
+    using std::chrono::milliseconds;
 
     auto time_point = from_iso8601(time_string);
     return duration_cast<milliseconds>(time_point.time_since_epoch()).count();
@@ -159,7 +162,7 @@ struct connection_state_traits<vda5050_types::ConnectionState>
 {
   static std::string to_string(const vda5050_types::ConnectionState& state)
   {
-    using namespace vda5050_types;
+    using vda5050_types::ConnectionState;
 
     switch (state)
     {
@@ -176,7 +179,7 @@ struct connection_state_traits<vda5050_types::ConnectionState>
 
   static vda5050_types::ConnectionState from_string(const std::string& state)
   {
-    using namespace vda5050_types;
+    using vda5050_types::ConnectionState;
 
     if (state == "ONLINE") return ConnectionState::ONLINE;
     if (state == "OFFLINE") return ConnectionState::OFFLINE;
@@ -192,7 +195,8 @@ struct connection_state_traits<std::string>
 {
   static std::string to_string(const std::string& state)
   {
-    using namespace vda5050_msgs::msg;
+    using vda5050_msgs::msg::Connection;
+
     if (
       state == Connection::ONLINE || state == Connection::OFFLINE ||
       state == Connection::CONNECTIONBROKEN)
@@ -204,7 +208,8 @@ struct connection_state_traits<std::string>
 
   static std::string from_string(const std::string& state)
   {
-    using namespace vda5050_msgs::msg;
+    using vda5050_msgs::msg::Connection;
+
     if (
       state == Connection::ONLINE || state == Connection::OFFLINE ||
       state == Connection::CONNECTIONBROKEN)
@@ -214,7 +219,87 @@ struct connection_state_traits<std::string>
     throw std::runtime_error("Invalid connectionState string");
   }
 };
+#endif  // ENABLE_ROS2
 
+//=============================================================================
+template <typename T>
+struct operating_mode_traits;
+
+//=============================================================================
+template <>
+struct operating_mode_traits<vda5050_types::OperatingMode>
+{
+  static std::string to_string(const vda5050_types::OperatingMode& mode)
+  {
+    using vda5050_types::OperatingMode;
+
+    switch (mode)
+    {
+      case OperatingMode::AUTOMATIC:
+        return "AUTOMATIC";
+      case OperatingMode::SEMIAUTOMATIC:
+        return "SEMIAUTOMATIC";
+      case OperatingMode::MANUAL:
+        return "MANUAL";
+      case OperatingMode::SERVICE:
+        return "SERVICE";
+      case OperatingMode::TEACHIN:
+        return "TEACHIN";
+      default:
+        throw std::runtime_error("Invalid OperatingMode enum value");
+    }
+  }
+
+  static vda5050_types::OperatingMode from_string(const std::string& mode)
+  {
+    using vda5050_types::OperatingMode;
+
+    if (mode == "AUTOMATIC") return OperatingMode::AUTOMATIC;
+    if (mode == "SEMIAUTOMATIC") return OperatingMode::SEMIAUTOMATIC;
+    if (mode == "MANUAL") return OperatingMode::MANUAL;
+    if (mode == "SERVICE") return OperatingMode::SERVICE;
+    if (mode == "TEACHIN") return OperatingMode::TEACHIN;
+    throw std::runtime_error("Invalid operatingMode string");
+  }
+};
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+template <>
+struct operating_mode_traits<std::string>
+{
+  static std::string to_string(const std::string& mode)
+  {
+    using vda5050_msgs::msg::State;
+
+    if (
+      mode == State::OPERATING_MODE_AUTOMATIC ||
+      mode == State::OPERATING_MODE_SEMIAUTOMATIC ||
+      mode == State::OPERATING_MODE_MANUAL ||
+      mode == State::OPERATING_MODE_SERVICE ||
+      mode == State::OPERATING_MODE_TEACHIN)
+    {
+      return mode;
+    }
+    throw std::runtime_error("Invalid operating_mode value");
+  }
+
+  static std::string from_string(const std::string& mode)
+  {
+    using vda5050_msgs::msg::State;
+
+    if (
+      mode == State::OPERATING_MODE_AUTOMATIC ||
+      mode == State::OPERATING_MODE_SEMIAUTOMATIC ||
+      mode == State::OPERATING_MODE_MANUAL ||
+      mode == State::OPERATING_MODE_SERVICE ||
+      mode == State::OPERATING_MODE_TEACHIN)
+    {
+      return mode;
+    }
+    throw std::runtime_error("Invalid operatingMode string");
+  }
+};
 #endif  // ENABLE_ROS2
 
 }  // namespace vda5050_json_utils

--- a/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2025 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_JSON_UTILS__TRAITS_HPP_
+#define VDA5050_JSON_UTILS__TRAITS_HPP_
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include <vda5050_types/connection.hpp>
+#include <vda5050_types/connection_state.hpp>
+#include <vda5050_types/header.hpp>
+
+#ifdef ENABLE_ROS2
+#include <vda5050_msgs/msg/connection.hpp>
+#endif  // ENABLE_ROS2
+
+namespace vda5050_json_utils {
+
+using TimePoint = std::chrono::time_point<std::chrono::system_clock>;
+
+//=============================================================================
+inline std::string to_iso8601(TimePoint time_point)
+{
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+  using std::chrono::system_clock;
+
+  std::time_t time_sec = system_clock::to_time_t(time_point);
+  auto duration = time_point.time_since_epoch();
+  auto millisec = duration_cast<milliseconds>(duration).count() % 1000;
+
+  std::ostringstream oss;
+  oss << std::put_time(std::gmtime(&time_sec), vda5050_types::ISO8601_FORMAT);
+  oss << "." << std::setw(3) << std::setfill('0') << millisec << "Z";
+  if (oss.fail())
+  {
+    throw std::runtime_error("Failed to format timestamp for serialization.");
+  }
+  return oss.str();
+}
+
+//=============================================================================
+inline TimePoint from_iso8601(const std::string& time_string)
+{
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+  using std::chrono::system_clock;
+
+  std::tm t = {};
+  char sep;
+  int millisec = 0;
+
+  std::istringstream ss(time_string);
+  ss >> std::get_time(&t, vda5050_types::ISO8601_FORMAT);
+
+  ss >> sep;
+  if (ss.fail() || sep != '.')
+  {
+    throw std::runtime_error(
+      "JSON parsing error for Header: Unexpected character after seconds in "
+      "timestamp.");
+  }
+  else
+  {
+    ss >> millisec;
+    if (ss.fail())
+    {
+      throw std::runtime_error(
+        "JSON parsing error for Header: Failed to parse milliseconds from "
+        "timestamp.");
+    }
+
+    if (!ss.eof())
+    {
+      ss.ignore(std::numeric_limits<std::streamsize>::max(), 'Z');
+    }
+    else
+    {
+      throw std::runtime_error(
+        "JSON parsing error for Header: Expected 'Z' at the end of timestamp "
+        "to indicate UTC.");
+    }
+  }
+
+  // TODO(sauk): Add a check to see if the platform supports timegm
+  auto tp = system_clock::from_time_t(timegm(&t));
+
+  return tp + milliseconds(millisec);
+}
+
+//=============================================================================
+template <typename T>
+struct timestamp_traits;
+
+//=============================================================================
+template <>
+struct timestamp_traits<TimePoint>
+{
+  static std::string to_string(const TimePoint& time_point)
+  {
+    return to_iso8601(time_point);
+  }
+
+  static TimePoint from_string(const std::string& time_string)
+  {
+    return from_iso8601(time_string);
+  }
+};
+
+//=============================================================================
+template <>
+struct timestamp_traits<int64_t>
+{
+  static std::string to_string(const int64_t& millisec)
+  {
+    using namespace std::chrono;
+
+    TimePoint time_point{milliseconds(millisec)};
+    return to_iso8601(time_point);
+  }
+
+  static int64_t from_string(const std::string& time_string)
+  {
+    using namespace std::chrono;
+
+    auto time_point = from_iso8601(time_string);
+    return duration_cast<milliseconds>(time_point.time_since_epoch()).count();
+  }
+};
+
+//=============================================================================
+template <typename T>
+struct connection_state_traits;
+
+//=============================================================================
+template <>
+struct connection_state_traits<vda5050_types::ConnectionState>
+{
+  static std::string to_string(const vda5050_types::ConnectionState& state)
+  {
+    using namespace vda5050_types;
+
+    switch (state)
+    {
+      case ConnectionState::ONLINE:
+        return "ONLINE";
+      case ConnectionState::OFFLINE:
+        return "OFFLINE";
+      case ConnectionState::CONNECTIONBROKEN:
+        return "CONNECTIONBROKEN";
+      default:
+        throw std::runtime_error("Invalid ConnectionState enum value");
+    }
+  }
+
+  static vda5050_types::ConnectionState from_string(const std::string& state)
+  {
+    using namespace vda5050_types;
+
+    if (state == "ONLINE") return ConnectionState::ONLINE;
+    if (state == "OFFLINE") return ConnectionState::OFFLINE;
+    if (state == "CONNECTIONBROKEN") return ConnectionState::CONNECTIONBROKEN;
+    throw std::runtime_error("Invalid connectionState string");
+  }
+};
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+template <>
+struct connection_state_traits<std::string>
+{
+  static std::string to_string(const std::string& state)
+  {
+    using namespace vda5050_msgs::msg;
+    if (
+      state == Connection::ONLINE || state == Connection::OFFLINE ||
+      state == Connection::CONNECTIONBROKEN)
+    {
+      return state;
+    }
+    throw std::runtime_error("Invalid connection_state value");
+  }
+
+  static std::string from_string(const std::string& state)
+  {
+    using namespace vda5050_msgs::msg;
+    if (
+      state == Connection::ONLINE || state == Connection::OFFLINE ||
+      state == Connection::CONNECTIONBROKEN)
+    {
+      return state;
+    }
+    throw std::runtime_error("Invalid connectionState string");
+  }
+};
+
+#endif  // ENABLE_ROS2
+
+}  // namespace vda5050_json_utils
+
+#endif  // VDA5050_JSON_UTILS__TRAITS_HPP_

--- a/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
@@ -35,6 +35,7 @@
 #include <vda5050_types/e_stop.hpp>
 #include <vda5050_types/error_level.hpp>
 #include <vda5050_types/header.hpp>
+#include <vda5050_types/info_level.hpp>
 #include <vda5050_types/operating_mode.hpp>
 
 #ifdef ENABLE_ROS2
@@ -42,6 +43,7 @@
 #include <vda5050_msgs/msg/action_state.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/error.hpp>
+#include <vda5050_msgs/msg/info.hpp>
 #include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #endif  // ENABLE_ROS2
@@ -83,7 +85,7 @@ struct optional_field_traits<rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>>
     return !opt.empty();
   }
 
-  static const T& get(const rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>& opt)
+  static const T get(const rosidl_runtime_cpp::BoundedVector<T, 1, Alloc>& opt)
   {
     return opt.front();
   }
@@ -436,6 +438,7 @@ struct action_status_traits<std::string>
   static std::string to_string(const std::string& status)
   {
     using vda5050_msgs::msg::ActionState;
+
     if (
       status == ActionState::ACTION_STATUS_WAITING ||
       status == ActionState::ACTION_STATUS_INITIALIZING ||
@@ -509,6 +512,7 @@ struct error_level_traits<std::string>
   static std::string to_string(const std::string& level)
   {
     using vda5050_msgs::msg::Error;
+
     if (
       level == Error::ERROR_LEVEL_WARNING || level == Error::ERROR_LEVEL_FATAL)
     {
@@ -520,6 +524,7 @@ struct error_level_traits<std::string>
   static std::string from_string(const std::string& level)
   {
     using vda5050_msgs::msg::Error;
+
     if (
       level == Error::ERROR_LEVEL_WARNING || level == Error::ERROR_LEVEL_FATAL)
     {
@@ -591,6 +596,7 @@ struct e_stop_traits<std::string>
   static std::string from_string(const std::string& type)
   {
     using vda5050_msgs::msg::SafetyState;
+
     if (
       type == SafetyState::E_STOP_AUTOACK ||
       type == SafetyState::E_STOP_MANUAL ||
@@ -599,6 +605,68 @@ struct e_stop_traits<std::string>
       return type;
     }
     throw std::runtime_error("Invalid eStop string");
+  }
+};
+#endif  // ENABLE_ROS2
+
+//=============================================================================
+template <typename T>
+struct info_level_traits;
+
+//=============================================================================
+template <>
+struct info_level_traits<vda5050_types::InfoLevel>
+{
+  static std::string to_string(const vda5050_types::InfoLevel& level)
+  {
+    using vda5050_types::InfoLevel;
+
+    switch (level)
+    {
+      case InfoLevel::INFO:
+        return "INFO";
+      case InfoLevel::DEBUG:
+        return "DEBUG";
+      default:
+        throw std::runtime_error("Invalid InfoLevel enum value");
+    }
+  }
+
+  static vda5050_types::InfoLevel from_string(const std::string& level)
+  {
+    using vda5050_types::InfoLevel;
+
+    if (level == "INFO") return InfoLevel::INFO;
+    if (level == "DEBUG") return InfoLevel::DEBUG;
+    throw std::runtime_error("Invalid infoLevel string");
+  }
+};
+
+//=============================================================================
+#ifdef ENABLE_ROS2
+template <>
+struct info_level_traits<std::string>
+{
+  static std::string to_string(const std::string& level)
+  {
+    using vda5050_msgs::msg::Info;
+
+    if (level == Info::INFO_LEVEL_INFO || level == Info::INFO_LEVEL_DEBUG)
+    {
+      return level;
+    }
+    throw std::runtime_error("Invalid info_level value");
+  }
+
+  static std::string from_string(const std::string& level)
+  {
+    using vda5050_msgs::msg::Info;
+
+    if (level == Info::INFO_LEVEL_INFO || level == Info::INFO_LEVEL_DEBUG)
+    {
+      return level;
+    }
+    throw std::runtime_error("Invalid infoLevel string");
   }
 };
 #endif  // ENABLE_ROS2

--- a/vda5050_json_utils/package.xml
+++ b/vda5050_json_utils/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>vda5050_json_utils</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="saurabh_kamat@artc.a-star.edu.sg">Saurabh Kamat</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>vda5050_types</build_depend>
+  <build_depend>vda5050_msgs</build_depend>
+
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/vda5050_json_utils/test/generator/generator.hpp
+++ b/vda5050_json_utils/test/generator/generator.hpp
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-#ifndef VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_HPP_
-#define VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_HPP_
+#ifndef GENERATOR__GENERATOR_HPP_
+#define GENERATOR__GENERATOR_HPP_
 
 #include <limits>
 #include <random>
@@ -548,4 +548,4 @@ private:
   std::uniform_real_distribution<double> percentage_dist_;
 };
 
-#endif  // VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_HPP_
+#endif  // GENERATOR__GENERATOR_HPP_

--- a/vda5050_json_utils/test/generator/generator.hpp
+++ b/vda5050_json_utils/test/generator/generator.hpp
@@ -28,12 +28,16 @@
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/connection_state.hpp>
 #include <vda5050_types/header.hpp>
+#include <vda5050_types/node_position.hpp>
+#include <vda5050_types/node_state.hpp>
 #include <vda5050_types/operating_mode.hpp>
 #include <vda5050_types/state.hpp>
 
 using vda5050_types::Connection;
 using vda5050_types::ConnectionState;
 using vda5050_types::Header;
+using vda5050_types::NodePosition;
+using vda5050_types::NodeState;
 using vda5050_types::OperatingMode;
 using vda5050_types::State;
 
@@ -45,6 +49,8 @@ public:
   RandomDataGenerator()
   : rng_(std::random_device()()),
     uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    float_dist_(
+      std::numeric_limits<double>::min(), std::numeric_limits<double>::max()),
     bool_dist_(0, 1),
     string_length_dist_(0, 50),
     size_dist_(0, 10)
@@ -56,6 +62,8 @@ public:
   explicit RandomDataGenerator(uint32_t seed)
   : rng_(seed),
     uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    float_dist_(
+      std::numeric_limits<double>::min(), std::numeric_limits<double>::max()),
     bool_dist_(0, 1),
     string_length_dist_(0, 50),
     size_dist_(0, 10)
@@ -80,6 +88,18 @@ public:
   {
     std::uniform_int_distribution<uint8_t> index_dist(0, size - 1);
     return index_dist(rng_);
+  }
+
+  /// \brief Generate a random value for vector length
+  uint8_t generate_random_size()
+  {
+    return size_dist_(rng_);
+  }
+
+  /// \brief Generate a random 64-bit floating-point number
+  double generate_random_float()
+  {
+    return float_dist_(rng_);
   }
 
   /// \brief Generate a random alphanumerical string with length upto 50
@@ -128,6 +148,18 @@ public:
     return mode[mode_idx];
   }
 
+  /// \brief Generate a random vector of type T
+  template <typename T>
+  std::vector<T> generate_random_vector(const uint8_t size)
+  {
+    std::vector<T> vec(size);
+    for (auto it = vec.begin(); it != vec.end(); ++it)
+    {
+      *it = generate<T>();
+    }
+    return vec;
+  }
+
   /// \brief Generate a fully populated message of a supported type
   template <typename T>
   T generate()
@@ -146,6 +178,24 @@ public:
       msg.manufacturer = generate_random_string();
       msg.serial_number = generate_random_string();
     }
+    else if constexpr (std::is_same_v<T, NodePosition>)
+    {
+      msg.x = generate_random_float();
+      msg.y = generate_random_float();
+      msg.theta = generate_random_float();
+      msg.allowed_deviation_x_y = generate_random_float();
+      msg.allowed_deviation_theta = generate_random_float();
+      msg.map_id = generate_random_string();
+      msg.map_description = generate_random_string();
+    }
+    else if constexpr (std::is_same_v<T, NodeState>)
+    {
+      msg.node_id = generate_random_string();
+      msg.sequence_id = generate_random_uint();
+      msg.node_description = generate_random_string();
+      msg.node_position = generate<NodePosition>();
+      msg.released = generate_random_bool();
+    }
     else if constexpr (std::is_same_v<T, State>)
     {
       msg.header = generate<Header>();
@@ -159,8 +209,8 @@ public:
       // msg.new_base_request.push_back(generate_random_bool());
       // msg.distance_since_last_node.push_back(generate_random_float());
       msg.operating_mode = generate_random_operating_mode();
-      // msg.node_states =
-      //   generate_random_vector<NodeState>(generate_random_size());
+      msg.node_states =
+        generate_random_vector<NodeState>(generate_random_size());
       // msg.edge_states =
       //   generate_random_vector<EdgeState>(generate_random_size());
       // msg.agv_position.push_back(generate<AGVPosition>());
@@ -188,6 +238,9 @@ private:
 
   /// \brief Distribution for unsigned 32-bit integers
   std::uniform_int_distribution<uint32_t> uint_dist_;
+
+  /// \brief Distribution for 64-bit floating-point numbers
+  std::uniform_real_distribution<double> float_dist_;
 
   /// \brief Distribution for a boolean value
   std::uniform_int_distribution<int> bool_dist_;

--- a/vda5050_json_utils/test/generator/generator.hpp
+++ b/vda5050_json_utils/test/generator/generator.hpp
@@ -27,7 +27,9 @@
 
 #include <vda5050_types/action_state.hpp>
 #include <vda5050_types/action_status.hpp>
+#include <vda5050_types/agv_position.hpp>
 #include <vda5050_types/battery_state.hpp>
+#include <vda5050_types/bounding_box_reference.hpp>
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/connection_state.hpp>
 #include <vda5050_types/control_point.hpp>
@@ -37,16 +39,24 @@
 #include <vda5050_types/error_level.hpp>
 #include <vda5050_types/error_reference.hpp>
 #include <vda5050_types/header.hpp>
+#include <vda5050_types/info.hpp>
+#include <vda5050_types/info_level.hpp>
+#include <vda5050_types/info_reference.hpp>
+#include <vda5050_types/load.hpp>
+#include <vda5050_types/load_dimensions.hpp>
 #include <vda5050_types/node_position.hpp>
 #include <vda5050_types/node_state.hpp>
 #include <vda5050_types/operating_mode.hpp>
 #include <vda5050_types/safety_state.hpp>
 #include <vda5050_types/state.hpp>
 #include <vda5050_types/trajectory.hpp>
+#include <vda5050_types/velocity.hpp>
 
 using vda5050_types::ActionState;
 using vda5050_types::ActionStatus;
+using vda5050_types::AGVPosition;
 using vda5050_types::BatteryState;
+using vda5050_types::BoundingBoxReference;
 using vda5050_types::Connection;
 using vda5050_types::ConnectionState;
 using vda5050_types::ControlPoint;
@@ -56,12 +66,18 @@ using vda5050_types::ErrorLevel;
 using vda5050_types::ErrorReference;
 using vda5050_types::EStop;
 using vda5050_types::Header;
+using vda5050_types::Info;
+using vda5050_types::InfoLevel;
+using vda5050_types::InfoReference;
+using vda5050_types::Load;
+using vda5050_types::LoadDimensions;
 using vda5050_types::NodePosition;
 using vda5050_types::NodeState;
 using vda5050_types::OperatingMode;
 using vda5050_types::SafetyState;
 using vda5050_types::State;
 using vda5050_types::Trajectory;
+using vda5050_types::Velocity;
 
 /// \brief Utility class to generate random instances of VDA 5050 message types
 class RandomDataGenerator
@@ -205,12 +221,20 @@ public:
   }
 
   /// \brief Generate a random eStop value
-  vda5050_types::EStop generate_random_e_stop()
+  EStop generate_random_e_stop()
   {
-    std::vector<vda5050_types::EStop> types = {
+    std::vector<EStop> types = {
       EStop::AUTOACK, EStop::MANUAL, EStop::REMOTE, EStop::NONE};
     auto type_idx = generate_random_index(types.size());
     return types[type_idx];
+  }
+
+  /// \brief Generate a random infoLevel value
+  InfoLevel generate_random_info_level()
+  {
+    std::vector<InfoLevel> levels = {InfoLevel::INFO, InfoLevel::DEBUG};
+    auto level_idx = generate_random_index(levels.size());
+    return levels[level_idx];
   }
 
   /// \brief Generate a random vector of type float64
@@ -249,6 +273,17 @@ public:
       msg.action_status = generate_action_status();
       msg.result_description = generate_random_string();
     }
+    else if constexpr (std::is_same_v<T, AGVPosition>)
+    {
+      msg.x = generate_random_float();
+      msg.y = generate_random_float();
+      msg.theta = generate_random_float();
+      msg.map_id = generate_random_string();
+      msg.map_description = generate_random_string();
+      msg.position_initialized = generate_random_bool();
+      msg.localization_score = generate_random_float();
+      msg.deviation_range = generate_random_float();
+    }
     else if constexpr (std::is_same_v<T, BatteryState>)
     {
       msg.battery_charge = generate_random_percentage();
@@ -256,6 +291,13 @@ public:
       msg.battery_health = generate_random_int();
       msg.charging = generate_random_bool();
       msg.reach = generate_random_uint();
+    }
+    else if constexpr (std::is_same_v<T, BoundingBoxReference>)
+    {
+      msg.x = generate_random_float();
+      msg.y = generate_random_float();
+      msg.z = generate_random_float();
+      msg.theta = generate_random_float();
     }
     else if constexpr (std::is_same_v<T, Connection>)
     {
@@ -296,6 +338,33 @@ public:
       msg.manufacturer = generate_random_string();
       msg.serial_number = generate_random_string();
     }
+    else if constexpr (std::is_same_v<T, Info>)
+    {
+      msg.info_type = generate_random_string();
+      msg.info_references = generate_random_vector<InfoReference>(5);
+      msg.info_description = generate_random_string();
+      msg.info_level = generate_random_info_level();
+    }
+    else if constexpr (std::is_same_v<T, InfoReference>)
+    {
+      msg.reference_key = generate_random_string();
+      msg.reference_value = generate_random_string();
+    }
+    else if constexpr (std::is_same_v<T, Load>)
+    {
+      msg.load_id = generate_random_string();
+      msg.load_type = generate_random_string();
+      msg.load_position = generate_random_string();
+      msg.bounding_box_reference = generate<BoundingBoxReference>();
+      msg.load_dimensions = generate<LoadDimensions>();
+      msg.weight = generate_random_float();
+    }
+    else if constexpr (std::is_same_v<T, LoadDimensions>)
+    {
+      msg.length = generate_random_float();
+      msg.width = generate_random_float();
+      msg.height = generate_random_float();
+    }
     else if constexpr (std::is_same_v<T, NodePosition>)
     {
       msg.x = generate_random_float();
@@ -324,26 +393,26 @@ public:
       msg.header = generate<Header>();
       msg.order_id = generate_random_string();
       msg.order_update_id = generate_random_uint();
-      // msg.zone_set_id.push_back(generate_random_string());
+      msg.zone_set_id = generate_random_string();
       msg.last_node_id = generate_random_string();
       msg.last_node_sequence_id = generate_random_uint();
       msg.driving = generate_random_bool();
-      // msg.paused.push_back(generate_random_bool());
-      // msg.new_base_request.push_back(generate_random_bool());
-      // msg.distance_since_last_node.push_back(generate_random_float());
+      msg.paused = generate_random_bool();
+      msg.new_base_request = generate_random_bool();
+      msg.distance_since_last_node = generate_random_float();
       msg.operating_mode = generate_random_operating_mode();
       msg.node_states =
         generate_random_vector<NodeState>(generate_random_size());
       msg.edge_states =
         generate_random_vector<EdgeState>(generate_random_size());
-      // msg.agv_position.push_back(generate<AGVPosition>());
-      // msg.velocity.push_back(generate<Velocity>());
-      // msg.loads = generate_random_vector<Load>(generate_random_size());
+      msg.agv_position = generate<AGVPosition>();
+      msg.velocity = generate<Velocity>();
+      msg.loads = generate_random_vector<Load>(generate_random_size());
       msg.action_states =
         generate_random_vector<ActionState>(generate_random_size());
       msg.battery_state = generate<BatteryState>();
       msg.errors = generate_random_vector<Error>(generate_random_size());
-      // msg.information = generate_random_vector<Info>(generate_random_size());
+      msg.information = generate_random_vector<Info>(generate_random_size());
       msg.safety_state = generate<SafetyState>();
     }
     else if constexpr (std::is_same_v<T, Trajectory>)
@@ -352,6 +421,12 @@ public:
       msg.control_points =
         generate_random_vector<ControlPoint>(generate_random_size());
       msg.degree = 1.0;
+    }
+    else if constexpr (std::is_same_v<T, Velocity>)
+    {
+      msg.vx = generate_random_float();
+      msg.vy = generate_random_float();
+      msg.omega = generate_random_float();
     }
     else
     {

--- a/vda5050_json_utils/test/generator/generator.hpp
+++ b/vda5050_json_utils/test/generator/generator.hpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2025 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_HPP_
+#define VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_HPP_
+
+#include <limits>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <vda5050_types/connection.hpp>
+#include <vda5050_types/connection_state.hpp>
+#include <vda5050_types/header.hpp>
+#include <vda5050_types/operating_mode.hpp>
+#include <vda5050_types/state.hpp>
+
+using vda5050_types::Connection;
+using vda5050_types::ConnectionState;
+using vda5050_types::Header;
+using vda5050_types::OperatingMode;
+using vda5050_types::State;
+
+/// \brief Utility class to generate random instances of VDA 5050 message types
+class RandomDataGenerator
+{
+public:
+  /// \brief Default constructor using a non-deterministic seed
+  RandomDataGenerator()
+  : rng_(std::random_device()()),
+    uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    bool_dist_(0, 1),
+    string_length_dist_(0, 50),
+    size_dist_(0, 10)
+  {
+    // Nothing to do
+  }
+
+  /// \brief Constructor with a fixed seed for deterministic results
+  explicit RandomDataGenerator(uint32_t seed)
+  : rng_(seed),
+    uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    bool_dist_(0, 1),
+    string_length_dist_(0, 50),
+    size_dist_(0, 10)
+  {
+    // Nothing to do
+  }
+
+  /// \brief Generate a random unsigned 32-bit integer
+  uint32_t generate_random_uint()
+  {
+    return uint_dist_(rng_);
+  }
+
+  /// \brief Generate a random boolean value
+  bool generate_random_bool()
+  {
+    return bool_dist_(rng_);
+  }
+
+  /// \brief Generate a random index for enum selection
+  uint8_t generate_random_index(size_t size)
+  {
+    std::uniform_int_distribution<uint8_t> index_dist(0, size - 1);
+    return index_dist(rng_);
+  }
+
+  /// \brief Generate a random alphanumerical string with length upto 50
+  std::string generate_random_string()
+  {
+    int length = string_length_dist_(rng_);
+    std::string s;
+    s.reserve(length);
+
+    const std::string charset =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    std::uniform_int_distribution<size_t> char_index_dist(
+      0, charset.length() - 1);
+
+    for (int i = 0; i < length; i++)
+    {
+      s += charset[char_index_dist(rng_)];
+    }
+    return s;
+  }
+
+  /// \brief Generate current timestamp
+  std::chrono::time_point<std::chrono::system_clock> generate_timestamp()
+  {
+    return std::chrono::system_clock::now();
+  }
+
+  /// \brief Generate a random connectionState value
+  ConnectionState generate_random_connection_state()
+  {
+    std::vector<ConnectionState> states = {
+      ConnectionState::ONLINE, ConnectionState::OFFLINE,
+      ConnectionState::CONNECTIONBROKEN};
+    auto state_idx = generate_random_index(states.size());
+    return states[state_idx];
+  }
+
+  /// \brief Generate a random operatingMode value
+  OperatingMode generate_random_operating_mode()
+  {
+    std::vector<OperatingMode> mode = {
+      OperatingMode::AUTOMATIC, OperatingMode::SEMIAUTOMATIC,
+      OperatingMode::MANUAL, OperatingMode::SERVICE, OperatingMode::TEACHIN};
+    auto mode_idx = generate_random_index(mode.size());
+    return mode[mode_idx];
+  }
+
+  /// \brief Generate a fully populated message of a supported type
+  template <typename T>
+  T generate()
+  {
+    T msg;
+    if constexpr (std::is_same_v<T, Connection>)
+    {
+      msg.header = generate<Header>();
+      msg.connection_state = generate_random_connection_state();
+    }
+    else if constexpr (std::is_same_v<T, Header>)
+    {
+      msg.header_id = generate_random_uint();
+      msg.timestamp = generate_timestamp();
+      msg.version = "2.0.0";  // Fix the VDA 5050 version to 2.0.0
+      msg.manufacturer = generate_random_string();
+      msg.serial_number = generate_random_string();
+    }
+    else if constexpr (std::is_same_v<T, State>)
+    {
+      msg.header = generate<Header>();
+      msg.order_id = generate_random_string();
+      msg.order_update_id = generate_random_uint();
+      // msg.zone_set_id.push_back(generate_random_string());
+      msg.last_node_id = generate_random_string();
+      msg.last_node_sequence_id = generate_random_uint();
+      msg.driving = generate_random_bool();
+      // msg.paused.push_back(generate_random_bool());
+      // msg.new_base_request.push_back(generate_random_bool());
+      // msg.distance_since_last_node.push_back(generate_random_float());
+      msg.operating_mode = generate_random_operating_mode();
+      // msg.node_states =
+      //   generate_random_vector<NodeState>(generate_random_size());
+      // msg.edge_states =
+      //   generate_random_vector<EdgeState>(generate_random_size());
+      // msg.agv_position.push_back(generate<AGVPosition>());
+      // msg.velocity.push_back(generate<Velocity>());
+      // msg.loads = generate_random_vector<Load>(generate_random_size());
+      // msg.action_states =
+      //   generate_random_vector<ActionState>(generate_random_size());
+      // msg.battery_state = generate<BatteryState>();
+      // msg.errors = generate_random_vector<Error>(generate_random_size());
+      // msg.information = generate_random_vector<Info>(generate_random_size());
+      // msg.safety_state = generate<SafetyState>();
+    }
+    else
+    {
+      throw std::runtime_error(
+        "No random data generator defined for this custom type: " +
+        std::string(typeid(T).name()));
+    }
+    return msg;
+  }
+
+private:
+  /// \brief Mersenne Twister random number engine
+  std::mt19937 rng_;
+
+  /// \brief Distribution for unsigned 32-bit integers
+  std::uniform_int_distribution<uint32_t> uint_dist_;
+
+  /// \brief Distribution for a boolean value
+  std::uniform_int_distribution<int> bool_dist_;
+
+  /// \brief Distribution for random string lengths
+  std::uniform_int_distribution<int> string_length_dist_;
+
+  /// \brief Distribution for random vector size
+  std::uniform_int_distribution<uint8_t> size_dist_;
+};
+
+#endif  // VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_HPP_

--- a/vda5050_json_utils/test/generator/generator.hpp
+++ b/vda5050_json_utils/test/generator/generator.hpp
@@ -25,15 +25,19 @@
 #include <string>
 #include <vector>
 
+#include <vda5050_types/action.hpp>
+#include <vda5050_types/action_parameter.hpp>
 #include <vda5050_types/action_state.hpp>
 #include <vda5050_types/action_status.hpp>
 #include <vda5050_types/agv_position.hpp>
 #include <vda5050_types/battery_state.hpp>
+#include <vda5050_types/blocking_type.hpp>
 #include <vda5050_types/bounding_box_reference.hpp>
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/connection_state.hpp>
 #include <vda5050_types/control_point.hpp>
 #include <vda5050_types/e_stop.hpp>
+#include <vda5050_types/edge.hpp>
 #include <vda5050_types/edge_state.hpp>
 #include <vda5050_types/error.hpp>
 #include <vda5050_types/error_level.hpp>
@@ -44,22 +48,29 @@
 #include <vda5050_types/info_reference.hpp>
 #include <vda5050_types/load.hpp>
 #include <vda5050_types/load_dimensions.hpp>
+#include <vda5050_types/node.hpp>
 #include <vda5050_types/node_position.hpp>
 #include <vda5050_types/node_state.hpp>
 #include <vda5050_types/operating_mode.hpp>
+#include <vda5050_types/order.hpp>
+#include <vda5050_types/orientation_type.hpp>
 #include <vda5050_types/safety_state.hpp>
 #include <vda5050_types/state.hpp>
 #include <vda5050_types/trajectory.hpp>
 #include <vda5050_types/velocity.hpp>
 
+using vda5050_types::Action;
+using vda5050_types::ActionParameter;
 using vda5050_types::ActionState;
 using vda5050_types::ActionStatus;
 using vda5050_types::AGVPosition;
 using vda5050_types::BatteryState;
+using vda5050_types::BlockingType;
 using vda5050_types::BoundingBoxReference;
 using vda5050_types::Connection;
 using vda5050_types::ConnectionState;
 using vda5050_types::ControlPoint;
+using vda5050_types::Edge;
 using vda5050_types::EdgeState;
 using vda5050_types::Error;
 using vda5050_types::ErrorLevel;
@@ -71,9 +82,12 @@ using vda5050_types::InfoLevel;
 using vda5050_types::InfoReference;
 using vda5050_types::Load;
 using vda5050_types::LoadDimensions;
+using vda5050_types::Node;
 using vda5050_types::NodePosition;
 using vda5050_types::NodeState;
 using vda5050_types::OperatingMode;
+using vda5050_types::Order;
+using vda5050_types::OrientationType;
 using vda5050_types::SafetyState;
 using vda5050_types::State;
 using vda5050_types::Trajectory;
@@ -237,6 +251,24 @@ public:
     return levels[level_idx];
   }
 
+  /// \brief Generate a random orientation type value
+  OrientationType generate_random_orientation_type()
+  {
+    std::vector<OrientationType> types = {
+      OrientationType::TANGENTIAL, OrientationType::GLOBAL};
+    auto type_idx = generate_random_index(types.size());
+    return types[type_idx];
+  }
+
+  /// \brief Generte a random blocking type value
+  BlockingType generate_random_blocking_type()
+  {
+    std::vector<BlockingType> types = {
+      BlockingType::NONE, BlockingType::SOFT, BlockingType::HARD};
+    auto type_idx = generate_random_index(types.size());
+    return types[type_idx];
+  }
+
   /// \brief Generate a random vector of type float64
   std::vector<double> generate_random_float_vector(const uint8_t size)
   {
@@ -265,7 +297,21 @@ public:
   T generate()
   {
     T msg;
-    if constexpr (std::is_same_v<T, ActionState>)
+    if constexpr (std::is_same_v<T, Action>)
+    {
+      msg.action_type = generate_random_string();
+      msg.action_id = generate_random_string();
+      msg.blocking_type = generate_random_blocking_type();
+      msg.action_description = generate_random_string();
+      msg.action_parameters =
+        generate_random_vector<ActionParameter>(generate_random_size());
+    }
+    else if constexpr (std::is_same_v<T, ActionParameter>)
+    {
+      msg.key = generate_random_string();
+      msg.value = generate_random_string();
+    }
+    else if constexpr (std::is_same_v<T, ActionState>)
     {
       msg.action_id = generate_random_string();
       msg.action_type = generate_random_string();
@@ -310,6 +356,26 @@ public:
       msg.y = generate_random_float();
       msg.weight = 1.0;
     }
+    else if constexpr (std::is_same_v<T, Edge>)
+    {
+      msg.edge_id = generate_random_string();
+      msg.sequence_id = generate_random_uint();
+      msg.start_node_id = generate_random_string();
+      msg.end_node_id = generate_random_string();
+      msg.released = generate_random_bool();
+      msg.actions = generate_random_vector<Action>(generate_random_size());
+      msg.edge_description = generate_random_string();
+      msg.max_speed = generate_random_float();
+      msg.max_height = generate_random_float();
+      msg.min_height = generate_random_float();
+      msg.orientation = generate_random_float();
+      msg.orientation_type = generate_random_orientation_type();
+      msg.direction = generate_random_string();
+      msg.rotation_allowed = generate_random_bool();
+      msg.max_rotation_speed = generate_random_float();
+      msg.trajectory = generate<Trajectory>();
+      msg.length = generate_random_float();
+    }
     else if constexpr (std::is_same_v<T, EdgeState>)
     {
       msg.edge_id = generate_random_string();
@@ -321,7 +387,8 @@ public:
     else if constexpr (std::is_same_v<T, Error>)
     {
       msg.error_type = generate_random_string();
-      msg.error_references = generate_random_vector<ErrorReference>(10);
+      msg.error_references =
+        generate_random_vector<ErrorReference>(generate_random_size());
       msg.error_description = generate_random_string();
       msg.error_level = generate_random_error_level();
     }
@@ -365,6 +432,15 @@ public:
       msg.width = generate_random_float();
       msg.height = generate_random_float();
     }
+    else if constexpr (std::is_same_v<T, Node>)
+    {
+      msg.node_id = generate_random_string();
+      msg.sequence_id = generate_random_uint();
+      msg.released = generate_random_bool();
+      msg.actions = generate_random_vector<Action>(generate_random_size());
+      msg.node_position = generate<NodePosition>();
+      msg.node_description = generate_random_string();
+    }
     else if constexpr (std::is_same_v<T, NodePosition>)
     {
       msg.x = generate_random_float();
@@ -382,6 +458,15 @@ public:
       msg.node_description = generate_random_string();
       msg.node_position = generate<NodePosition>();
       msg.released = generate_random_bool();
+    }
+    else if constexpr (std::is_same_v<T, Order>)
+    {
+      msg.header = generate<Header>();
+      msg.order_id = generate_random_string();
+      msg.order_update_id = generate_random_uint();
+      msg.nodes = generate_random_vector<Node>(generate_random_size());
+      msg.edges = generate_random_vector<Edge>(generate_random_size());
+      msg.zone_set_id = generate_random_string();
     }
     else if constexpr (std::is_same_v<T, SafetyState>)
     {

--- a/vda5050_json_utils/test/generator/generator.hpp
+++ b/vda5050_json_utils/test/generator/generator.hpp
@@ -25,21 +25,43 @@
 #include <string>
 #include <vector>
 
+#include <vda5050_types/action_state.hpp>
+#include <vda5050_types/action_status.hpp>
+#include <vda5050_types/battery_state.hpp>
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/connection_state.hpp>
+#include <vda5050_types/control_point.hpp>
+#include <vda5050_types/e_stop.hpp>
+#include <vda5050_types/edge_state.hpp>
+#include <vda5050_types/error.hpp>
+#include <vda5050_types/error_level.hpp>
+#include <vda5050_types/error_reference.hpp>
 #include <vda5050_types/header.hpp>
 #include <vda5050_types/node_position.hpp>
 #include <vda5050_types/node_state.hpp>
 #include <vda5050_types/operating_mode.hpp>
+#include <vda5050_types/safety_state.hpp>
 #include <vda5050_types/state.hpp>
+#include <vda5050_types/trajectory.hpp>
 
+using vda5050_types::ActionState;
+using vda5050_types::ActionStatus;
+using vda5050_types::BatteryState;
 using vda5050_types::Connection;
 using vda5050_types::ConnectionState;
+using vda5050_types::ControlPoint;
+using vda5050_types::EdgeState;
+using vda5050_types::Error;
+using vda5050_types::ErrorLevel;
+using vda5050_types::ErrorReference;
+using vda5050_types::EStop;
 using vda5050_types::Header;
 using vda5050_types::NodePosition;
 using vda5050_types::NodeState;
 using vda5050_types::OperatingMode;
+using vda5050_types::SafetyState;
 using vda5050_types::State;
+using vda5050_types::Trajectory;
 
 /// \brief Utility class to generate random instances of VDA 5050 message types
 class RandomDataGenerator
@@ -49,11 +71,13 @@ public:
   RandomDataGenerator()
   : rng_(std::random_device()()),
     uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    int_dist_(0, 100),
     float_dist_(
       std::numeric_limits<double>::min(), std::numeric_limits<double>::max()),
     bool_dist_(0, 1),
     string_length_dist_(0, 50),
-    size_dist_(0, 10)
+    size_dist_(0, 10),
+    percentage_dist_(0, 100)
   {
     // Nothing to do
   }
@@ -62,11 +86,13 @@ public:
   explicit RandomDataGenerator(uint32_t seed)
   : rng_(seed),
     uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    int_dist_(0, 100),
     float_dist_(
       std::numeric_limits<double>::min(), std::numeric_limits<double>::max()),
     bool_dist_(0, 1),
     string_length_dist_(0, 50),
-    size_dist_(0, 10)
+    size_dist_(0, 10),
+    percentage_dist_(0, 100)
   {
     // Nothing to do
   }
@@ -75,6 +101,12 @@ public:
   uint32_t generate_random_uint()
   {
     return uint_dist_(rng_);
+  }
+
+  /// \brief Generate a random signed 8-bit integer
+  int8_t generate_random_int()
+  {
+    return int_dist_(rng_);
   }
 
   /// \brief Generate a random boolean value
@@ -128,6 +160,12 @@ public:
     return std::chrono::system_clock::now();
   }
 
+  /// \brief Generate a random percentage value
+  double generate_random_percentage()
+  {
+    return percentage_dist_(rng_);
+  }
+
   /// \brief Generate a random connectionState value
   ConnectionState generate_random_connection_state()
   {
@@ -148,6 +186,44 @@ public:
     return mode[mode_idx];
   }
 
+  /// \brief Generate a random actionStatus value
+  ActionStatus generate_action_status()
+  {
+    std::vector<ActionStatus> statuses = {
+      ActionStatus::WAITING, ActionStatus::INITIALIZING, ActionStatus::RUNNING,
+      ActionStatus::PAUSED, ActionStatus::FINISHED};
+    auto status_idx = generate_random_index(statuses.size());
+    return statuses[status_idx];
+  }
+
+  /// \brief Generate a random errorLevel value
+  ErrorLevel generate_random_error_level()
+  {
+    std::vector<ErrorLevel> levels = {ErrorLevel::WARNING, ErrorLevel::FATAL};
+    auto level_idx = generate_random_index(levels.size());
+    return levels[level_idx];
+  }
+
+  /// \brief Generate a random eStop value
+  vda5050_types::EStop generate_random_e_stop()
+  {
+    std::vector<vda5050_types::EStop> types = {
+      EStop::AUTOACK, EStop::MANUAL, EStop::REMOTE, EStop::NONE};
+    auto type_idx = generate_random_index(types.size());
+    return types[type_idx];
+  }
+
+  /// \brief Generate a random vector of type float64
+  std::vector<double> generate_random_float_vector(const uint8_t size)
+  {
+    std::vector<double> vec(size);
+    for (auto it = vec.begin(); it != vec.end(); ++it)
+    {
+      *it = generate_random_float();
+    }
+    return vec;
+  }
+
   /// \brief Generate a random vector of type T
   template <typename T>
   std::vector<T> generate_random_vector(const uint8_t size)
@@ -165,10 +241,52 @@ public:
   T generate()
   {
     T msg;
-    if constexpr (std::is_same_v<T, Connection>)
+    if constexpr (std::is_same_v<T, ActionState>)
+    {
+      msg.action_id = generate_random_string();
+      msg.action_type = generate_random_string();
+      msg.action_description = generate_random_string();
+      msg.action_status = generate_action_status();
+      msg.result_description = generate_random_string();
+    }
+    else if constexpr (std::is_same_v<T, BatteryState>)
+    {
+      msg.battery_charge = generate_random_percentage();
+      msg.battery_voltage = generate_random_float();
+      msg.battery_health = generate_random_int();
+      msg.charging = generate_random_bool();
+      msg.reach = generate_random_uint();
+    }
+    else if constexpr (std::is_same_v<T, Connection>)
     {
       msg.header = generate<Header>();
       msg.connection_state = generate_random_connection_state();
+    }
+    else if constexpr (std::is_same_v<T, ControlPoint>)
+    {
+      msg.x = generate_random_float();
+      msg.y = generate_random_float();
+      msg.weight = 1.0;
+    }
+    else if constexpr (std::is_same_v<T, EdgeState>)
+    {
+      msg.edge_id = generate_random_string();
+      msg.sequence_id = generate_random_uint();
+      msg.edge_description = generate_random_string();
+      msg.released = generate_random_bool();
+      msg.trajectory = generate<Trajectory>();
+    }
+    else if constexpr (std::is_same_v<T, Error>)
+    {
+      msg.error_type = generate_random_string();
+      msg.error_references = generate_random_vector<ErrorReference>(10);
+      msg.error_description = generate_random_string();
+      msg.error_level = generate_random_error_level();
+    }
+    else if constexpr (std::is_same_v<T, ErrorReference>)
+    {
+      msg.reference_key = generate_random_string();
+      msg.reference_value = generate_random_string();
     }
     else if constexpr (std::is_same_v<T, Header>)
     {
@@ -196,6 +314,11 @@ public:
       msg.node_position = generate<NodePosition>();
       msg.released = generate_random_bool();
     }
+    else if constexpr (std::is_same_v<T, SafetyState>)
+    {
+      msg.e_stop = generate_random_e_stop();
+      msg.field_violation = generate_random_bool();
+    }
     else if constexpr (std::is_same_v<T, State>)
     {
       msg.header = generate<Header>();
@@ -211,17 +334,24 @@ public:
       msg.operating_mode = generate_random_operating_mode();
       msg.node_states =
         generate_random_vector<NodeState>(generate_random_size());
-      // msg.edge_states =
-      //   generate_random_vector<EdgeState>(generate_random_size());
+      msg.edge_states =
+        generate_random_vector<EdgeState>(generate_random_size());
       // msg.agv_position.push_back(generate<AGVPosition>());
       // msg.velocity.push_back(generate<Velocity>());
       // msg.loads = generate_random_vector<Load>(generate_random_size());
-      // msg.action_states =
-      //   generate_random_vector<ActionState>(generate_random_size());
-      // msg.battery_state = generate<BatteryState>();
-      // msg.errors = generate_random_vector<Error>(generate_random_size());
+      msg.action_states =
+        generate_random_vector<ActionState>(generate_random_size());
+      msg.battery_state = generate<BatteryState>();
+      msg.errors = generate_random_vector<Error>(generate_random_size());
       // msg.information = generate_random_vector<Info>(generate_random_size());
-      // msg.safety_state = generate<SafetyState>();
+      msg.safety_state = generate<SafetyState>();
+    }
+    else if constexpr (std::is_same_v<T, Trajectory>)
+    {
+      msg.knot_vector = generate_random_float_vector(generate_random_size());
+      msg.control_points =
+        generate_random_vector<ControlPoint>(generate_random_size());
+      msg.degree = 1.0;
     }
     else
     {
@@ -239,6 +369,9 @@ private:
   /// \brief Distribution for unsigned 32-bit integers
   std::uniform_int_distribution<uint32_t> uint_dist_;
 
+  /// \brief Distribution for signed 8-bit integers
+  std::uniform_int_distribution<int8_t> int_dist_;
+
   /// \brief Distribution for 64-bit floating-point numbers
   std::uniform_real_distribution<double> float_dist_;
 
@@ -250,6 +383,9 @@ private:
 
   /// \brief Distribution for random vector size
   std::uniform_int_distribution<uint8_t> size_dist_;
+
+  /// \brief Distribution for random percentage values
+  std::uniform_real_distribution<double> percentage_dist_;
 };
 
 #endif  // VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_HPP_

--- a/vda5050_json_utils/test/generator/generator_ros2.hpp
+++ b/vda5050_json_utils/test/generator/generator_ros2.hpp
@@ -24,12 +24,15 @@
 #include <string>
 #include <vector>
 
+#include <vda5050_msgs/msg/action.hpp>
+#include <vda5050_msgs/msg/action_parameter.hpp>
 #include <vda5050_msgs/msg/action_state.hpp>
 #include <vda5050_msgs/msg/agv_position.hpp>
 #include <vda5050_msgs/msg/battery_state.hpp>
 #include <vda5050_msgs/msg/bounding_box_reference.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/control_point.hpp>
+#include <vda5050_msgs/msg/edge.hpp>
 #include <vda5050_msgs/msg/edge_state.hpp>
 #include <vda5050_msgs/msg/error.hpp>
 #include <vda5050_msgs/msg/error_reference.hpp>
@@ -38,19 +41,24 @@
 #include <vda5050_msgs/msg/info_reference.hpp>
 #include <vda5050_msgs/msg/load.hpp>
 #include <vda5050_msgs/msg/load_dimensions.hpp>
+#include <vda5050_msgs/msg/node.hpp>
 #include <vda5050_msgs/msg/node_position.hpp>
 #include <vda5050_msgs/msg/node_state.hpp>
+#include <vda5050_msgs/msg/order.hpp>
 #include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #include <vda5050_msgs/msg/trajectory.hpp>
 #include <vda5050_msgs/msg/velocity.hpp>
 
+using vda5050_msgs::msg::Action;
+using vda5050_msgs::msg::ActionParameter;
 using vda5050_msgs::msg::ActionState;
 using vda5050_msgs::msg::AGVPosition;
 using vda5050_msgs::msg::BatteryState;
 using vda5050_msgs::msg::BoundingBoxReference;
 using vda5050_msgs::msg::Connection;
 using vda5050_msgs::msg::ControlPoint;
+using vda5050_msgs::msg::Edge;
 using vda5050_msgs::msg::EdgeState;
 using vda5050_msgs::msg::Error;
 using vda5050_msgs::msg::ErrorReference;
@@ -59,8 +67,10 @@ using vda5050_msgs::msg::Info;
 using vda5050_msgs::msg::InfoReference;
 using vda5050_msgs::msg::Load;
 using vda5050_msgs::msg::LoadDimensions;
+using vda5050_msgs::msg::Node;
 using vda5050_msgs::msg::NodePosition;
 using vda5050_msgs::msg::NodeState;
+using vda5050_msgs::msg::Order;
 using vda5050_msgs::msg::SafetyState;
 using vda5050_msgs::msg::State;
 using vda5050_msgs::msg::Trajectory;
@@ -231,6 +241,25 @@ public:
     return levels[level_idx];
   }
 
+  /// \brief Generate a random orientation type value
+  std::string generate_random_orientation_type()
+  {
+    std::vector<std::string> types = {
+      Edge::ORIENTATION_TYPE_TANGENTIAL, Edge::ORIENTATION_TYPE_GLOBAL};
+    auto type_idx = generate_random_index(types.size());
+    return types[type_idx];
+  }
+
+  /// \brief Generte a random blocking type value
+  std::string generate_random_blocking_type()
+  {
+    std::vector<std::string> types = {
+      Action::BLOCKING_TYPE_NONE, Action::BLOCKING_TYPE_SOFT,
+      Action::BLOCKING_TYPE_HARD};
+    auto type_idx = generate_random_index(types.size());
+    return types[type_idx];
+  }
+
   /// \brief Generate a random vector of type float64
   std::vector<double> generate_random_float_vector(const uint8_t size)
   {
@@ -259,7 +288,26 @@ public:
   T generate()
   {
     T msg;
-    if constexpr (std::is_same_v<T, ActionState>)
+    if constexpr (std::is_same_v<T, Action>)
+    {
+      msg.action_type = generate_random_string();
+      msg.action_id = generate_random_string();
+      msg.blocking_type = generate_random_blocking_type();
+      msg.action_description.push_back(generate_random_string());
+
+      auto action_param_vec =
+        generate_random_vector<ActionParameter>(generate_random_size());
+      for (auto param : action_param_vec)
+      {
+        msg.action_parameters.push_back(param);
+      }
+    }
+    else if constexpr (std::is_same_v<T, ActionParameter>)
+    {
+      msg.key = generate_random_string();
+      msg.value = generate_random_string();
+    }
+    else if constexpr (std::is_same_v<T, ActionState>)
     {
       msg.action_id = generate_random_string();
       msg.action_type.push_back(generate_random_string());
@@ -304,6 +352,26 @@ public:
       msg.y = generate_random_float();
       msg.weight = 1.0;
     }
+    else if constexpr (std::is_same_v<T, Edge>)
+    {
+      msg.edge_id = generate_random_string();
+      msg.sequence_id = generate_random_uint();
+      msg.start_node_id = generate_random_string();
+      msg.end_node_id = generate_random_string();
+      msg.released = generate_random_bool();
+      msg.actions = generate_random_vector<Action>(generate_random_size());
+      msg.edge_description.push_back(generate_random_string());
+      msg.max_speed.push_back(generate_random_float());
+      msg.max_height.push_back(generate_random_float());
+      msg.min_height.push_back(generate_random_float());
+      msg.orientation.push_back(generate_random_float());
+      msg.orientation_type[0] = generate_random_orientation_type();
+      msg.direction.push_back(generate_random_string());
+      msg.rotation_allowed.push_back(generate_random_bool());
+      msg.max_rotation_speed.push_back(generate_random_float());
+      msg.trajectory.push_back(generate<Trajectory>());
+      msg.length.push_back(generate_random_float());
+    }
     else if constexpr (std::is_same_v<T, EdgeState>)
     {
       msg.edge_id = generate_random_string();
@@ -315,7 +383,8 @@ public:
     else if constexpr (std::is_same_v<T, Error>)
     {
       msg.error_type = generate_random_string();
-      auto error_ref_vec = generate_random_vector<ErrorReference>(10);
+      auto error_ref_vec =
+        generate_random_vector<ErrorReference>(generate_random_size());
       for (auto ref : error_ref_vec)
       {
         msg.error_references.push_back(ref);
@@ -339,7 +408,8 @@ public:
     else if constexpr (std::is_same_v<T, Info>)
     {
       msg.info_type = generate_random_string();
-      auto info_ref_vec = generate_random_vector<InfoReference>(10);
+      auto info_ref_vec =
+        generate_random_vector<InfoReference>(generate_random_size());
       for (auto ref : info_ref_vec)
       {
         msg.info_references.push_back(ref);
@@ -367,6 +437,15 @@ public:
       msg.width = generate_random_float();
       msg.height.push_back(generate_random_float());
     }
+    else if constexpr (std::is_same_v<T, Node>)
+    {
+      msg.node_id = generate_random_string();
+      msg.sequence_id = generate_random_uint();
+      msg.released = generate_random_bool();
+      msg.actions = generate_random_vector<Action>(generate_random_size());
+      msg.node_position.push_back(generate<NodePosition>());
+      msg.node_description.push_back(generate_random_string());
+    }
     else if constexpr (std::is_same_v<T, NodePosition>)
     {
       msg.x = generate_random_float();
@@ -384,6 +463,15 @@ public:
       msg.node_description.push_back(generate_random_string());
       msg.node_position.push_back(generate<NodePosition>());
       msg.released = generate_random_bool();
+    }
+    else if constexpr (std::is_same_v<T, Order>)
+    {
+      msg.header = generate<Header>();
+      msg.order_id = generate_random_string();
+      msg.order_update_id = generate_random_uint();
+      msg.nodes = generate_random_vector<Node>(generate_random_size());
+      msg.edges = generate_random_vector<Edge>(generate_random_size());
+      msg.zone_set_id.push_back(generate_random_string());
     }
     else if constexpr (std::is_same_v<T, SafetyState>)
     {
@@ -409,7 +497,7 @@ public:
         generate_random_vector<EdgeState>(generate_random_size());
       msg.agv_position.push_back(generate<AGVPosition>());
       msg.velocity.push_back(generate<Velocity>());
-      auto loads_vec = generate_random_vector<Load>(10);
+      auto loads_vec = generate_random_vector<Load>(generate_random_size());
       for (auto load : loads_vec)
       {
         msg.loads.push_back(load);
@@ -418,7 +506,7 @@ public:
         generate_random_vector<ActionState>(generate_random_size());
       msg.battery_state = generate<BatteryState>();
       msg.errors = generate_random_vector<Error>(generate_random_size());
-      auto info_vec = generate_random_vector<Info>(10);
+      auto info_vec = generate_random_vector<Info>(generate_random_size());
       for (auto info : info_vec)
       {
         msg.information.push_back(info);

--- a/vda5050_json_utils/test/generator/generator_ros2.hpp
+++ b/vda5050_json_utils/test/generator/generator_ros2.hpp
@@ -25,32 +25,46 @@
 #include <vector>
 
 #include <vda5050_msgs/msg/action_state.hpp>
+#include <vda5050_msgs/msg/agv_position.hpp>
 #include <vda5050_msgs/msg/battery_state.hpp>
+#include <vda5050_msgs/msg/bounding_box_reference.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/control_point.hpp>
 #include <vda5050_msgs/msg/edge_state.hpp>
 #include <vda5050_msgs/msg/error.hpp>
 #include <vda5050_msgs/msg/error_reference.hpp>
 #include <vda5050_msgs/msg/header.hpp>
+#include <vda5050_msgs/msg/info.hpp>
+#include <vda5050_msgs/msg/info_reference.hpp>
+#include <vda5050_msgs/msg/load.hpp>
+#include <vda5050_msgs/msg/load_dimensions.hpp>
 #include <vda5050_msgs/msg/node_position.hpp>
 #include <vda5050_msgs/msg/node_state.hpp>
 #include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #include <vda5050_msgs/msg/trajectory.hpp>
+#include <vda5050_msgs/msg/velocity.hpp>
 
 using vda5050_msgs::msg::ActionState;
+using vda5050_msgs::msg::AGVPosition;
 using vda5050_msgs::msg::BatteryState;
+using vda5050_msgs::msg::BoundingBoxReference;
 using vda5050_msgs::msg::Connection;
 using vda5050_msgs::msg::ControlPoint;
 using vda5050_msgs::msg::EdgeState;
 using vda5050_msgs::msg::Error;
 using vda5050_msgs::msg::ErrorReference;
 using vda5050_msgs::msg::Header;
+using vda5050_msgs::msg::Info;
+using vda5050_msgs::msg::InfoReference;
+using vda5050_msgs::msg::Load;
+using vda5050_msgs::msg::LoadDimensions;
 using vda5050_msgs::msg::NodePosition;
 using vda5050_msgs::msg::NodeState;
 using vda5050_msgs::msg::SafetyState;
 using vda5050_msgs::msg::State;
 using vda5050_msgs::msg::Trajectory;
+using vda5050_msgs::msg::Velocity;
 
 /// \brief Utility class to generate random instances of VDA 5050 message types
 class RandomDataGeneratorROS2
@@ -169,43 +183,52 @@ public:
   /// \brief Generate a random operatingMode value
   std::string generate_random_operating_mode()
   {
-    std::vector<std::string> states = {
+    std::vector<std::string> modes = {
       State::OPERATING_MODE_AUTOMATIC, State::OPERATING_MODE_SEMIAUTOMATIC,
       State::OPERATING_MODE_MANUAL, State::OPERATING_MODE_SERVICE,
       State::OPERATING_MODE_TEACHIN};
-    auto state_idx = generate_random_index(states.size());
-    return states[state_idx];
+    auto mode_idx = generate_random_index(modes.size());
+    return modes[mode_idx];
   }
 
   /// \brief Generate a random actionStatus value
   std::string generate_action_status()
   {
-    std::vector<std::string> states = {
+    std::vector<std::string> statuses = {
       ActionState::ACTION_STATUS_WAITING,
       ActionState::ACTION_STATUS_INITIALIZING,
       ActionState::ACTION_STATUS_RUNNING, ActionState::ACTION_STATUS_PAUSED,
       ActionState::ACTION_STATUS_FINISHED};
-    auto state_idx = generate_random_index(states.size());
-    return states[state_idx];
+    auto status_idx = generate_random_index(statuses.size());
+    return statuses[status_idx];
   }
 
   /// \brief Generate a random errorLevel value
   std::string generate_random_error_level()
   {
-    std::vector<std::string> states = {
+    std::vector<std::string> levels = {
       Error::ERROR_LEVEL_WARNING, Error::ERROR_LEVEL_FATAL};
-    auto state_idx = generate_random_index(states.size());
-    return states[state_idx];
+    auto level_idx = generate_random_index(levels.size());
+    return levels[level_idx];
   }
 
   /// \brief Generate a random eStop value
   std::string generate_random_e_stop()
   {
-    std::vector<std::string> states = {
+    std::vector<std::string> types = {
       SafetyState::E_STOP_AUTOACK, SafetyState::E_STOP_MANUAL,
       SafetyState::E_STOP_REMOTE, SafetyState::E_STOP_NONE};
-    auto state_idx = generate_random_index(states.size());
-    return states[state_idx];
+    auto type_idx = generate_random_index(types.size());
+    return types[type_idx];
+  }
+
+  /// \brief Generate a random infoLevel value
+  std::string generate_random_info_level()
+  {
+    std::vector<std::string> levels = {
+      Info::INFO_LEVEL_INFO, Info::INFO_LEVEL_DEBUG};
+    auto level_idx = generate_random_index(levels.size());
+    return levels[level_idx];
   }
 
   /// \brief Generate a random vector of type float64
@@ -244,6 +267,17 @@ public:
       msg.action_status = generate_action_status();
       msg.result_description.push_back(generate_random_string());
     }
+    else if constexpr (std::is_same_v<T, AGVPosition>)
+    {
+      msg.x = generate_random_float();
+      msg.y = generate_random_float();
+      msg.theta = generate_random_float();
+      msg.map_id = generate_random_string();
+      msg.map_description.push_back(generate_random_string());
+      msg.position_initialized = generate_random_bool();
+      msg.localization_score.push_back(generate_random_float());
+      msg.deviation_range.push_back(generate_random_float());
+    }
     else if constexpr (std::is_same_v<T, BatteryState>)
     {
       msg.battery_charge = generate_random_percentage();
@@ -251,6 +285,13 @@ public:
       msg.battery_health.push_back(generate_random_int());
       msg.charging = generate_random_bool();
       msg.reach.push_back(generate_random_uint());
+    }
+    else if constexpr (std::is_same_v<T, BoundingBoxReference>)
+    {
+      msg.x = generate_random_float();
+      msg.y = generate_random_float();
+      msg.z = generate_random_float();
+      msg.theta.push_back(generate_random_float());
     }
     else if constexpr (std::is_same_v<T, Connection>)
     {
@@ -295,6 +336,37 @@ public:
       msg.manufacturer = generate_random_string();
       msg.serial_number = generate_random_string();
     }
+    else if constexpr (std::is_same_v<T, Info>)
+    {
+      msg.info_type = generate_random_string();
+      auto info_ref_vec = generate_random_vector<InfoReference>(10);
+      for (auto ref : info_ref_vec)
+      {
+        msg.info_references.push_back(ref);
+      }
+      msg.info_description.push_back(generate_random_string());
+      msg.info_level = generate_random_info_level();
+    }
+    else if constexpr (std::is_same_v<T, InfoReference>)
+    {
+      msg.reference_key = generate_random_string();
+      msg.reference_value = generate_random_string();
+    }
+    else if constexpr (std::is_same_v<T, Load>)
+    {
+      msg.load_id.push_back(generate_random_string());
+      msg.load_type.push_back(generate_random_string());
+      msg.load_position.push_back(generate_random_string());
+      msg.bounding_box_reference.push_back(generate<BoundingBoxReference>());
+      msg.load_dimensions.push_back(generate<LoadDimensions>());
+      msg.weight.push_back(generate_random_float());
+    }
+    else if constexpr (std::is_same_v<T, LoadDimensions>)
+    {
+      msg.length = generate_random_float();
+      msg.width = generate_random_float();
+      msg.height.push_back(generate_random_float());
+    }
     else if constexpr (std::is_same_v<T, NodePosition>)
     {
       msg.x = generate_random_float();
@@ -323,26 +395,34 @@ public:
       msg.header = generate<Header>();
       msg.order_id = generate_random_string();
       msg.order_update_id = generate_random_uint();
-      // msg.zone_set_id.push_back(generate_random_string());
+      msg.zone_set_id.push_back(generate_random_string());
       msg.last_node_id = generate_random_string();
       msg.last_node_sequence_id = generate_random_uint();
       msg.driving = generate_random_bool();
-      // msg.paused.push_back(generate_random_bool());
-      // msg.new_base_request.push_back(generate_random_bool());
-      // msg.distance_since_last_node.push_back(generate_random_float());
+      msg.paused.push_back(generate_random_bool());
+      msg.new_base_request.push_back(generate_random_bool());
+      msg.distance_since_last_node.push_back(generate_random_float());
       msg.operating_mode = generate_random_operating_mode();
       msg.node_states =
         generate_random_vector<NodeState>(generate_random_size());
       msg.edge_states =
         generate_random_vector<EdgeState>(generate_random_size());
-      // msg.agv_position.push_back(generate<AGVPosition>());
-      // msg.velocity.push_back(generate<Velocity>());
-      // msg.loads = generate_random_vector<Load>(generate_random_size());
+      msg.agv_position.push_back(generate<AGVPosition>());
+      msg.velocity.push_back(generate<Velocity>());
+      auto loads_vec = generate_random_vector<Load>(10);
+      for (auto load : loads_vec)
+      {
+        msg.loads.push_back(load);
+      }
       msg.action_states =
         generate_random_vector<ActionState>(generate_random_size());
       msg.battery_state = generate<BatteryState>();
       msg.errors = generate_random_vector<Error>(generate_random_size());
-      // msg.information = generate_random_vector<Info>(generate_random_size());
+      auto info_vec = generate_random_vector<Info>(10);
+      for (auto info : info_vec)
+      {
+        msg.information.push_back(info);
+      }
       msg.safety_state = generate<SafetyState>();
     }
     else if constexpr (std::is_same_v<T, Trajectory>)
@@ -351,6 +431,12 @@ public:
       msg.control_points =
         generate_random_vector<ControlPoint>(generate_random_size());
       msg.degree = 1.0;
+    }
+    else if constexpr (std::is_same_v<T, Velocity>)
+    {
+      msg.vx.push_back(generate_random_float());
+      msg.vy.push_back(generate_random_float());
+      msg.omega.push_back(generate_random_float());
     }
     else
     {

--- a/vda5050_json_utils/test/generator/generator_ros2.hpp
+++ b/vda5050_json_utils/test/generator/generator_ros2.hpp
@@ -26,10 +26,14 @@
 
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/header.hpp>
+#include <vda5050_msgs/msg/node_position.hpp>
+#include <vda5050_msgs/msg/node_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 
 using vda5050_msgs::msg::Connection;
 using vda5050_msgs::msg::Header;
+using vda5050_msgs::msg::NodePosition;
+using vda5050_msgs::msg::NodeState;
 using vda5050_msgs::msg::State;
 
 /// \brief Utility class to generate random instances of VDA 5050 message types
@@ -40,9 +44,12 @@ public:
   RandomDataGeneratorROS2()
   : rng_(std::random_device()()),
     uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    float_dist_(
+      std::numeric_limits<double>::min(), std::numeric_limits<double>::max()),
     bool_dist_(0, 1),
     string_length_dist_(0, 50),
-    milliseconds_dist_(0, 4000000000000L)
+    milliseconds_dist_(0, 4000000000000L),
+    size_dist_(0, 10)
   {
     // Nothing to do
   }
@@ -51,9 +58,12 @@ public:
   explicit RandomDataGeneratorROS2(uint32_t seed)
   : rng_(seed),
     uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    float_dist_(
+      std::numeric_limits<double>::min(), std::numeric_limits<double>::max()),
     bool_dist_(0, 1),
     string_length_dist_(0, 50),
-    milliseconds_dist_(0, 4000000000000L)
+    milliseconds_dist_(0, 4000000000000L),
+    size_dist_(0, 10)
   {
     // Nothing to do
   }
@@ -62,6 +72,12 @@ public:
   uint32_t generate_random_uint()
   {
     return uint_dist_(rng_);
+  }
+
+  /// \brief Generate a random 64-bit floating-point number
+  double generate_random_float()
+  {
+    return float_dist_(rng_);
   }
 
   /// \brief Generate a random boolean value
@@ -75,6 +91,12 @@ public:
   {
     std::uniform_int_distribution<uint8_t> index_dist(0, size - 1);
     return index_dist(rng_);
+  }
+
+  /// \brief Generate a random value for vector length
+  uint8_t generate_random_size()
+  {
+    return size_dist_(rng_);
   }
 
   /// \brief Generate a random alphanumerical string with length upto 50
@@ -123,6 +145,18 @@ public:
     return states[state_idx];
   }
 
+  /// \brief Generate a random vector of type T
+  template <typename T>
+  std::vector<T> generate_random_vector(const uint8_t size)
+  {
+    std::vector<T> vec(size);
+    for (auto it = vec.begin(); it != vec.end(); ++it)
+    {
+      *it = generate<T>();
+    }
+    return vec;
+  }
+
   /// \brief Generate a fully populated message of a supported type
   template <typename T>
   T generate()
@@ -141,6 +175,24 @@ public:
       msg.manufacturer = generate_random_string();
       msg.serial_number = generate_random_string();
     }
+    else if constexpr (std::is_same_v<T, NodePosition>)
+    {
+      msg.x = generate_random_float();
+      msg.y = generate_random_float();
+      msg.theta.push_back(generate_random_float());
+      msg.allowed_deviation_x_y.push_back(generate_random_float());
+      msg.allowed_deviation_theta.push_back(generate_random_float());
+      msg.map_id = generate_random_string();
+      msg.map_description.push_back(generate_random_string());
+    }
+    else if constexpr (std::is_same_v<T, NodeState>)
+    {
+      msg.node_id = generate_random_string();
+      msg.sequence_id = generate_random_uint();
+      msg.node_description.push_back(generate_random_string());
+      msg.node_position.push_back(generate<NodePosition>());
+      msg.released = generate_random_bool();
+    }
     else if constexpr (std::is_same_v<T, State>)
     {
       msg.header = generate<Header>();
@@ -154,8 +206,8 @@ public:
       // msg.new_base_request.push_back(generate_random_bool());
       // msg.distance_since_last_node.push_back(generate_random_float());
       msg.operating_mode = generate_random_operating_mode();
-      // msg.node_states =
-      //   generate_random_vector<NodeState>(generate_random_size());
+      msg.node_states =
+        generate_random_vector<NodeState>(generate_random_size());
       // msg.edge_states =
       //   generate_random_vector<EdgeState>(generate_random_size());
       // msg.agv_position.push_back(generate<AGVPosition>());
@@ -184,6 +236,9 @@ private:
   /// \brief Distribution for unsigned 32-bit integers
   std::uniform_int_distribution<uint32_t> uint_dist_;
 
+  /// \brief Distribution for 64-bit floating-point numbers
+  std::uniform_real_distribution<double> float_dist_;
+
   /// \brief Distribution for a boolean value
   std::uniform_int_distribution<int> bool_dist_;
 
@@ -192,6 +247,9 @@ private:
 
   /// \brief Distribution for milliseconds from epoch
   std::uniform_int_distribution<int64_t> milliseconds_dist_;
+
+  /// \brief Distribution for random vector size
+  std::uniform_int_distribution<uint8_t> size_dist_;
 };
 
 #endif  // VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_ROS2_HPP_

--- a/vda5050_json_utils/test/generator/generator_ros2.hpp
+++ b/vda5050_json_utils/test/generator/generator_ros2.hpp
@@ -24,17 +24,33 @@
 #include <string>
 #include <vector>
 
+#include <vda5050_msgs/msg/action_state.hpp>
+#include <vda5050_msgs/msg/battery_state.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
+#include <vda5050_msgs/msg/control_point.hpp>
+#include <vda5050_msgs/msg/edge_state.hpp>
+#include <vda5050_msgs/msg/error.hpp>
+#include <vda5050_msgs/msg/error_reference.hpp>
 #include <vda5050_msgs/msg/header.hpp>
 #include <vda5050_msgs/msg/node_position.hpp>
 #include <vda5050_msgs/msg/node_state.hpp>
+#include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
+#include <vda5050_msgs/msg/trajectory.hpp>
 
+using vda5050_msgs::msg::ActionState;
+using vda5050_msgs::msg::BatteryState;
 using vda5050_msgs::msg::Connection;
+using vda5050_msgs::msg::ControlPoint;
+using vda5050_msgs::msg::EdgeState;
+using vda5050_msgs::msg::Error;
+using vda5050_msgs::msg::ErrorReference;
 using vda5050_msgs::msg::Header;
 using vda5050_msgs::msg::NodePosition;
 using vda5050_msgs::msg::NodeState;
+using vda5050_msgs::msg::SafetyState;
 using vda5050_msgs::msg::State;
+using vda5050_msgs::msg::Trajectory;
 
 /// \brief Utility class to generate random instances of VDA 5050 message types
 class RandomDataGeneratorROS2
@@ -44,12 +60,14 @@ public:
   RandomDataGeneratorROS2()
   : rng_(std::random_device()()),
     uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    int_dist_(0, 100),
     float_dist_(
       std::numeric_limits<double>::min(), std::numeric_limits<double>::max()),
     bool_dist_(0, 1),
     string_length_dist_(0, 50),
     milliseconds_dist_(0, 4000000000000L),
-    size_dist_(0, 10)
+    size_dist_(0, 10),
+    percentage_dist_(0, 100)
   {
     // Nothing to do
   }
@@ -58,12 +76,14 @@ public:
   explicit RandomDataGeneratorROS2(uint32_t seed)
   : rng_(seed),
     uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    int_dist_(0, 100),
     float_dist_(
       std::numeric_limits<double>::min(), std::numeric_limits<double>::max()),
     bool_dist_(0, 1),
     string_length_dist_(0, 50),
     milliseconds_dist_(0, 4000000000000L),
-    size_dist_(0, 10)
+    size_dist_(0, 10),
+    percentage_dist_(0, 100)
   {
     // Nothing to do
   }
@@ -72,6 +92,12 @@ public:
   uint32_t generate_random_uint()
   {
     return uint_dist_(rng_);
+  }
+
+  /// \brief Generate a random signed 8-bit integer
+  int8_t generate_random_int()
+  {
+    return int_dist_(rng_);
   }
 
   /// \brief Generate a random 64-bit floating-point number
@@ -125,6 +151,12 @@ public:
     return milliseconds_dist_(rng_);
   }
 
+  /// \brief Generate a random percentage value
+  double generate_random_percentage()
+  {
+    return percentage_dist_(rng_);
+  }
+
   /// \brief Generate a random connectionState value
   std::string generate_random_connection_state()
   {
@@ -145,6 +177,48 @@ public:
     return states[state_idx];
   }
 
+  /// \brief Generate a random actionStatus value
+  std::string generate_action_status()
+  {
+    std::vector<std::string> states = {
+      ActionState::ACTION_STATUS_WAITING,
+      ActionState::ACTION_STATUS_INITIALIZING,
+      ActionState::ACTION_STATUS_RUNNING, ActionState::ACTION_STATUS_PAUSED,
+      ActionState::ACTION_STATUS_FINISHED};
+    auto state_idx = generate_random_index(states.size());
+    return states[state_idx];
+  }
+
+  /// \brief Generate a random errorLevel value
+  std::string generate_random_error_level()
+  {
+    std::vector<std::string> states = {
+      Error::ERROR_LEVEL_WARNING, Error::ERROR_LEVEL_FATAL};
+    auto state_idx = generate_random_index(states.size());
+    return states[state_idx];
+  }
+
+  /// \brief Generate a random eStop value
+  std::string generate_random_e_stop()
+  {
+    std::vector<std::string> states = {
+      SafetyState::E_STOP_AUTOACK, SafetyState::E_STOP_MANUAL,
+      SafetyState::E_STOP_REMOTE, SafetyState::E_STOP_NONE};
+    auto state_idx = generate_random_index(states.size());
+    return states[state_idx];
+  }
+
+  /// \brief Generate a random vector of type float64
+  std::vector<double> generate_random_float_vector(const uint8_t size)
+  {
+    std::vector<double> vec(size);
+    for (auto it = vec.begin(); it != vec.end(); ++it)
+    {
+      *it = generate_random_float();
+    }
+    return vec;
+  }
+
   /// \brief Generate a random vector of type T
   template <typename T>
   std::vector<T> generate_random_vector(const uint8_t size)
@@ -162,10 +236,56 @@ public:
   T generate()
   {
     T msg;
-    if constexpr (std::is_same_v<T, Connection>)
+    if constexpr (std::is_same_v<T, ActionState>)
+    {
+      msg.action_id = generate_random_string();
+      msg.action_type.push_back(generate_random_string());
+      msg.action_description.push_back(generate_random_string());
+      msg.action_status = generate_action_status();
+      msg.result_description.push_back(generate_random_string());
+    }
+    else if constexpr (std::is_same_v<T, BatteryState>)
+    {
+      msg.battery_charge = generate_random_percentage();
+      msg.battery_voltage.push_back(generate_random_float());
+      msg.battery_health.push_back(generate_random_int());
+      msg.charging = generate_random_bool();
+      msg.reach.push_back(generate_random_uint());
+    }
+    else if constexpr (std::is_same_v<T, Connection>)
     {
       msg.header = generate<Header>();
       msg.connection_state = generate_random_connection_state();
+    }
+    else if constexpr (std::is_same_v<T, ControlPoint>)
+    {
+      msg.x = generate_random_float();
+      msg.y = generate_random_float();
+      msg.weight = 1.0;
+    }
+    else if constexpr (std::is_same_v<T, EdgeState>)
+    {
+      msg.edge_id = generate_random_string();
+      msg.sequence_id = generate_random_uint();
+      msg.edge_description.push_back(generate_random_string());
+      msg.released = generate_random_bool();
+      msg.trajectory.push_back(generate<Trajectory>());
+    }
+    else if constexpr (std::is_same_v<T, Error>)
+    {
+      msg.error_type = generate_random_string();
+      auto error_ref_vec = generate_random_vector<ErrorReference>(10);
+      for (auto ref : error_ref_vec)
+      {
+        msg.error_references.push_back(ref);
+      }
+      msg.error_description.push_back(generate_random_string());
+      msg.error_level = generate_random_error_level();
+    }
+    else if constexpr (std::is_same_v<T, ErrorReference>)
+    {
+      msg.reference_key = generate_random_string();
+      msg.reference_value = generate_random_string();
     }
     else if constexpr (std::is_same_v<T, Header>)
     {
@@ -193,6 +313,11 @@ public:
       msg.node_position.push_back(generate<NodePosition>());
       msg.released = generate_random_bool();
     }
+    else if constexpr (std::is_same_v<T, SafetyState>)
+    {
+      msg.e_stop = generate_random_e_stop();
+      msg.field_violation = generate_random_bool();
+    }
     else if constexpr (std::is_same_v<T, State>)
     {
       msg.header = generate<Header>();
@@ -208,17 +333,24 @@ public:
       msg.operating_mode = generate_random_operating_mode();
       msg.node_states =
         generate_random_vector<NodeState>(generate_random_size());
-      // msg.edge_states =
-      //   generate_random_vector<EdgeState>(generate_random_size());
+      msg.edge_states =
+        generate_random_vector<EdgeState>(generate_random_size());
       // msg.agv_position.push_back(generate<AGVPosition>());
       // msg.velocity.push_back(generate<Velocity>());
       // msg.loads = generate_random_vector<Load>(generate_random_size());
-      // msg.action_states =
-      //   generate_random_vector<ActionState>(generate_random_size());
-      // msg.battery_state = generate<BatteryState>();
-      // msg.errors = generate_random_vector<Error>(generate_random_size());
+      msg.action_states =
+        generate_random_vector<ActionState>(generate_random_size());
+      msg.battery_state = generate<BatteryState>();
+      msg.errors = generate_random_vector<Error>(generate_random_size());
       // msg.information = generate_random_vector<Info>(generate_random_size());
-      // msg.safety_state = generate<SafetyState>();
+      msg.safety_state = generate<SafetyState>();
+    }
+    else if constexpr (std::is_same_v<T, Trajectory>)
+    {
+      msg.knot_vector = generate_random_float_vector(generate_random_size());
+      msg.control_points =
+        generate_random_vector<ControlPoint>(generate_random_size());
+      msg.degree = 1.0;
     }
     else
     {
@@ -236,6 +368,9 @@ private:
   /// \brief Distribution for unsigned 32-bit integers
   std::uniform_int_distribution<uint32_t> uint_dist_;
 
+  /// \brief Distribution for signed 8-bit integers
+  std::uniform_int_distribution<int8_t> int_dist_;
+
   /// \brief Distribution for 64-bit floating-point numbers
   std::uniform_real_distribution<double> float_dist_;
 
@@ -250,6 +385,9 @@ private:
 
   /// \brief Distribution for random vector size
   std::uniform_int_distribution<uint8_t> size_dist_;
+
+  /// \brief Distribution for random percentage values
+  std::uniform_real_distribution<double> percentage_dist_;
 };
 
 #endif  // VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_ROS2_HPP_

--- a/vda5050_json_utils/test/generator/generator_ros2.hpp
+++ b/vda5050_json_utils/test/generator/generator_ros2.hpp
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-#ifndef VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_ROS2_HPP_
-#define VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_ROS2_HPP_
+#ifndef GENERATOR__GENERATOR_ROS2_HPP_
+#define GENERATOR__GENERATOR_ROS2_HPP_
 
 #include <limits>
 #include <random>
@@ -564,4 +564,4 @@ private:
   std::uniform_real_distribution<double> percentage_dist_;
 };
 
-#endif  // VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_ROS2_HPP_
+#endif  // GENERATOR__GENERATOR_ROS2_HPP_

--- a/vda5050_json_utils/test/generator/generator_ros2.hpp
+++ b/vda5050_json_utils/test/generator/generator_ros2.hpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2025 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_ROS2_HPP_
+#define VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_ROS2_HPP_
+
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <vda5050_msgs/msg/connection.hpp>
+#include <vda5050_msgs/msg/header.hpp>
+#include <vda5050_msgs/msg/state.hpp>
+
+using vda5050_msgs::msg::Connection;
+using vda5050_msgs::msg::Header;
+using vda5050_msgs::msg::State;
+
+/// \brief Utility class to generate random instances of VDA 5050 message types
+class RandomDataGeneratorROS2
+{
+public:
+  /// \brief Default constructor using a non-deterministic seed
+  RandomDataGeneratorROS2()
+  : rng_(std::random_device()()),
+    uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    bool_dist_(0, 1),
+    string_length_dist_(0, 50),
+    milliseconds_dist_(0, 4000000000000L)
+  {
+    // Nothing to do
+  }
+
+  /// \brief Constructor with a fixed seed for deterministic results
+  explicit RandomDataGeneratorROS2(uint32_t seed)
+  : rng_(seed),
+    uint_dist_(0, std::numeric_limits<uint32_t>::max()),
+    bool_dist_(0, 1),
+    string_length_dist_(0, 50),
+    milliseconds_dist_(0, 4000000000000L)
+  {
+    // Nothing to do
+  }
+
+  /// \brief Generate a random unsigned 32-bit integer
+  uint32_t generate_random_uint()
+  {
+    return uint_dist_(rng_);
+  }
+
+  /// \brief Generate a random boolean value
+  bool generate_random_bool()
+  {
+    return bool_dist_(rng_);
+  }
+
+  /// \brief Generate a random index for enum selection
+  uint8_t generate_random_index(size_t size)
+  {
+    std::uniform_int_distribution<uint8_t> index_dist(0, size - 1);
+    return index_dist(rng_);
+  }
+
+  /// \brief Generate a random alphanumerical string with length upto 50
+  std::string generate_random_string()
+  {
+    int length = string_length_dist_(rng_);
+    std::string s;
+    s.reserve(length);
+
+    const std::string charset =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    std::uniform_int_distribution<size_t> char_index_dist(
+      0, charset.length() - 1);
+
+    for (int i = 0; i < length; i++)
+    {
+      s += charset[char_index_dist(rng_)];
+    }
+    return s;
+  }
+
+  /// \brief Generate a random millisecond timestamp
+  int64_t generate_milliseconds()
+  {
+    return milliseconds_dist_(rng_);
+  }
+
+  /// \brief Generate a random connectionState value
+  std::string generate_random_connection_state()
+  {
+    std::vector<std::string> states = {
+      Connection::ONLINE, Connection::OFFLINE, Connection::CONNECTIONBROKEN};
+    auto state_idx = generate_random_index(states.size());
+    return states[state_idx];
+  }
+
+  /// \brief Generate a random operatingMode value
+  std::string generate_random_operating_mode()
+  {
+    std::vector<std::string> states = {
+      State::OPERATING_MODE_AUTOMATIC, State::OPERATING_MODE_SEMIAUTOMATIC,
+      State::OPERATING_MODE_MANUAL, State::OPERATING_MODE_SERVICE,
+      State::OPERATING_MODE_TEACHIN};
+    auto state_idx = generate_random_index(states.size());
+    return states[state_idx];
+  }
+
+  /// \brief Generate a fully populated message of a supported type
+  template <typename T>
+  T generate()
+  {
+    T msg;
+    if constexpr (std::is_same_v<T, Connection>)
+    {
+      msg.header = generate<Header>();
+      msg.connection_state = generate_random_connection_state();
+    }
+    else if constexpr (std::is_same_v<T, Header>)
+    {
+      msg.header_id = generate_random_uint();
+      msg.timestamp = generate_milliseconds();
+      msg.version = "2.0.0";  // Fix the VDA 5050 version to 2.0.0
+      msg.manufacturer = generate_random_string();
+      msg.serial_number = generate_random_string();
+    }
+    else if constexpr (std::is_same_v<T, State>)
+    {
+      msg.header = generate<Header>();
+      msg.order_id = generate_random_string();
+      msg.order_update_id = generate_random_uint();
+      // msg.zone_set_id.push_back(generate_random_string());
+      msg.last_node_id = generate_random_string();
+      msg.last_node_sequence_id = generate_random_uint();
+      msg.driving = generate_random_bool();
+      // msg.paused.push_back(generate_random_bool());
+      // msg.new_base_request.push_back(generate_random_bool());
+      // msg.distance_since_last_node.push_back(generate_random_float());
+      msg.operating_mode = generate_random_operating_mode();
+      // msg.node_states =
+      //   generate_random_vector<NodeState>(generate_random_size());
+      // msg.edge_states =
+      //   generate_random_vector<EdgeState>(generate_random_size());
+      // msg.agv_position.push_back(generate<AGVPosition>());
+      // msg.velocity.push_back(generate<Velocity>());
+      // msg.loads = generate_random_vector<Load>(generate_random_size());
+      // msg.action_states =
+      //   generate_random_vector<ActionState>(generate_random_size());
+      // msg.battery_state = generate<BatteryState>();
+      // msg.errors = generate_random_vector<Error>(generate_random_size());
+      // msg.information = generate_random_vector<Info>(generate_random_size());
+      // msg.safety_state = generate<SafetyState>();
+    }
+    else
+    {
+      throw std::runtime_error(
+        "No random data generator defined for this custom type: " +
+        std::string(typeid(T).name()));
+    }
+    return msg;
+  }
+
+private:
+  /// \brief Mersenne Twister random number engine
+  std::mt19937 rng_;
+
+  /// \brief Distribution for unsigned 32-bit integers
+  std::uniform_int_distribution<uint32_t> uint_dist_;
+
+  /// \brief Distribution for a boolean value
+  std::uniform_int_distribution<int> bool_dist_;
+
+  /// \brief Distribution for random string lengths
+  std::uniform_int_distribution<int> string_length_dist_;
+
+  /// \brief Distribution for milliseconds from epoch
+  std::uniform_int_distribution<int64_t> milliseconds_dist_;
+};
+
+#endif  // VDA5050_JSON_UTILS__TEST__GENERATOR__GENERATOR_ROS2_HPP_

--- a/vda5050_json_utils/test/test_json_utils.cpp
+++ b/vda5050_json_utils/test/test_json_utils.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <vda5050_types/connection.hpp>
+#include <vda5050_types/header.hpp>
+#include <vda5050_types/state.hpp>
+
+#include "vda5050_json_utils/serialization.hpp"
+
+#include "generator/generator.hpp"
+
+using vda5050_types::Connection;
+using vda5050_types::Header;
+using vda5050_types::State;
+
+// List of types to be tested for serialization round-trip
+using SerializableTypes = ::testing::Types<Connection, Header, State>;
+
+template <typename T>
+class SerializationTest : public ::testing::Test
+{
+protected:
+  // Random data generator instance
+  RandomDataGenerator generator;
+
+  /// \brief Performs a serialization round-trip for a given message object
+  ///
+  /// \param original Object of type T to be tested
+  void round_trip_test(const T& original)
+  {
+    // Serialize the original object into JSON
+    nlohmann::json serialized_data = original;
+
+    // Deserialize the JSON object back into an object of type T
+    T deserialized_object = serialized_data;
+
+    EXPECT_EQ(original, deserialized_object)
+      << "Serialization round-trip failed for type: " << typeid(T).name();
+  }
+};
+
+TYPED_TEST_SUITE(SerializationTest, SerializableTypes);
+
+TYPED_TEST(SerializationTest, RoundTrip)
+{
+  // Number of iterations for round-trip of each object
+  const int num_random_tests = 100;
+
+  for (int i = 0; i < num_random_tests; i++)
+  {
+    SCOPED_TRACE("Test iteration " + std::to_string(i));
+    TypeParam random_object = this->generator.template generate<TypeParam>();
+    this->round_trip_test(random_object);
+  }
+}

--- a/vda5050_json_utils/test/test_json_utils.cpp
+++ b/vda5050_json_utils/test/test_json_utils.cpp
@@ -19,42 +19,57 @@
 #include <gtest/gtest.h>
 
 #include <vda5050_types/action_state.hpp>
+#include <vda5050_types/agv_position.hpp>
 #include <vda5050_types/battery_state.hpp>
+#include <vda5050_types/bounding_box_reference.hpp>
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/control_point.hpp>
 #include <vda5050_types/edge_state.hpp>
 #include <vda5050_types/error.hpp>
 #include <vda5050_types/error_reference.hpp>
 #include <vda5050_types/header.hpp>
+#include <vda5050_types/info.hpp>
+#include <vda5050_types/info_reference.hpp>
+#include <vda5050_types/load.hpp>
+#include <vda5050_types/load_dimensions.hpp>
 #include <vda5050_types/node_position.hpp>
 #include <vda5050_types/node_state.hpp>
 #include <vda5050_types/safety_state.hpp>
 #include <vda5050_types/state.hpp>
 #include <vda5050_types/trajectory.hpp>
+#include <vda5050_types/velocity.hpp>
 
 #include "vda5050_json_utils/serialization.hpp"
 
 #include "generator/generator.hpp"
 
 using vda5050_types::ActionState;
+using vda5050_types::AGVPosition;
 using vda5050_types::BatteryState;
+using vda5050_types::BoundingBoxReference;
 using vda5050_types::Connection;
 using vda5050_types::ControlPoint;
 using vda5050_types::EdgeState;
 using vda5050_types::Error;
 using vda5050_types::ErrorReference;
 using vda5050_types::Header;
+using vda5050_types::Info;
+using vda5050_types::InfoReference;
+using vda5050_types::Load;
+using vda5050_types::LoadDimensions;
 using vda5050_types::NodePosition;
 using vda5050_types::NodeState;
 using vda5050_types::SafetyState;
 using vda5050_types::State;
 using vda5050_types::Trajectory;
+using vda5050_types::Velocity;
 
 // List of types to be tested for serialization round-trip
 using SerializableTypes = ::testing::Types<
-  ActionState, BatteryState, Connection, ControlPoint, EdgeState, Error,
-  ErrorReference, Header, NodePosition, NodeState, SafetyState, State,
-  Trajectory>;
+  ActionState, AGVPosition, BatteryState, BoundingBoxReference, Connection,
+  ControlPoint, EdgeState, Error, ErrorReference, Header, Info, InfoReference,
+  Load, LoadDimensions, NodePosition, NodeState, SafetyState, State, Trajectory,
+  Velocity>;
 
 template <typename T>
 class SerializationTest : public ::testing::Test

--- a/vda5050_json_utils/test/test_json_utils.cpp
+++ b/vda5050_json_utils/test/test_json_utils.cpp
@@ -18,25 +18,43 @@
 
 #include <gtest/gtest.h>
 
+#include <vda5050_types/action_state.hpp>
+#include <vda5050_types/battery_state.hpp>
 #include <vda5050_types/connection.hpp>
+#include <vda5050_types/control_point.hpp>
+#include <vda5050_types/edge_state.hpp>
+#include <vda5050_types/error.hpp>
+#include <vda5050_types/error_reference.hpp>
 #include <vda5050_types/header.hpp>
 #include <vda5050_types/node_position.hpp>
 #include <vda5050_types/node_state.hpp>
+#include <vda5050_types/safety_state.hpp>
 #include <vda5050_types/state.hpp>
+#include <vda5050_types/trajectory.hpp>
 
 #include "vda5050_json_utils/serialization.hpp"
 
 #include "generator/generator.hpp"
 
+using vda5050_types::ActionState;
+using vda5050_types::BatteryState;
 using vda5050_types::Connection;
+using vda5050_types::ControlPoint;
+using vda5050_types::EdgeState;
+using vda5050_types::Error;
+using vda5050_types::ErrorReference;
 using vda5050_types::Header;
 using vda5050_types::NodePosition;
 using vda5050_types::NodeState;
+using vda5050_types::SafetyState;
 using vda5050_types::State;
+using vda5050_types::Trajectory;
 
 // List of types to be tested for serialization round-trip
-using SerializableTypes =
-  ::testing::Types<Connection, Header, NodePosition, NodeState, State>;
+using SerializableTypes = ::testing::Types<
+  ActionState, BatteryState, Connection, ControlPoint, EdgeState, Error,
+  ErrorReference, Header, NodePosition, NodeState, SafetyState, State,
+  Trajectory>;
 
 template <typename T>
 class SerializationTest : public ::testing::Test

--- a/vda5050_json_utils/test/test_json_utils.cpp
+++ b/vda5050_json_utils/test/test_json_utils.cpp
@@ -20,6 +20,8 @@
 
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/header.hpp>
+#include <vda5050_types/node_position.hpp>
+#include <vda5050_types/node_state.hpp>
 #include <vda5050_types/state.hpp>
 
 #include "vda5050_json_utils/serialization.hpp"
@@ -28,10 +30,13 @@
 
 using vda5050_types::Connection;
 using vda5050_types::Header;
+using vda5050_types::NodePosition;
+using vda5050_types::NodeState;
 using vda5050_types::State;
 
 // List of types to be tested for serialization round-trip
-using SerializableTypes = ::testing::Types<Connection, Header, State>;
+using SerializableTypes =
+  ::testing::Types<Connection, Header, NodePosition, NodeState, State>;
 
 template <typename T>
 class SerializationTest : public ::testing::Test

--- a/vda5050_json_utils/test/test_json_utils.cpp
+++ b/vda5050_json_utils/test/test_json_utils.cpp
@@ -18,12 +18,15 @@
 
 #include <gtest/gtest.h>
 
+#include <vda5050_types/action.hpp>
+#include <vda5050_types/action_parameter.hpp>
 #include <vda5050_types/action_state.hpp>
 #include <vda5050_types/agv_position.hpp>
 #include <vda5050_types/battery_state.hpp>
 #include <vda5050_types/bounding_box_reference.hpp>
 #include <vda5050_types/connection.hpp>
 #include <vda5050_types/control_point.hpp>
+#include <vda5050_types/edge.hpp>
 #include <vda5050_types/edge_state.hpp>
 #include <vda5050_types/error.hpp>
 #include <vda5050_types/error_reference.hpp>
@@ -32,8 +35,10 @@
 #include <vda5050_types/info_reference.hpp>
 #include <vda5050_types/load.hpp>
 #include <vda5050_types/load_dimensions.hpp>
+#include <vda5050_types/node.hpp>
 #include <vda5050_types/node_position.hpp>
 #include <vda5050_types/node_state.hpp>
+#include <vda5050_types/order.hpp>
 #include <vda5050_types/safety_state.hpp>
 #include <vda5050_types/state.hpp>
 #include <vda5050_types/trajectory.hpp>
@@ -43,12 +48,15 @@
 
 #include "generator/generator.hpp"
 
+using vda5050_types::Action;
+using vda5050_types::ActionParameter;
 using vda5050_types::ActionState;
 using vda5050_types::AGVPosition;
 using vda5050_types::BatteryState;
 using vda5050_types::BoundingBoxReference;
 using vda5050_types::Connection;
 using vda5050_types::ControlPoint;
+using vda5050_types::Edge;
 using vda5050_types::EdgeState;
 using vda5050_types::Error;
 using vda5050_types::ErrorReference;
@@ -57,8 +65,10 @@ using vda5050_types::Info;
 using vda5050_types::InfoReference;
 using vda5050_types::Load;
 using vda5050_types::LoadDimensions;
+using vda5050_types::Node;
 using vda5050_types::NodePosition;
 using vda5050_types::NodeState;
+using vda5050_types::Order;
 using vda5050_types::SafetyState;
 using vda5050_types::State;
 using vda5050_types::Trajectory;
@@ -66,10 +76,10 @@ using vda5050_types::Velocity;
 
 // List of types to be tested for serialization round-trip
 using SerializableTypes = ::testing::Types<
-  ActionState, AGVPosition, BatteryState, BoundingBoxReference, Connection,
-  ControlPoint, EdgeState, Error, ErrorReference, Header, Info, InfoReference,
-  Load, LoadDimensions, NodePosition, NodeState, SafetyState, State, Trajectory,
-  Velocity>;
+  Action, ActionParameter, ActionState, AGVPosition, BatteryState,
+  BoundingBoxReference, Connection, ControlPoint, Edge, EdgeState, Error,
+  ErrorReference, Header, Info, InfoReference, Load, LoadDimensions, Node,
+  NodePosition, NodeState, Order, SafetyState, State, Trajectory, Velocity>;
 
 template <typename T>
 class SerializationTest : public ::testing::Test

--- a/vda5050_json_utils/test/test_json_utils_ros2.cpp
+++ b/vda5050_json_utils/test/test_json_utils_ros2.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <rosidl_runtime_cpp/traits.hpp>
+
+#include <vda5050_msgs/msg/connection.hpp>
+#include <vda5050_msgs/msg/header.hpp>
+#include <vda5050_msgs/msg/state.hpp>
+
+#include "vda5050_json_utils/serialization.hpp"
+
+#include "generator/generator_ros2.hpp"
+
+using vda5050_msgs::msg::Connection;
+using vda5050_msgs::msg::Header;
+using vda5050_msgs::msg::State;
+
+// List of types to be tested for serialization round-trip
+using SerializableTypesROS2 = ::testing::Types<Connection, Header, State>;
+
+template <typename T>
+class SerializationTestROS2 : public ::testing::Test
+{
+protected:
+  // Random data generator instance
+  RandomDataGeneratorROS2 generator;
+
+  /// \brief Performs a serialization round-trip for a given message object
+  ///
+  /// \param original Object of type T to be tested
+  void round_trip_test(const T& original)
+  {
+    // Serialize the original object into JSON
+    nlohmann::json serialized_data = original;
+
+    // Deserialize the JSON object back into an object of type T
+    T deserialized_object = serialized_data;
+
+    EXPECT_EQ(original, deserialized_object)
+      << "Serialization round-trip failed for type: " << typeid(T).name();
+  }
+};
+
+TYPED_TEST_SUITE(SerializationTestROS2, SerializableTypesROS2);
+
+TYPED_TEST(SerializationTestROS2, RoundTrip)
+{
+  // Number of iterations for round-trip of each object
+  const int num_random_tests = 100;
+
+  for (int i = 0; i < num_random_tests; i++)
+  {
+    SCOPED_TRACE("Test iteration " + std::to_string(i));
+    TypeParam random_object = this->generator.template generate<TypeParam>();
+    this->round_trip_test(random_object);
+  }
+}

--- a/vda5050_json_utils/test/test_json_utils_ros2.cpp
+++ b/vda5050_json_utils/test/test_json_utils_ros2.cpp
@@ -22,6 +22,8 @@
 
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/header.hpp>
+#include <vda5050_msgs/msg/node_position.hpp>
+#include <vda5050_msgs/msg/node_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 
 #include "vda5050_json_utils/serialization.hpp"
@@ -30,10 +32,13 @@
 
 using vda5050_msgs::msg::Connection;
 using vda5050_msgs::msg::Header;
+using vda5050_msgs::msg::NodePosition;
+using vda5050_msgs::msg::NodeState;
 using vda5050_msgs::msg::State;
 
 // List of types to be tested for serialization round-trip
-using SerializableTypesROS2 = ::testing::Types<Connection, Header, State>;
+using SerializableTypesROS2 =
+  ::testing::Types<Connection, Header, NodePosition, NodeState, State>;
 
 template <typename T>
 class SerializationTestROS2 : public ::testing::Test

--- a/vda5050_json_utils/test/test_json_utils_ros2.cpp
+++ b/vda5050_json_utils/test/test_json_utils_ros2.cpp
@@ -20,12 +20,15 @@
 
 #include <rosidl_runtime_cpp/traits.hpp>
 
+#include <vda5050_msgs/msg/action.hpp>
+#include <vda5050_msgs/msg/action_parameter.hpp>
 #include <vda5050_msgs/msg/action_state.hpp>
 #include <vda5050_msgs/msg/agv_position.hpp>
 #include <vda5050_msgs/msg/battery_state.hpp>
 #include <vda5050_msgs/msg/bounding_box_reference.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/control_point.hpp>
+#include <vda5050_msgs/msg/edge.hpp>
 #include <vda5050_msgs/msg/edge_state.hpp>
 #include <vda5050_msgs/msg/error.hpp>
 #include <vda5050_msgs/msg/error_reference.hpp>
@@ -34,8 +37,10 @@
 #include <vda5050_msgs/msg/info_reference.hpp>
 #include <vda5050_msgs/msg/load.hpp>
 #include <vda5050_msgs/msg/load_dimensions.hpp>
+#include <vda5050_msgs/msg/node.hpp>
 #include <vda5050_msgs/msg/node_position.hpp>
 #include <vda5050_msgs/msg/node_state.hpp>
+#include <vda5050_msgs/msg/order.hpp>
 #include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #include <vda5050_msgs/msg/trajectory.hpp>
@@ -45,12 +50,15 @@
 
 #include "generator/generator_ros2.hpp"
 
+using vda5050_msgs::msg::Action;
+using vda5050_msgs::msg::ActionParameter;
 using vda5050_msgs::msg::ActionState;
 using vda5050_msgs::msg::AGVPosition;
 using vda5050_msgs::msg::BatteryState;
 using vda5050_msgs::msg::BoundingBoxReference;
 using vda5050_msgs::msg::Connection;
 using vda5050_msgs::msg::ControlPoint;
+using vda5050_msgs::msg::Edge;
 using vda5050_msgs::msg::EdgeState;
 using vda5050_msgs::msg::Error;
 using vda5050_msgs::msg::ErrorReference;
@@ -59,8 +67,10 @@ using vda5050_msgs::msg::Info;
 using vda5050_msgs::msg::InfoReference;
 using vda5050_msgs::msg::Load;
 using vda5050_msgs::msg::LoadDimensions;
+using vda5050_msgs::msg::Node;
 using vda5050_msgs::msg::NodePosition;
 using vda5050_msgs::msg::NodeState;
+using vda5050_msgs::msg::Order;
 using vda5050_msgs::msg::SafetyState;
 using vda5050_msgs::msg::State;
 using vda5050_msgs::msg::Trajectory;
@@ -68,10 +78,10 @@ using vda5050_msgs::msg::Velocity;
 
 // List of types to be tested for serialization round-trip
 using SerializableTypesROS2 = ::testing::Types<
-  ActionState, AGVPosition, BatteryState, BoundingBoxReference, Connection,
-  ControlPoint, EdgeState, Error, ErrorReference, Header, Info, InfoReference,
-  Load, LoadDimensions, NodePosition, NodeState, SafetyState, State, Trajectory,
-  Velocity>;
+  Action, ActionParameter, ActionState, AGVPosition, BatteryState,
+  BoundingBoxReference, Connection, ControlPoint, Edge, EdgeState, Error,
+  ErrorReference, Header, Info, InfoReference, Load, LoadDimensions, Node,
+  NodePosition, NodeState, Order, SafetyState, State, Trajectory, Velocity>;
 
 template <typename T>
 class SerializationTestROS2 : public ::testing::Test

--- a/vda5050_json_utils/test/test_json_utils_ros2.cpp
+++ b/vda5050_json_utils/test/test_json_utils_ros2.cpp
@@ -21,42 +21,57 @@
 #include <rosidl_runtime_cpp/traits.hpp>
 
 #include <vda5050_msgs/msg/action_state.hpp>
+#include <vda5050_msgs/msg/agv_position.hpp>
 #include <vda5050_msgs/msg/battery_state.hpp>
+#include <vda5050_msgs/msg/bounding_box_reference.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
 #include <vda5050_msgs/msg/control_point.hpp>
 #include <vda5050_msgs/msg/edge_state.hpp>
 #include <vda5050_msgs/msg/error.hpp>
 #include <vda5050_msgs/msg/error_reference.hpp>
 #include <vda5050_msgs/msg/header.hpp>
+#include <vda5050_msgs/msg/info.hpp>
+#include <vda5050_msgs/msg/info_reference.hpp>
+#include <vda5050_msgs/msg/load.hpp>
+#include <vda5050_msgs/msg/load_dimensions.hpp>
 #include <vda5050_msgs/msg/node_position.hpp>
 #include <vda5050_msgs/msg/node_state.hpp>
 #include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
 #include <vda5050_msgs/msg/trajectory.hpp>
+#include <vda5050_msgs/msg/velocity.hpp>
 
 #include "vda5050_json_utils/serialization.hpp"
 
 #include "generator/generator_ros2.hpp"
 
 using vda5050_msgs::msg::ActionState;
+using vda5050_msgs::msg::AGVPosition;
 using vda5050_msgs::msg::BatteryState;
+using vda5050_msgs::msg::BoundingBoxReference;
 using vda5050_msgs::msg::Connection;
 using vda5050_msgs::msg::ControlPoint;
 using vda5050_msgs::msg::EdgeState;
 using vda5050_msgs::msg::Error;
 using vda5050_msgs::msg::ErrorReference;
 using vda5050_msgs::msg::Header;
+using vda5050_msgs::msg::Info;
+using vda5050_msgs::msg::InfoReference;
+using vda5050_msgs::msg::Load;
+using vda5050_msgs::msg::LoadDimensions;
 using vda5050_msgs::msg::NodePosition;
 using vda5050_msgs::msg::NodeState;
 using vda5050_msgs::msg::SafetyState;
 using vda5050_msgs::msg::State;
 using vda5050_msgs::msg::Trajectory;
+using vda5050_msgs::msg::Velocity;
 
 // List of types to be tested for serialization round-trip
 using SerializableTypesROS2 = ::testing::Types<
-  ActionState, BatteryState, Connection, ControlPoint, EdgeState, Error,
-  ErrorReference, Header, NodePosition, NodeState, SafetyState, State,
-  Trajectory>;
+  ActionState, AGVPosition, BatteryState, BoundingBoxReference, Connection,
+  ControlPoint, EdgeState, Error, ErrorReference, Header, Info, InfoReference,
+  Load, LoadDimensions, NodePosition, NodeState, SafetyState, State, Trajectory,
+  Velocity>;
 
 template <typename T>
 class SerializationTestROS2 : public ::testing::Test

--- a/vda5050_json_utils/test/test_json_utils_ros2.cpp
+++ b/vda5050_json_utils/test/test_json_utils_ros2.cpp
@@ -20,25 +20,43 @@
 
 #include <rosidl_runtime_cpp/traits.hpp>
 
+#include <vda5050_msgs/msg/action_state.hpp>
+#include <vda5050_msgs/msg/battery_state.hpp>
 #include <vda5050_msgs/msg/connection.hpp>
+#include <vda5050_msgs/msg/control_point.hpp>
+#include <vda5050_msgs/msg/edge_state.hpp>
+#include <vda5050_msgs/msg/error.hpp>
+#include <vda5050_msgs/msg/error_reference.hpp>
 #include <vda5050_msgs/msg/header.hpp>
 #include <vda5050_msgs/msg/node_position.hpp>
 #include <vda5050_msgs/msg/node_state.hpp>
+#include <vda5050_msgs/msg/safety_state.hpp>
 #include <vda5050_msgs/msg/state.hpp>
+#include <vda5050_msgs/msg/trajectory.hpp>
 
 #include "vda5050_json_utils/serialization.hpp"
 
 #include "generator/generator_ros2.hpp"
 
+using vda5050_msgs::msg::ActionState;
+using vda5050_msgs::msg::BatteryState;
 using vda5050_msgs::msg::Connection;
+using vda5050_msgs::msg::ControlPoint;
+using vda5050_msgs::msg::EdgeState;
+using vda5050_msgs::msg::Error;
+using vda5050_msgs::msg::ErrorReference;
 using vda5050_msgs::msg::Header;
 using vda5050_msgs::msg::NodePosition;
 using vda5050_msgs::msg::NodeState;
+using vda5050_msgs::msg::SafetyState;
 using vda5050_msgs::msg::State;
+using vda5050_msgs::msg::Trajectory;
 
 // List of types to be tested for serialization round-trip
-using SerializableTypesROS2 =
-  ::testing::Types<Connection, Header, NodePosition, NodeState, State>;
+using SerializableTypesROS2 = ::testing::Types<
+  ActionState, BatteryState, Connection, ControlPoint, EdgeState, Error,
+  ErrorReference, Header, NodePosition, NodeState, SafetyState, State,
+  Trajectory>;
 
 template <typename T>
 class SerializationTestROS2 : public ::testing::Test

--- a/vda5050_types/include/vda5050_types/action.hpp
+++ b/vda5050_types/include/vda5050_types/action.hpp
@@ -30,19 +30,23 @@ namespace vda5050_types {
 
 struct Action
 {
-  /// \brief Name of action as described in the first column of Actions and Parameters. Identifies the function of the action
+  /// \brief Name of action as described in the first column of Actions and
+  /// Parameters. Identifies the function of the action
   std::string action_type;
 
-  /// \brief Unique ID to identify the action and map it to the actionState in the State message
+  /// \brief Unique ID to identify the action and map it to the actionState in
+  /// the State message
   std::string action_id;
 
-  /// \brief  Regulates if the action is allowed to be executed during movement and/or parallel to other actions.
+  /// \brief  Regulates if the action is allowed to be executed during movement
+  /// and/or parallel to other actions.
   BlockingType blocking_type;
 
   /// \brief Additional information on the action
   std::optional<std::string> action_description;
 
-  /// \brief Array of actionParameter objects for the indicated action. If not defined, the action has no parameters
+  /// \brief Array of actionParameter objects for the indicated action. If not
+  /// defined, the action has no parameters
   /// eg: deviceId, loadId, external Triggers
   std::optional<std::vector<ActionParameter>> action_parameters;
 

--- a/vda5050_types/include/vda5050_types/action_parameter_factsheet.hpp
+++ b/vda5050_types/include/vda5050_types/action_parameter_factsheet.hpp
@@ -17,7 +17,7 @@
  */
 
 #ifndef VDA5050_TYPES__ACTION_PARAMETER_FACTSHEET_HPP_
-#define VDA5050_TYPES__ACTION_PARAMETER_FACTHSEET_HPP_
+#define VDA5050_TYPES__ACTION_PARAMETER_FACTSHEET_HPP_
 
 #include <optional>
 #include <string>
@@ -26,7 +26,8 @@
 
 namespace vda5050_types {
 
-/// \brief NOTE: This message is different from ActionParameter.msg used in Order.msg.
+/// \brief NOTE: This message is different from ActionParameter.msg used
+/// in Order.msg.
 /// For more details, refer to page 54 of VDA5050 Recommendation v2.0.0.
 /// ActionParameter message specifically used in Factsheet.msg.
 /// Describes the array of parameters that an action has.

--- a/vda5050_types/include/vda5050_types/agv_action.hpp
+++ b/vda5050_types/include/vda5050_types/agv_action.hpp
@@ -30,8 +30,8 @@
 namespace vda5050_types {
 
 /// \brief Actions with parameters supported by the AGV.
-/// This includes standard actions specified in VDA5050 and manufacturer-specific
-/// actions.
+/// This includes standard actions specified in VDA5050 and
+/// manufacturer-specific actions.
 struct AGVAction
 {
   /// \brief Unique type of action corresponding to action.actionType
@@ -40,7 +40,8 @@ struct AGVAction
   /// \brief Array of allowed scopes for using this action type.
   std::vector<ActionScope> action_scopes;
 
-  /// \brief Array of parameters an action has. If not defined, the action has no parameters.
+  /// \brief Array of parameters an action has. If not defined, the
+  /// action has no parameters.
   std::optional<std::vector<ActionParameterFactsheet>> action_parameters;
 
   /// \brief Free-form text: description of the result.

--- a/vda5050_types/include/vda5050_types/agv_geometry.hpp
+++ b/vda5050_types/include/vda5050_types/agv_geometry.hpp
@@ -28,16 +28,18 @@
 
 namespace vda5050_types {
 
-/// @brief Message defining the geometry properties of the AGV. eg: outlines and wheel positions.
+/// \brief Message defining the geometry properties of the AGV. eg: outlines and wheel positions.
 struct AGVGeometry
 {
-  /// @brief Array of wheels, containing wheel arrangement and geometry.
+  /// \brief Array of wheels, containing wheel arrangement and geometry.
   std::optional<std::vector<WheelDefinition>> wheel_definitions;
 
-  /// @brief Array of AGV envelope curves in 2D. eg: the mechanical envelopes for unloaded and loaded state, the safety fields for different speed cases.
+  /// \brief Array of AGV envelope curves in 2D. eg: the mechanical envelopes
+  /// for unloaded and loaded state, the safety fields for different speed
+  /// cases.
   std::optional<std::vector<Envelope2d>> envelopes_2d;
 
-  /// @brief Array of AGV envelope curves in 3D.
+  /// \brief Array of AGV envelope curves in 3D.
   std::optional<std::vector<Envelope3d>> envelopes_3d;
 
   /// \brief Equality operator

--- a/vda5050_types/include/vda5050_types/blocking_type.hpp
+++ b/vda5050_types/include/vda5050_types/blocking_type.hpp
@@ -26,7 +26,8 @@ enum class BlockingType
   /// \brief action can happen in parallel with others, including movement
   NONE,
 
-  /// \brief action can happen simultaneously with other actions, but not while moving
+  /// \brief action can happen simultaneously with other actions,
+  /// but not while moving
   SOFT,
 
   /// \brief no other action can be performed while this action is running

--- a/vda5050_types/include/vda5050_types/edge.hpp
+++ b/vda5050_types/include/vda5050_types/edge.hpp
@@ -36,9 +36,9 @@ struct Edge
   /// \brief Unique edge identification.
   std::string edge_id;
 
-  /// \brief Number to track the sequence of nodes and edges in an order, simplifying updates.
-  /// Distinguishes between nodes/edges that may be revisited in the same order.
-  /// Resets when a new orderId is issued.
+  /// \brief Number to track the sequence of nodes and edges in an order,
+  /// simplifying updates. Distinguishes between nodes/edges that may be
+  /// revisited in the same order. Resets when a new orderId is issued.
   uint32_t sequence_id;
 
   /// \brief The nodeId of the start node for this edge.
@@ -54,9 +54,9 @@ struct Edge
 
   /// \brief Array of actionIds to be executed on the edge.
   /// Array is empty if no actions are required.
-  /// An action triggered by an edge will only be active for the time that the AGV is
-  /// traversing it. When the AGV leaves the edge, the action will stop and the state
-  /// before entering the edge will be restored.
+  /// An action triggered by an edge will only be active for the time that
+  /// the AGV is traversing it. When the AGV leaves the edge, the action will
+  /// stop and the state before entering the edge will be restored.
   std::vector<Action> actions;
 
   /// \brief Additional information about the edge.
@@ -66,26 +66,28 @@ struct Edge
   /// Speed is defined by the fastest measurement of the vehicle.
   std::optional<double> max_speed;
 
-  /// \brief Permitted maximum height [m] of the vehicle including load on the edge.
+  /// \brief Permitted maximum height [m] of the vehicle including load
+  /// on the edge.
   std::optional<double> max_height;
 
-  /// \brief Permitted minimal height [m] of the load handling device on the edge.
+  /// \brief Permitted minimal height [m] of the load handling device
+  /// on the edge.
   std::optional<double> min_height;
 
   /// \brief Orientation of the AGV on the edge [rad].
-  /// If the AGV starts in a different orientation, rotate the vehicle on the edge to
-  /// the desired orientation if rotationAllowed is true.
+  /// If the AGV starts in a different orientation, rotate the vehicle on
+  /// the edge to the desired orientation if rotationAllowed is true.
   /// If rotationAllowed is false, rotate before entering the edge.
   std::optional<double> orientation;
 
-  /// \brief Defines if the orientation field is interpreted relative to the global
-  /// project specific map coordinate system or tangential to the edge.
+  /// \brief Defines if the orientation field is interpreted relative to the
+  /// global project specific map coordinate system or tangential to the edge.
   /// If tangential to the edge, 0.0 = forwards, Pi = backwards.
   /// Default value: TANGENTIAL
   std::optional<OrientationType> orientation_type;
 
-  /// \brief Sets direction at junctions for line-guided or wire-guided vehicles.
-  /// To be defined initially (vehicle-individual).
+  /// \brief Sets direction at junctions for line-guided or wire-guided
+  /// vehicles. To be defined initially (vehicle-individual).
   /// Eg: straight, left, right.
   std::optional<std::string> direction;
 
@@ -98,14 +100,16 @@ struct Edge
   /// No limit, if not set.
   std::optional<double> max_rotation_speed;
 
-  /// \brief The Trajectory object for this edge as a Non-Uniform Rational B-Spline (NURBS).
-  /// Defines the path that the AGV should move between the start node and end node
-  /// of the edge. This field can be omitted if the AGV cannot process trajectories
-  /// or if the AGV plans its own trajectory.
+  /// \brief The Trajectory object for this edge as a Non-Uniform Rational
+  /// B-Spline (NURBS). Defines the path that the AGV should move between
+  /// the start node and end node of the edge. This field can be omitted if
+  /// the AGV cannot process trajectories or if the AGV plans its own
+  /// trajectory.
   std::optional<Trajectory> trajectory;
 
   /// \brief Length of the path from the start node to the end node [m].
-  /// Used by line-guided AGVs to decrease their speed before reaching a stop position.
+  /// Used by line-guided AGVs to decrease their speed before reaching a stop
+  /// position.
   std::optional<double> length;
 
   /// \brief Equality operator

--- a/vda5050_types/include/vda5050_types/envelope2d.hpp
+++ b/vda5050_types/include/vda5050_types/envelope2d.hpp
@@ -33,7 +33,8 @@ struct Envelope2d
   /// \brief Name of the envelope curve set.
   std::string set;
 
-  /// \brief Envelope curve as an x/y-polygon. Polygon is assumed as closed and shall be non-self-intersecting.
+  /// \brief Envelope curve as an x/y-polygon. Polygon is assumed as closed
+  /// and shall be non-self-intersecting.
   std::vector<PolygonPoint> polygon_points;
 
   /// \brief Free-form text: description of envelope curve set.

--- a/vda5050_types/include/vda5050_types/envelope3d.hpp
+++ b/vda5050_types/include/vda5050_types/envelope3d.hpp
@@ -33,10 +33,12 @@ struct Envelope3d
   /// \brief Format of the data, eg: DXF.
   std::string format;
 
-  /// \brief 3D-envelope curve data as a string. Format of this data is specified in the 'format' field, and should be handled accordingly.
+  /// \brief 3D-envelope curve data as a string. Format of this data is
+  /// specified in the 'format' field, and should be handled accordingly.
   std::optional<std::string> data;
 
-  /// \brief Protocol and URL definition for downloading the 3D-envelope curve data. eg: ftp://xxx.yyy.com/ac4dgvhoif5tghji
+  /// \brief Protocol and URL definition for downloading the 3D-envelope
+  /// curve data. eg: ftp://xxx.yyy.com/ac4dgvhoif5tghji
   std::optional<std::string> url;
 
   /// \brief Free-form text: description of envelope curve set.

--- a/vda5050_types/include/vda5050_types/factsheet.hpp
+++ b/vda5050_types/include/vda5050_types/factsheet.hpp
@@ -34,16 +34,19 @@ namespace vda5050_types {
 /// as required by the VDA5050 specification.
 struct Factsheet
 {
-  /// \brief Message header that contains the common fields required across all messages
+  /// \brief Message header that contains the common fields required across all
+  /// messages
   Header header;
 
-  /// \brief Parameters that generally specify the class and the capabilities of the AGV
+  /// \brief Parameters that generally specify the class and the capabilities
+  /// of the AGV
   TypeSpecification type_specification;
 
   /// \brief Parameters that specify the basic physical properties of the AGV
   PhysicalParameters physical_parameters;
 
-  /// \brief Limits for length of identifiers, arrays, strings, and similar in MQTT communication
+  /// \brief Limits for length of identifiers, arrays, strings, and similar in
+  /// MQTT communication
   ProtocolLimits protocol_limits;
 
   /// \brief Supported features of VDA5050 protocol

--- a/vda5050_types/include/vda5050_types/load_set.hpp
+++ b/vda5050_types/include/vda5050_types/load_set.hpp
@@ -36,15 +36,17 @@ struct LoadSet
   /// \brief Type of load (e.g., EPAL, XLT1200, etc.)
   std::string load_type;
 
-  /// \brief Array of load positions between load handling devices that this load set is valid for.
-  /// If this parameter does not exist or is empty, this load set is valid for all load
-  /// handling devices on this AGV.
+  /// \brief Array of load positions between load handling devices that this
+  /// load set is valid for. If this parameter does not exist or is empty, this
+  /// load set is valid for all load handling devices on this AGV.
   std::optional<std::vector<std::string>> load_positions;
 
-  /// \brief Bounding box reference as defined in parameter loads[] in the state message.
+  /// \brief Bounding box reference as defined in parameter loads[] in the state
+  /// message.
   std::optional<BoundingBoxReference> bounding_box_reference;
 
-  /// \brief Load dimensions as defined in parameter loads[] in the state message.
+  /// \brief Load dimensions as defined in parameter loads[] in the state
+  /// message.
   std::optional<LoadDimensions> load_dimensions;
 
   /// \brief Maximum weight of this load type [kg].

--- a/vda5050_types/include/vda5050_types/load_specification.hpp
+++ b/vda5050_types/include/vda5050_types/load_specification.hpp
@@ -26,13 +26,15 @@
 
 namespace vda5050_types {
 
-/// \brief Message specifying the load handling and supported load types of the AGV
+/// \brief Message specifying the load handling and supported load types
+/// of the AGV
 struct LoadSpecification
 {
   /// \brief Array of load positions / load handling devices.
-  /// This array contains the valid values for "state.loads[].loadPosition" and for the
-  /// action parameter "lhd" of pick-and-drop actions.
-  /// If this array doesn't exist or is empty, the AGV has no load handling device.
+  /// This array contains the valid values for "state.loads[].loadPosition"
+  /// and for the action parameter "lhd" of pick-and-drop actions.
+  /// If this array doesn't exist or is empty, the AGV has no load handling
+  /// device.
   std::optional<std::vector<std::string>> load_positions;
 
   /// \brief Array of load sets that can be handled by the AGV.

--- a/vda5050_types/include/vda5050_types/max_array_lens.hpp
+++ b/vda5050_types/include/vda5050_types/max_array_lens.hpp
@@ -23,8 +23,8 @@
 
 namespace vda5050_types {
 
-/// \brief This message defines the maximum lengths of arrays processable by the AGV
-/// according to the VDA5050 specification.
+/// \brief This message defines the maximum lengths of arrays processable
+/// by the AGV according to the VDA5050 specification.
 struct MaxArrayLens
 {
   /// \brief Maximum number of nodes per order processable by the AGV.
@@ -42,13 +42,15 @@ struct MaxArrayLens
   /// \brief Maximum number of parameters per action processable by the AGV.
   uint32_t actions_actions_parameters;
 
-  /// \brief Maximum number of instant actions per message processable by the AGV.
+  /// \brief Maximum number of instant actions per message processable by
+  /// the AGV.
   uint32_t instant_actions;
 
   /// \brief Maximum number of knots per trajectory processable by the AGV.
   uint32_t trajectory_knot_vector;
 
-  /// \brief Maximum number of control points per trajectory processable by the AGV.
+  /// \brief Maximum number of control points per trajectory processable by
+  /// the AGV.
   uint32_t trajectory_control_points;
 
   /// \brief Maximum number of nodeStates sent by the AGV,
@@ -68,13 +70,15 @@ struct MaxArrayLens
   /// \brief Maximum number of errors sent by the AGV in one state message.
   uint32_t state_errors;
 
-  /// \brief Maximum number of information objects sent by the AGV in one state message.
+  /// \brief Maximum number of information objects sent by the AGV in one
+  /// state message.
   uint32_t state_information;
 
   /// \brief Maximum number of error references sent by the AGV for each error.
   uint32_t error_error_references;
 
-  /// \brief Maximum number of info references sent by the AGV for each information.
+  /// \brief Maximum number of info references sent by the AGV for each
+  /// information.
   uint32_t information_info_references;
 
   /// \brief Equality operator

--- a/vda5050_types/include/vda5050_types/max_string_lens.hpp
+++ b/vda5050_types/include/vda5050_types/max_string_lens.hpp
@@ -24,8 +24,8 @@
 
 namespace vda5050_types {
 
-/// \brief This message defines the maximum lengths of strings used in MQTT communication
-/// and other identifiers within the VDA5050 specification.
+/// \brief This message defines the maximum lengths of strings used in
+/// MQTT communication and other identifiers within the VDA5050 specification.
 struct MaxStringLens
 {
   /// \brief Maximum MQTT message length.

--- a/vda5050_types/include/vda5050_types/network.hpp
+++ b/vda5050_types/include/vda5050_types/network.hpp
@@ -34,14 +34,17 @@ struct Network
   /// \brief Array of Network Time Protocol (NTP) servers used by the vehicle.
   std::optional<std::vector<std::string>> ntp_servers;
 
-  /// \brief A priori assigned IP address used to communicate with the MQTT broker.
+  /// \brief A priori assigned IP address used to communicate with
+  /// the MQTT broker.
   /// Note: This IP address should not be modified/changed during operations.
   std::optional<std::string> local_ip_address;
 
-  /// \brief The subnet mask used in the network configuration corresponding to the local IP address.
+  /// \brief The subnet mask used in the network configuration corresponding to
+  /// the local IP address.
   std::optional<std::string> netmask;
 
-  /// \brief The default gateway used by the vehicle, corresponding to the local IP address.
+  /// \brief The default gateway used by the vehicle, corresponding to the
+  /// local IP address.
   std::optional<std::string> default_gateway;
 
   /// \brief Equality operator

--- a/vda5050_types/include/vda5050_types/node.hpp
+++ b/vda5050_types/include/vda5050_types/node.hpp
@@ -35,9 +35,10 @@ struct Node
   /// \brief Unique node identification
   std::string node_id;
 
-  /// \brief Number to track the sequence of nodes and edges in an order and to simplify order updates.
-  /// Distinguishes between nodes that may be passed more than once in the same order.
-  /// Runs across all nodes/edges of the same order and resets when a new orderId is issued.
+  /// \brief Number to track the sequence of nodes and edges in an order and to
+  /// simplify order updates. Distinguishes between nodes that may be passed
+  /// more than once in the same order. Runs across all nodes/edges of the same
+  /// order and resets when a new orderId is issued.
   uint32_t sequence_id;
 
   /// \brief "true" indicates that the node is part of the base
@@ -48,8 +49,8 @@ struct Node
   /// Empty array if no actions are required.
   std::vector<Action> actions;
 
-  /// \brief Node position, required only for vehicle-types that need node positions.
-  /// (e.g., not required for line-guided vehicles)
+  /// \brief Node position, required only for vehicle-types that need
+  /// node positions. (e.g., not required for line-guided vehicles)
   std::optional<NodePosition> node_position;
 
   /// \brief Additional information about the node

--- a/vda5050_types/include/vda5050_types/state.hpp
+++ b/vda5050_types/include/vda5050_types/state.hpp
@@ -179,4 +179,4 @@ struct State
 
 }  // namespace vda5050_types
 
-#endif  // VDA5050_TYPES__STATE_HPP
+#endif  // VDA5050_TYPES__STATE_HPP_

--- a/vda5050_types/include/vda5050_types/support_type.hpp
+++ b/vda5050_types/include/vda5050_types/support_type.hpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef VDA5050_TYPES__SUPPORT_TYPE_HPP_
 #define VDA5050_TYPES__SUPPORT_TYPE_HPP_
 

--- a/vda5050_types/include/vda5050_types/wheel_definition.hpp
+++ b/vda5050_types/include/vda5050_types/wheel_definition.hpp
@@ -48,10 +48,12 @@ struct WheelDefinition
   /// \brief Nominal width of the wheel [m].
   double width;
 
-  /// \brief Nominal displacement of the wheel's center to the rotation points. This field is necessary for caster wheels.
+  /// \brief Nominal displacement of the wheel's center to the rotation points.
+  /// This field is necessary for caster wheels.
   double center_displacement = 0.0;
 
-  /// \brief Free-form text: can be used by the manufacturer to define constraints.
+  /// \brief Free-form text: can be used by the manufacturer to define
+  /// constraints.
   std::optional<std::string> constraints;
 
   /// \brief Equality operator


### PR DESCRIPTION
## Summary

This PR is created by cherry picking the remaining commits from [`feat/new-types`](https://github.com/ros-industrial/vda5050_client/tree/feat/new-types). It brings in JSON (de)serialization for connection, state and order messages. Round-trip tests have been added for both C++ structs and ROS 2 messages

Building with ROS 2 support requires the [`throwaway/remove-serde`](https://github.com/ros-industrial/vda5050_interfaces/tree/throwaway/remove-serde) of the `vda5050_interfaces` repository.

Enable ROS 2 support using the following command, this will build (de)serializers for the ROS 2 messages
```bash
colcon build --cmake-args -DENABLE_ROS2=ON
```

## Pending features
- Complete (de)serialization for all the remaining messages
- Add corresponding tests for all the messages