### PR TITLE
Feat (CI) : Run Mosquitto in workflows to spin up local 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -qq -y
-          apt-get install libpaho-mqtt-dev libpaho-mqttpp-dev libfmt-dev -qq -y
+          apt-get install libpaho-mqtt-dev libpaho-mqttpp-dev libfmt-dev mosquitto -qq -y
+      - name: Start MQTT broker
+        run: |
+          mosquitto -d
+          sleep 2  # Wait for broker to start
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{ matrix.env }}

--- a/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
+++ b/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
@@ -26,7 +26,7 @@
 
 TEST(PahoMqttClientTest, PublishSubscribe)
 {
-  std::string broker = "tcp://test.mosquitto.org:1883";
+  std::string broker = "tcp://localhost:1883";
   std::string topic = "/test/integration";
   std::string payload = "hello";
   int qos = 0;
@@ -61,7 +61,7 @@ TEST(PahoMqttClientTest, PublishSubscribe)
 
 TEST(PahoMqttClientTest, UnsubscribeStopsMessages)
 {
-  std::string broker = "tcp://test.mosquitto.org:1883";
+  std::string broker = "tcp://localhost:1883";
   std::string topic = "/test/integration/unsubscribe";
   std::string payload = "hello";
   int qos = 0;
@@ -104,7 +104,7 @@ TEST(PahoMqttClientTest, UnsubscribeStopsMessages)
 
 TEST(PahoMqttClient, LastWill)
 {
-  std::string broker = "tcp://test.mosquitto.org:1883";
+  std::string broker = "tcp://localhost:1883";
   std::string topic = "/test/integration/unsubscribe";
   std::string payload = "hello";
   int qos = 0;


### PR DESCRIPTION
As mentioned by @sauk2 , the `test.mosquitto.org:1883` server is relatively flaky and is not advised to be used for public testing of infrastructure. to prevent constant CI failures from intermittent downtime of the server, this PR attempts to add in a step to run mosquitto locally for testing. 