### PR TITLE
feat(json_utils): add (de)serialization for instant actions

### DIFF
--- a/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/serialization.hpp
@@ -1585,6 +1585,28 @@ void from_json(const nlohmann::json& j, OrderT& msg)
 
 }  // namespace order_detail
 
+namespace instant_actions_detail {
+
+//=============================================================================
+template <typename InstantActionsT>
+void to_json(nlohmann::json& j, const InstantActionsT& msg)
+{
+  to_json(j, msg.header);
+
+  j["actions"] = msg.actions;
+}
+
+//=============================================================================
+template <typename InstantActionsT>
+void from_json(const nlohmann::json& j, InstantActionsT& msg)
+{
+  from_json(j, msg.header);
+
+  msg.actions = j.at("actions");
+}
+
+}  // namespace instant_actions_detail
+
 }  // namespace vda5050_types
 
 //=============================================================================
@@ -1840,14 +1862,14 @@ inline void from_json(const nlohmann::json& j, Order& msg)
   vda5050_types::order_detail::from_json(j, msg);
 }
 
-inline void to_json(nlohmann::json& /*j*/, const InstantActions& /*msg*/)
+inline void to_json(nlohmann::json& j, const InstantActions& msg)
 {
-  // TODO(sauk): Add missing serialization
+  vda5050_types::instant_actions_detail::to_json(j, msg);
 }
 
-inline void from_json(const nlohmann::json& /*j*/, InstantActions& /*msg*/)
+inline void from_json(const nlohmann::json& j, InstantActions& msg)
 {
-  // TODO(sauk): Add missing deserialization
+  vda5050_types::instant_actions_detail::from_json(j, msg);
 }
 
 inline void to_json(nlohmann::json& /*j*/, const Factsheet& /*msg*/)
@@ -2128,14 +2150,14 @@ inline void from_json(const nlohmann::json& j, Order& msg)
   vda5050_types::order_detail::from_json(j, msg);
 }
 
-inline void to_json(nlohmann::json& /*j*/, const InstantActions& /*msg*/)
+inline void to_json(nlohmann::json& j, const InstantActions& msg)
 {
-  // TODO(sauk): Add missing serialization
+  vda5050_types::instant_actions_detail::to_json(j, msg);
 }
 
-inline void from_json(const nlohmann::json& /*j*/, InstantActions& /*msg*/)
+inline void from_json(const nlohmann::json& j, InstantActions& msg)
 {
-  // TODO(sauk): Add missing deserialization
+  vda5050_types::instant_actions_detail::from_json(j, msg);
 }
 
 inline void to_json(nlohmann::json& /*j*/, const Factsheet& /*msg*/)

--- a/vda5050_json_utils/test/generator/generator.hpp
+++ b/vda5050_json_utils/test/generator/generator.hpp
@@ -46,6 +46,7 @@
 #include <vda5050_types/info.hpp>
 #include <vda5050_types/info_level.hpp>
 #include <vda5050_types/info_reference.hpp>
+#include <vda5050_types/instant_actions.hpp>
 #include <vda5050_types/load.hpp>
 #include <vda5050_types/load_dimensions.hpp>
 #include <vda5050_types/node.hpp>
@@ -80,6 +81,7 @@ using vda5050_types::Header;
 using vda5050_types::Info;
 using vda5050_types::InfoLevel;
 using vda5050_types::InfoReference;
+using vda5050_types::InstantActions;
 using vda5050_types::Load;
 using vda5050_types::LoadDimensions;
 using vda5050_types::Node;
@@ -425,6 +427,11 @@ public:
       msg.bounding_box_reference = generate<BoundingBoxReference>();
       msg.load_dimensions = generate<LoadDimensions>();
       msg.weight = generate_random_float();
+    }
+    else if constexpr (std::is_same_v<T, InstantActions>)
+    {
+      msg.header = generate<Header>();
+      msg.actions = generate_random_vector<Action>(generate_random_size());
     }
     else if constexpr (std::is_same_v<T, LoadDimensions>)
     {

--- a/vda5050_json_utils/test/generator/generator_ros2.hpp
+++ b/vda5050_json_utils/test/generator/generator_ros2.hpp
@@ -39,6 +39,7 @@
 #include <vda5050_interfaces/msg/header.hpp>
 #include <vda5050_interfaces/msg/info.hpp>
 #include <vda5050_interfaces/msg/info_reference.hpp>
+#include <vda5050_interfaces/msg/instant_actions.hpp>
 #include <vda5050_interfaces/msg/load.hpp>
 #include <vda5050_interfaces/msg/load_dimensions.hpp>
 #include <vda5050_interfaces/msg/node.hpp>
@@ -65,6 +66,7 @@ using vda5050_interfaces::msg::ErrorReference;
 using vda5050_interfaces::msg::Header;
 using vda5050_interfaces::msg::Info;
 using vda5050_interfaces::msg::InfoReference;
+using vda5050_interfaces::msg::InstantActions;
 using vda5050_interfaces::msg::Load;
 using vda5050_interfaces::msg::LoadDimensions;
 using vda5050_interfaces::msg::Node;
@@ -421,6 +423,11 @@ public:
     {
       msg.reference_key = generate_random_string();
       msg.reference_value = generate_random_string();
+    }
+    else if constexpr (std::is_same_v<T, InstantActions>)
+    {
+      msg.header = generate<Header>();
+      msg.actions = generate_random_vector<Action>(generate_random_size());
     }
     else if constexpr (std::is_same_v<T, Load>)
     {

--- a/vda5050_json_utils/test/test_json_utils.cpp
+++ b/vda5050_json_utils/test/test_json_utils.cpp
@@ -33,6 +33,7 @@
 #include <vda5050_types/header.hpp>
 #include <vda5050_types/info.hpp>
 #include <vda5050_types/info_reference.hpp>
+#include <vda5050_types/instant_actions.hpp>
 #include <vda5050_types/load.hpp>
 #include <vda5050_types/load_dimensions.hpp>
 #include <vda5050_types/node.hpp>
@@ -63,6 +64,7 @@ using vda5050_types::ErrorReference;
 using vda5050_types::Header;
 using vda5050_types::Info;
 using vda5050_types::InfoReference;
+using vda5050_types::InstantActions;
 using vda5050_types::Load;
 using vda5050_types::LoadDimensions;
 using vda5050_types::Node;
@@ -78,8 +80,9 @@ using vda5050_types::Velocity;
 using SerializableTypes = ::testing::Types<
   Action, ActionParameter, ActionState, AGVPosition, BatteryState,
   BoundingBoxReference, Connection, ControlPoint, Edge, EdgeState, Error,
-  ErrorReference, Header, Info, InfoReference, Load, LoadDimensions, Node,
-  NodePosition, NodeState, Order, SafetyState, State, Trajectory, Velocity>;
+  ErrorReference, Header, Info, InfoReference, InstantActions, Load,
+  LoadDimensions, Node, NodePosition, NodeState, Order, SafetyState, State,
+  Trajectory, Velocity>;
 
 template <typename T>
 class SerializationTest : public ::testing::Test

--- a/vda5050_json_utils/test/test_json_utils_ros2.cpp
+++ b/vda5050_json_utils/test/test_json_utils_ros2.cpp
@@ -35,6 +35,7 @@
 #include <vda5050_interfaces/msg/header.hpp>
 #include <vda5050_interfaces/msg/info.hpp>
 #include <vda5050_interfaces/msg/info_reference.hpp>
+#include <vda5050_interfaces/msg/instant_actions.hpp>
 #include <vda5050_interfaces/msg/load.hpp>
 #include <vda5050_interfaces/msg/load_dimensions.hpp>
 #include <vda5050_interfaces/msg/node.hpp>
@@ -65,6 +66,7 @@ using vda5050_interfaces::msg::ErrorReference;
 using vda5050_interfaces::msg::Header;
 using vda5050_interfaces::msg::Info;
 using vda5050_interfaces::msg::InfoReference;
+using vda5050_interfaces::msg::InstantActions;
 using vda5050_interfaces::msg::Load;
 using vda5050_interfaces::msg::LoadDimensions;
 using vda5050_interfaces::msg::Node;
@@ -80,8 +82,9 @@ using vda5050_interfaces::msg::Velocity;
 using SerializableTypesROS2 = ::testing::Types<
   Action, ActionParameter, ActionState, AGVPosition, BatteryState,
   BoundingBoxReference, Connection, ControlPoint, Edge, EdgeState, Error,
-  ErrorReference, Header, Info, InfoReference, Load, LoadDimensions, Node,
-  NodePosition, NodeState, Order, SafetyState, State, Trajectory, Velocity>;
+  ErrorReference, Header, Info, InfoReference, InstantActions, Load,
+  LoadDimensions, Node, NodePosition, NodeState, Order, SafetyState, State,
+  Trajectory, Velocity>;
 
 template <typename T>
 class SerializationTestROS2 : public ::testing::Test


### PR DESCRIPTION
## Summary

This PR adds serialization/deserialization for instant actions structs (C++ and ROS 2). Added random data generation and roundtrip test. 