### PR TITLE
feat(mqtt): update mqtt interface with new methods

### DIFF
--- a/vda5050_core/include/vda5050_core/mqtt_client/mqtt_client_interface.hpp
+++ b/vda5050_core/include/vda5050_core/mqtt_client/mqtt_client_interface.hpp
@@ -48,7 +48,8 @@ public:
   /// \param message Raw message string
   /// \param qos Quality of service setting for the publish
   virtual void publish(
-    const std::string& topic, const std::string& message, int qos) = 0;
+    const std::string& topic, const std::string& message, int qos,
+    bool retain = false) = 0;
 
   using MessageHandler =
     std::function<void(const std::string&, const std::string&)>;

--- a/vda5050_core/include/vda5050_core/mqtt_client/mqtt_client_interface.hpp
+++ b/vda5050_core/include/vda5050_core/mqtt_client/mqtt_client_interface.hpp
@@ -39,6 +39,9 @@ public:
   /// \brief Disconnect from the the MQTT broker
   virtual void disconnect() = 0;
 
+  /// \brief Check MQTT connection
+  virtual bool connected() = 0;
+
   /// \brief Publish a message to the MQTT broker
   ///
   /// \param topic Topic for publish
@@ -62,6 +65,14 @@ public:
   ///
   /// \param topic Topic to unsubscribe from
   virtual void unsubscribe(const std::string& topic) = 0;
+
+  /// \brief Set a will message for when the client disconnects abruptly
+  ///
+  /// \param topic Topic to publish will message
+  /// \param message Raw message string
+  /// \param Quality of service setting for the publish
+  virtual void set_will(
+    const std::string& topic, const std::string& message, int qos) = 0;
 };
 
 /// \brief Create a default MQTT client interface

--- a/vda5050_core/include/vda5050_core/mqtt_client/paho_mqtt_client.hpp
+++ b/vda5050_core/include/vda5050_core/mqtt_client/paho_mqtt_client.hpp
@@ -110,7 +110,8 @@ public:
 
   // Documentation inherited from MqttClientInterface
   void publish(
-    const std::string& topic, const std::string& message, int qos) override;
+    const std::string& topic, const std::string& message, int qos,
+    bool retain = false) override;
 
   // Documentation inherited from MqttClientInterface
   void subscribe(

--- a/vda5050_core/include/vda5050_core/mqtt_client/paho_mqtt_client.hpp
+++ b/vda5050_core/include/vda5050_core/mqtt_client/paho_mqtt_client.hpp
@@ -149,6 +149,7 @@ private:
   /// \brief Mutex protecting list of message handlers
   std::mutex handler_mutex_;
 
+  /// \brief MQTT connection options
   mqtt::connect_options conn_options_;
 };
 

--- a/vda5050_core/include/vda5050_core/mqtt_client/paho_mqtt_client.hpp
+++ b/vda5050_core/include/vda5050_core/mqtt_client/paho_mqtt_client.hpp
@@ -23,6 +23,7 @@
 #include <mqtt/callback.h>
 #include <mqtt/connect_options.h>
 #include <mqtt/iaction_listener.h>
+#include <mqtt/will_options.h>
 
 #include <memory>
 #include <mutex>
@@ -105,6 +106,9 @@ public:
   void disconnect() override;
 
   // Documentation inherited from MqttClientInterface
+  bool connected() override;
+
+  // Documentation inherited from MqttClientInterface
   void publish(
     const std::string& topic, const std::string& message, int qos) override;
 
@@ -114,6 +118,10 @@ public:
 
   // Documentation inherited from MqttClientInterface
   void unsubscribe(const std::string& topic) override;
+
+  // Documentation inherited from MqttClientInterface
+  void set_will(
+    const std::string& topic, const std::string& message, int qos) override;
 
   friend class MqttCallback;
 
@@ -139,6 +147,8 @@ private:
 
   /// \brief Mutex protecting list of message handlers
   std::mutex handler_mutex_;
+
+  mqtt::connect_options conn_options_;
 };
 
 }  // namespace mqtt_client

--- a/vda5050_core/include/vda5050_core/mqtt_client/paho_mqtt_client.hpp
+++ b/vda5050_core/include/vda5050_core/mqtt_client/paho_mqtt_client.hpp
@@ -124,6 +124,11 @@ public:
   void set_will(
     const std::string& topic, const std::string& message, int qos) override;
 
+  /// \brief Get a mutable reference to Paho configuration options
+  ///
+  /// \return Mutable reference to Paho configuration options
+  mqtt::connect_options& connect_options();
+
   friend class MqttCallback;
 
 private:

--- a/vda5050_core/src/vda5050_core/mqtt_client/paho_mqtt_client.cpp
+++ b/vda5050_core/src/vda5050_core/mqtt_client/paho_mqtt_client.cpp
@@ -144,7 +144,7 @@ bool PahoMqttClient::connected()
 
 //=============================================================================
 void PahoMqttClient::publish(
-  const std::string& topic, const std::string& message, int qos)
+  const std::string& topic, const std::string& message, int qos, bool retain)
 {
   try
   {
@@ -152,6 +152,7 @@ void PahoMqttClient::publish(
     msg->set_topic(topic);
     msg->set_payload(message);
     msg->set_qos(qos);
+    msg->set_retained(retain);
 
     client_->publish(msg)->wait();
   }

--- a/vda5050_core/src/vda5050_core/mqtt_client/paho_mqtt_client.cpp
+++ b/vda5050_core/src/vda5050_core/mqtt_client/paho_mqtt_client.cpp
@@ -109,15 +109,7 @@ void PahoMqttClient::connect()
 
   try
   {
-    mqtt::connect_options conn_options;
-    conn_options.set_mqtt_version(4);
-    conn_options.set_clean_session(false);
-    conn_options.set_user_name("");
-    conn_options.set_password("");
-    conn_options.set_automatic_reconnect(true);
-    conn_options.set_automatic_reconnect(2, 32);
-
-    client_->connect(conn_options, nullptr, action_listener_)->wait();
+    client_->connect(conn_options_, nullptr, action_listener_)->wait();
   }
   catch (const mqtt::exception& e)
   {
@@ -142,6 +134,12 @@ void PahoMqttClient::disconnect()
       VDA5050_ERROR_STREAM("MQTT disconnection failed: " << e.get_message());
     }
   }
+}
+
+//=============================================================================
+bool PahoMqttClient::connected()
+{
+  return client_->is_connected();
 }
 
 //=============================================================================
@@ -195,6 +193,19 @@ void PahoMqttClient::unsubscribe(const std::string& topic)
 }
 
 //=============================================================================
+void PahoMqttClient::set_will(
+  const std::string& topic, const std::string& message, int qos)
+{
+  mqtt::will_options will;
+  will.set_topic(topic);
+  will.set_retained(true);
+  will.set_qos(qos);
+  will.set_payload(message);
+
+  conn_options_.set_will(will);
+}
+
+//=============================================================================
 PahoMqttClient::PahoMqttClient(
   const std::string& broker_address, const std::string& client_id)
 : client_(std::make_unique<mqtt::async_client>(broker_address, client_id)),
@@ -202,6 +213,13 @@ PahoMqttClient::PahoMqttClient(
   callback_(MqttCallback(*this))
 {
   client_->set_callback(callback_);
+
+  conn_options_.set_mqtt_version(4);
+  conn_options_.set_clean_session(false);
+  conn_options_.set_user_name("");
+  conn_options_.set_password("");
+  conn_options_.set_automatic_reconnect(true);
+  conn_options_.set_automatic_reconnect(2, 32);
 }
 
 }  // namespace mqtt_client

--- a/vda5050_core/src/vda5050_core/mqtt_client/paho_mqtt_client.cpp
+++ b/vda5050_core/src/vda5050_core/mqtt_client/paho_mqtt_client.cpp
@@ -207,6 +207,12 @@ void PahoMqttClient::set_will(
 }
 
 //=============================================================================
+mqtt::connect_options& PahoMqttClient::connect_options()
+{
+  return conn_options_;
+}
+
+//=============================================================================
 PahoMqttClient::PahoMqttClient(
   const std::string& broker_address, const std::string& client_id)
 : client_(std::make_unique<mqtt::async_client>(broker_address, client_id)),

--- a/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
+++ b/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
@@ -35,6 +35,7 @@ TEST(PahoMqttClientTest, PublishSubscribe)
   auto listener =
     vda5050_core::mqtt_client::create_default_client(broker, "listener");
   ASSERT_NO_THROW(listener->connect());
+  ASSERT_TRUE(listener->connected());
   ASSERT_NO_THROW(listener->subscribe(
     topic,
     [&](const std::string& topic_, const std::string& payload_) {

--- a/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
+++ b/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
@@ -113,6 +113,7 @@ TEST(PahoMqttClient, LastWill)
     vda5050_core::mqtt_client::PahoMqttClient::make(broker, "last_will_client");
   ASSERT_NO_THROW(client->set_will(topic, payload, qos));
   ASSERT_NO_THROW(client->connect());
+  ASSERT_TRUE(client->connected());
 
   ASSERT_EQ(client->connect_options().get_will_topic(), topic);
   ASSERT_EQ(client->connect_options().get_will_message()->to_string(), payload);

--- a/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
+++ b/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
@@ -101,3 +101,21 @@ TEST(PahoMqttClientTest, UnsubscribeStopsMessages)
   ASSERT_NO_THROW(talker->disconnect());
   ASSERT_NO_THROW(listener->disconnect());
 }
+
+TEST(PahoMqttClient, LastWill)
+{
+  std::string broker = "tcp://test.mosquitto.org:1883";
+  std::string topic = "/test/integration/unsubscribe";
+  std::string payload = "hello";
+  int qos = 0;
+
+  auto client =
+    vda5050_core::mqtt_client::PahoMqttClient::make(broker, "last_will_client");
+  ASSERT_NO_THROW(client->set_will(topic, payload, qos));
+  ASSERT_NO_THROW(client->connect());
+
+  ASSERT_EQ(client->connect_options().get_will_topic(), topic);
+  ASSERT_EQ(client->connect_options().get_will_message()->to_string(), payload);
+
+  ASSERT_NO_THROW(client->disconnect());
+}

--- a/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
+++ b/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
@@ -22,6 +22,7 @@
 #include <thread>
 
 #include "vda5050_core/mqtt_client/mqtt_client_interface.hpp"
+#include "vda5050_core/mqtt_client/paho_mqtt_client.hpp"
 
 TEST(PahoMqttClientTest, PublishSubscribe)
 {
@@ -30,16 +31,16 @@ TEST(PahoMqttClientTest, PublishSubscribe)
   std::string payload = "hello";
   int qos = 0;
 
-  std::atomic_bool received = false;
+  std::atomic_int message_count{0};
 
   auto listener =
-    vda5050_core::mqtt_client::create_default_client(broker, "listener");
+    vda5050_core::mqtt_client::PahoMqttClient::make(broker, "listener");
   ASSERT_NO_THROW(listener->connect());
   ASSERT_TRUE(listener->connected());
   ASSERT_NO_THROW(listener->subscribe(
     topic,
     [&](const std::string& topic_, const std::string& payload_) {
-      received = true;
+      message_count++;
       ASSERT_EQ(topic, topic_);
       ASSERT_EQ(payload, payload_);
     },
@@ -52,7 +53,7 @@ TEST(PahoMqttClientTest, PublishSubscribe)
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
-  ASSERT_TRUE(received);
+  ASSERT_EQ(message_count, 1);
 
   ASSERT_NO_THROW(talker->disconnect());
   ASSERT_NO_THROW(listener->disconnect());
@@ -68,7 +69,7 @@ TEST(PahoMqttClientTest, UnsubscribeStopsMessages)
   std::atomic_int message_count{0};
 
   auto listener =
-    vda5050_core::mqtt_client::create_default_client(broker, "unsub_listener");
+    vda5050_core::mqtt_client::PahoMqttClient::make(broker, "unsub_listener");
   ASSERT_NO_THROW(listener->connect());
   ASSERT_NO_THROW(listener->subscribe(
     topic,

--- a/vda5050_core/test/unit/mqtt_client/test_mqtt_client_interface.cpp
+++ b/vda5050_core/test/unit/mqtt_client/test_mqtt_client_interface.cpp
@@ -27,7 +27,8 @@ public:
   MOCK_METHOD(void, disconnect, (), (override));
   MOCK_METHOD(bool, connected, (), (override));
   MOCK_METHOD(
-    void, publish, (const std::string&, const std::string&, int), (override));
+    void, publish, (const std::string&, const std::string&, int, bool),
+    (override));
   MOCK_METHOD(
     void, subscribe,
     (const std::string&,
@@ -62,8 +63,8 @@ TEST(MqttClientInterfaceTest, CheckConnection)
 TEST(MqttClientInterfaceTest, PublishMessage)
 {
   MockMqttClient mock;
-  EXPECT_CALL(mock, publish("topic", "{payload: 'data'}", 0)).Times(1);
-  mock.publish("topic", "{payload: 'data'}", 0);
+  EXPECT_CALL(mock, publish("topic", "{payload: 'data'}", 0, false)).Times(1);
+  mock.publish("topic", "{payload: 'data'}", 0, false);
 }
 
 TEST(MqttClientInterfaceTest, SubscribeTopic)

--- a/vda5050_core/test/unit/mqtt_client/test_mqtt_client_interface.cpp
+++ b/vda5050_core/test/unit/mqtt_client/test_mqtt_client_interface.cpp
@@ -25,6 +25,7 @@ class MockMqttClient : public vda5050_core::mqtt_client::MqttClientInterface
 public:
   MOCK_METHOD(void, connect, (), (override));
   MOCK_METHOD(void, disconnect, (), (override));
+  MOCK_METHOD(bool, connected, (), (override));
   MOCK_METHOD(
     void, publish, (const std::string&, const std::string&, int), (override));
   MOCK_METHOD(
@@ -33,6 +34,8 @@ public:
      std::function<void(const std::string&, const std::string&)>, int),
     (override));
   MOCK_METHOD(void, unsubscribe, (const std::string&), (override));
+  MOCK_METHOD(
+    void, set_will, (const std::string&, const std::string&, int), (override));
 };
 
 TEST(MqttClientInterfaceTest, ConnectCall)
@@ -47,6 +50,13 @@ TEST(MqttClientInterfaceTest, DisconnectCall)
   MockMqttClient mock;
   EXPECT_CALL(mock, disconnect()).Times(1);
   mock.disconnect();
+}
+
+TEST(MqttClientInterfaceTest, CheckConnection)
+{
+  MockMqttClient mock;
+  EXPECT_CALL(mock, connected()).Times(1);
+  mock.connected();
 }
 
 TEST(MqttClientInterfaceTest, PublishMessage)
@@ -69,4 +79,11 @@ TEST(MqttClientInterfaceTest, UnsubscribeTopic)
   MockMqttClient mock;
   EXPECT_CALL(mock, unsubscribe("topic")).Times(1);
   mock.unsubscribe("topic");
+}
+
+TEST(MqttClientInterfaceTest, SetWill)
+{
+  MockMqttClient mock;
+  EXPECT_CALL(mock, set_will("topic", "{payload: 'data'}", 1)).Times(1);
+  mock.set_will("topic", "{payload: 'data'}", 1);
 }

--- a/vda5050_json_utils/CMakeLists.txt
+++ b/vda5050_json_utils/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(vda5050_types REQUIRED)
 find_package(nlohmann_json REQUIRED)
-find_package(vda5050_msgs REQUIRED)
 
 include(GNUInstallDirs)
 
@@ -64,7 +63,6 @@ ament_export_targets(export_vda5050_json_utils HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   nlohmann_json
   vda5050_types
-  vda5050_msgs
 )
 
 if(ENABLE_ROS2)


### PR DESCRIPTION
## Summary

This PR adds 2 new methods to the MQTT interface and modifies an existing method. It also updates the Paho client and unit tests to reflect the changes.

New methods added,
- `connected()` - Check MQTT connection status
- `set_will(...)` - Set a last will message that will be sent when the client disconnects abruptly

Existing methods updated,
- `publish(...)` - A new `boolean` flag has been added to allow users to indicate if this message should be retained in the broker