### PR TITLE
feat(humble): add support for humble

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,23 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env:
-          - ICI_JOB_NAME: gcc
-            ROS_DISTRO: jazzy
-            UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
-            TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'
-          - ICI_JOB_NAME: clang
-            ROS_DISTRO: jazzy
-            UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
-            ADDITIONAL_DEBS: clang lld
-            CC: "clang"
-            CXX: "clang++"
-            TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'
+        distro: [humble, foxy]
+        compiler: [gcc, clang]
     env:
       ISOLATION: "shell"
     runs-on: ubuntu-latest
     container:
-      image: ros:jazzy-ros-core
+      image: ros:${{ matrix.distro }}-ros-core
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -41,5 +31,22 @@ jobs:
         run: |
           mosquitto -d
           sleep 2  # Wait for broker to start
-      - uses: 'ros-industrial/industrial_ci@master'
-        env: ${{ matrix.env }}
+
+      # GCC
+      - if: ${{ matrix.comiler == 'gcc' }}
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_DISTRO: ${{ matrix.distro }}
+          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
+          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'
+
+      # Clang
+      - if: ${{ matrix.comiler == 'clang' }}
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_DISTRO: ${{ matrix.distro }}
+          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
+          ADDITIONAL_DEBS: clang lld
+          CC: "clang"
+          CXX: "clang++"
+          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [humble, foxy]
+        distro: [humble, jazzy]
         compiler: [gcc, clang]
     env:
       ISOLATION: "shell"
@@ -34,7 +34,7 @@ jobs:
           sleep 2  # Wait for broker to start
 
       # GCC
-      - if: ${{ matrix.comiler == 'gcc' }}
+      - if: ${{ matrix.compiler == 'gcc' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_DISTRO: ${{ matrix.distro }}
@@ -42,7 +42,7 @@ jobs:
           TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'
 
       # Clang
-      - if: ${{ matrix.comiler == 'clang' }}
+      - if: ${{ matrix.compiler == 'clang' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - develop
+      - feature/add-humble-ci
 
 jobs:
   industrial_ci:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - develop
-      - feature/add-humble-ci
 
 jobs:
   industrial_ci:

--- a/cmake/vda5050_lint_common.cmake
+++ b/cmake/vda5050_lint_common.cmake
@@ -1,0 +1,60 @@
+# Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+# Advanced Remanufacturing and Technology Centre
+# A*STAR Research Entities (Co. Registration No. 199702110H)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Run common linters for VDA5050
+#
+
+function(vda5050_lint_common)
+  find_package(ament_cmake_cppcheck REQUIRED)
+  ament_cppcheck()
+
+  find_package(ament_cmake_cpplint REQUIRED)
+  set(cpplint_filters
+    "-whitespace/newline"
+  )
+  ament_cpplint(
+    FILTERS "${cpplint_filters}"
+  )
+
+  # Only run ament_clang_format for 16.0.0 and higher
+  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
+  if(CLANG_FORMAT_EXECUTABLE)
+    execute_process(
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} --version
+        OUTPUT_VARIABLE CLANG_FORMAT_VERSION_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # Parse the version number from the output
+    # The output typically looks something like: "<platform> clang-format version 17.0.6-<platform-version>"
+    string(REGEX REPLACE ".*version \([0-9.]\+\).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION_OUTPUT}")
+
+    message(STATUS "clang-format version: ${CLANG_FORMAT_VERSION}")
+    if(CLANG_FORMAT_VERSION VERSION_GREATER_EQUAL "16.0.0")
+      find_package(ament_cmake_clang_format REQUIRED)
+      ament_clang_format(
+        CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
+      )
+    endif()
+  endif()
+
+  # Disable copyright check for older ament_copyright versions
+  find_package(ament_cmake_copyright 0.13.3 QUIET)
+  if(ament_cmake_copyright_FOUND)
+    ament_copyright()
+  endif()
+endfunction()

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -93,13 +93,33 @@ if(BUILD_TESTING)
     FILTERS "${cpplint_filters}"
   )
 
-  find_package(ament_cmake_clang_format REQUIRED)
-  ament_clang_format(
-    CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
-  )
+  # Only run ament_clang_format for 16.0.0 and higher
+  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
+  if(CLANG_FORMAT_EXECUTABLE)
+    execute_process(
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} --version
+        OUTPUT_VARIABLE CLANG_FORMAT_VERSION_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-  find_package(ament_cmake_copyright REQUIRED)
-  ament_copyright()
+    # Parse the version number from the output
+    # The output typically looks something like: "<platform> clang-format version 17.0.6-<platform-version>"
+    string(REGEX REPLACE ".*version \([0-9.]\+\).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION_OUTPUT}")
+
+    message(STATUS "clang-format version: ${CLANG_FORMAT_VERSION}")
+    if(CLANG_FORMAT_VERSION VERSION_GREATER_EQUAL "16.0.0")
+      find_package(ament_cmake_clang_format REQUIRED)
+      ament_clang_format(
+        CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
+      )
+    endif()
+  endif()
+
+  # Disable copyright check for older ament_copyright versions
+  find_package(ament_cmake_copyright 0.13.3 QUIET)
+  if(ament_cmake_copyright_FOUND)
+    ament_copyright()
+  endif()
 
   find_package(ament_cmake_gmock REQUIRED)
   ament_add_gmock(test_mqtt_client

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -86,44 +86,8 @@ ament_export_targets(export_vda5050_core HAS_LIBRARY_TARGET)
 ament_export_dependencies(PahoMqttCpp fmt)
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  ament_cppcheck()
-
-  find_package(ament_cmake_cpplint REQUIRED)
-  set(cpplint_filters
-    "-whitespace/newline"
-  )
-  ament_cpplint(
-    FILTERS "${cpplint_filters}"
-  )
-
-  # Only run ament_clang_format for 16.0.0 and higher
-  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
-  if(CLANG_FORMAT_EXECUTABLE)
-    execute_process(
-        COMMAND ${CLANG_FORMAT_EXECUTABLE} --version
-        OUTPUT_VARIABLE CLANG_FORMAT_VERSION_OUTPUT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-    # Parse the version number from the output
-    # The output typically looks something like: "<platform> clang-format version 17.0.6-<platform-version>"
-    string(REGEX REPLACE ".*version \([0-9.]\+\).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION_OUTPUT}")
-
-    message(STATUS "clang-format version: ${CLANG_FORMAT_VERSION}")
-    if(CLANG_FORMAT_VERSION VERSION_GREATER_EQUAL "16.0.0")
-      find_package(ament_cmake_clang_format REQUIRED)
-      ament_clang_format(
-        CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
-      )
-    endif()
-  endif()
-
-  # Disable copyright check for older ament_copyright versions
-  find_package(ament_cmake_copyright 0.13.3 QUIET)
-  if(ament_cmake_copyright_FOUND)
-    ament_copyright()
-  endif()
+  include(../cmake/vda5050_lint_common.cmake)
+  vda5050_lint_common()
 
   find_package(ament_cmake_gmock REQUIRED)
   ament_add_gmock(test_mqtt_client

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
 project(vda5050_core)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
+++ b/vda5050_core/test/integration/mqtt_client/test_paho_mqtt_client.cpp
@@ -18,6 +18,7 @@
 
 #include <gmock/gmock.h>
 
+#include <atomic>
 #include <chrono>
 #include <thread>
 

--- a/vda5050_json_utils/CMakeLists.txt
+++ b/vda5050_json_utils/CMakeLists.txt
@@ -73,46 +73,8 @@ if(ENABLE_ROS2)
 endif()
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  ament_cppcheck()
-
-  find_package(ament_cmake_cpplint REQUIRED)
-
-  set(cpplint_filters
-    "-whitespace/newline"
-  )
-
-  ament_cpplint(
-    FILTERS "${cpplint_filters}"
-  )
-
-  # Only run ament_clang_format for 16.0.0 and higher
-  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
-  if(CLANG_FORMAT_EXECUTABLE)
-    execute_process(
-        COMMAND ${CLANG_FORMAT_EXECUTABLE} --version
-        OUTPUT_VARIABLE CLANG_FORMAT_VERSION_OUTPUT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-    # Parse the version number from the output
-    # The output typically looks something like: "<platform> clang-format version 17.0.6-<platform-version>"
-    string(REGEX REPLACE ".*version \([0-9.]\+\).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION_OUTPUT}")
-
-    message(STATUS "clang-format version: ${CLANG_FORMAT_VERSION}")
-    if(CLANG_FORMAT_VERSION VERSION_GREATER_EQUAL "16.0.0")
-      find_package(ament_cmake_clang_format REQUIRED)
-      ament_clang_format(
-        CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
-      )
-    endif()
-  endif()
-
-  # Disable copyright check for older ament_copyright versions
-  find_package(ament_cmake_copyright 0.13.3 QUIET)
-  if(ament_cmake_copyright_FOUND)
-    ament_copyright()
-  endif()
+  include(../cmake/vda5050_lint_common.cmake)
+  vda5050_lint_common()
 
   find_package(ament_cmake_gtest REQUIRED)
 

--- a/vda5050_json_utils/CMakeLists.txt
+++ b/vda5050_json_utils/CMakeLists.txt
@@ -83,13 +83,33 @@ if(BUILD_TESTING)
     FILTERS "${cpplint_filters}"
   )
 
-  find_package(ament_cmake_clang_format REQUIRED)
-  ament_clang_format(
-    CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
-  )
+  # Only run ament_clang_format for 16.0.0 and higher
+  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
+  if(CLANG_FORMAT_EXECUTABLE)
+    execute_process(
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} --version
+        OUTPUT_VARIABLE CLANG_FORMAT_VERSION_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-  find_package(ament_cmake_copyright REQUIRED)
-  ament_copyright()
+    # Parse the version number from the output
+    # The output typically looks something like: "<platform> clang-format version 17.0.6-<platform-version>"
+    string(REGEX REPLACE ".*version \([0-9.]\+\).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION_OUTPUT}")
+
+    message(STATUS "clang-format version: ${CLANG_FORMAT_VERSION}")
+    if(CLANG_FORMAT_VERSION VERSION_GREATER_EQUAL "16.0.0")
+      find_package(ament_cmake_clang_format REQUIRED)
+      ament_clang_format(
+        CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
+      )
+    endif()
+  endif()
+
+  # Disable copyright check for older ament_copyright versions
+  find_package(ament_cmake_copyright 0.13.3 QUIET)
+  if(ament_cmake_copyright_FOUND)
+    ament_copyright()
+  endif()
 
   find_package(ament_cmake_gtest REQUIRED)
 

--- a/vda5050_json_utils/CMakeLists.txt
+++ b/vda5050_json_utils/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 project(vda5050_json_utils)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/vda5050_types/CMakeLists.txt
+++ b/vda5050_types/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 project(vda5050_types)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/vda5050_types/CMakeLists.txt
+++ b/vda5050_types/CMakeLists.txt
@@ -37,13 +37,33 @@ if(BUILD_TESTING)
   find_package(ament_cmake_cpplint REQUIRED)
   ament_cpplint()
 
-  find_package(ament_cmake_clang_format REQUIRED)
-  ament_clang_format(
-    CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
-  )
+  # Only run ament_clang_format for 16.0.0 and higher
+  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
+  if(CLANG_FORMAT_EXECUTABLE)
+    execute_process(
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} --version
+        OUTPUT_VARIABLE CLANG_FORMAT_VERSION_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-  find_package(ament_cmake_copyright REQUIRED)
-  ament_copyright()
+    # Parse the version number from the output
+    # The output typically looks something like: "<platform> clang-format version 17.0.6-<platform-version>"
+    string(REGEX REPLACE ".*version \([0-9.]\+\).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION_OUTPUT}")
+
+    message(STATUS "clang-format version: ${CLANG_FORMAT_VERSION}")
+    if(CLANG_FORMAT_VERSION VERSION_GREATER_EQUAL "16.0.0")
+      find_package(ament_cmake_clang_format REQUIRED)
+      ament_clang_format(
+        CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
+      )
+    endif()
+  endif()
+
+  # Disable copyright check for older ament_copyright versions
+  find_package(ament_cmake_copyright 0.13.3 QUIET)
+  if(ament_cmake_copyright_FOUND)
+    ament_copyright()
+  endif()
 endif()
 
 ament_package()

--- a/vda5050_types/CMakeLists.txt
+++ b/vda5050_types/CMakeLists.txt
@@ -34,39 +34,8 @@ ament_export_include_directories(include)
 ament_export_targets(export_vda5050_types HAS_LIBRARY_TARGET)
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  ament_cppcheck()
-
-  find_package(ament_cmake_cpplint REQUIRED)
-  ament_cpplint()
-
-  # Only run ament_clang_format for 16.0.0 and higher
-  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
-  if(CLANG_FORMAT_EXECUTABLE)
-    execute_process(
-        COMMAND ${CLANG_FORMAT_EXECUTABLE} --version
-        OUTPUT_VARIABLE CLANG_FORMAT_VERSION_OUTPUT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-    # Parse the version number from the output
-    # The output typically looks something like: "<platform> clang-format version 17.0.6-<platform-version>"
-    string(REGEX REPLACE ".*version \([0-9.]\+\).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION_OUTPUT}")
-
-    message(STATUS "clang-format version: ${CLANG_FORMAT_VERSION}")
-    if(CLANG_FORMAT_VERSION VERSION_GREATER_EQUAL "16.0.0")
-      find_package(ament_cmake_clang_format REQUIRED)
-      ament_clang_format(
-        CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
-      )
-    endif()
-  endif()
-
-  # Disable copyright check for older ament_copyright versions
-  find_package(ament_cmake_copyright 0.13.3 QUIET)
-  if(ament_cmake_copyright_FOUND)
-    ament_copyright()
-  endif()
+  include(../cmake/vda5050_lint_common.cmake)
+  vda5050_lint_common()
 endif()
 
 ament_package()


### PR DESCRIPTION
This PR fixes the build issues for gcc-11, clang-14, 22.04 and humble.

Key changes
- Enable humble build as matrix strategy in GHA, this should make adding new distros easier
- resolve #26 ([failed jobs](https://github.com/Briancbn/vda5050_client/actions/runs/20983794175))
- add c++ 17 to address `std::optional` not found from clang 14 ([failed jobs](https://github.com/Briancbn/vda5050_client/actions/runs/21023979259))
- Only enable linters at their minimal supported versions, as they only ships with 24.04 and jazzy.