### PR TITLE
Feat (VDA5050 master) : Using`vda5050_execution::ProtocolAdapter` to manage Pub/Sub

### DIFF
--- a/vda5050_master/CMakeLists.txt
+++ b/vda5050_master/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(vda5050_core REQUIRED)
+find_package(vda5050_execution REQUIRED)
 find_package(vda5050_types REQUIRED)
 find_package(vda5050_json_utils REQUIRED)
 find_package(fmt REQUIRED)
@@ -26,6 +27,7 @@ add_library(vda5050_master
 
 ament_target_dependencies(vda5050_master
   vda5050_core
+  vda5050_execution
   vda5050_types
   vda5050_json_utils
   fmt

--- a/vda5050_master/include/vda5050_master/agv/agv.hpp
+++ b/vda5050_master/include/vda5050_master/agv/agv.hpp
@@ -30,7 +30,7 @@
 #include <string>
 #include <thread>
 
-#include "vda5050_core/mqtt_client/mqtt_client_interface.hpp"
+#include "vda5050_execution/protocol_adapter.hpp"
 #include "vda5050_master/communication/heartbeat.hpp"
 #include "vda5050_master/standard_names.hpp"
 #include "vda5050_master/vda5050_interfaces.hpp"
@@ -61,7 +61,7 @@ enum class AGVState
  * - Outgoing message queue for orders and instant actions
  *
  * The VDA5050Master routes incoming messages to AGV instances and the AGV
- * handles outgoing messages via transient MQTT clients.
+ * handles ingoing/outgoing messages via the VDA5050Execution ProtocolAdapter.
  *
  * Thread safety: Methods are thread-safe. Cached data access is protected
  * by mutexes.
@@ -75,17 +75,18 @@ public:
 
   /**
    * @brief Construct an AGV instance
+   * @param protocol_adapter Protocol adapter for pub/sub
    * @param manufacturer Manufacturer name
    * @param serial_number Serial number
-   * @param broker_address MQTT broker address for creating transient publish clients
    * @param max_queue_size Maximum number of outgoing messages to queue (default: 10)
    * @param drop_oldest If true, drop oldest message when queue full; if false, reject new (default: true)
    * @param state_heartbeat_interval State heartbeat timeout in seconds
    */
   AGV(
+    std::shared_ptr<vda5050_execution::ProtocolAdapter> protocol_adapter,
     const std::string& manufacturer, const std::string& serial_number,
-    const std::string& broker_address, size_t max_queue_size = 10,
-    bool drop_oldest = true,
+    size_t max_queue_size = 10, bool drop_oldest = true,
+
     int state_heartbeat_interval = StateHeartbeatInterval);
 
   /**
@@ -308,6 +309,19 @@ public:
 
 private:
   // ============================================================================
+  // Subscription Management
+  // ============================================================================
+
+  void setup_subscriptions();
+
+  // ============================================================================
+  // Message Handlers (from MQTT callbacks)
+  // ============================================================================
+
+  template <typename MsgType>
+  void create_subscription(void (AGV::*agv_handler)(const MsgType&), int qos);
+
+  // ============================================================================
   // Internal State Management
   // ============================================================================
 
@@ -328,9 +342,6 @@ private:
   void process_queues();
 
   // Publishing
-  void publish_message(
-    const std::string& topic, const std::string& payload, int qos,
-    const std::string& label);
   void publish_order(const vda5050_types::Order& order);
   void publish_instant_actions(const vda5050_types::InstantActions& actions);
 
@@ -346,9 +357,8 @@ private:
   std::string serial_number_;
   std::string agv_id_;
 
-  // MQTT client for publishing outgoing messages
-  std::string broker_address_;
-  std::shared_ptr<vda5050_core::mqtt_client::MqttClientInterface> mqtt_client_;
+  // Protocol Adapter for publishing/subscribing
+  std::shared_ptr<vda5050_execution::ProtocolAdapter> protocol_adapter_;
 
   // Heartbeat listener for state timeout detection (protected by heartbeat_mutex_)
   mutable std::mutex heartbeat_mutex_;

--- a/vda5050_master/include/vda5050_master/vda5050_master/master.hpp
+++ b/vda5050_master/include/vda5050_master/vda5050_master/master.hpp
@@ -36,18 +36,13 @@ namespace vda5050_master {
  * @brief VDA5050 Master for multi-AGV fleet management
  *
  * This abstract base class manages VDA5050 communication for multiple AGVs
- * using a single shared MQTT client with wildcard subscriptions.
+ * using a single shared MQTT client that creates protocol adapters for each AGV.
  *
  * Features:
- * - Single shared MQTT client with wildcard subscriptions
+ * - Single shared MQTT client that creates protocol adapters for each AGV
  * - AGV onboarding/offboarding with allow list
  * - Message routing based on topic parsing
- * - Transient MQTT clients for publishing to AGVs
- *
- * Topic structure: {interfaceName}/{majorVersion}/{manufacturer}/{serialNumber}/{topic}
- * Example: rmf2/v2/MyManufacturer/AGV001/state
- *
- * Wildcard subscriptions: rmf2/v2/+/+/connection, rmf2/v2/+/+/state, etc.
+ * - Protocol adapters for subscribing and publishing to AGVs
  *
  * Thread safety note: Callbacks are invoked on the MQTT client thread.
  * If thread safety is required, the callback implementation should handle
@@ -59,22 +54,18 @@ public:
   /**
    * @brief Construct a VDA5050 master with shared MQTT client and broker address
    * @param mqtt_client Shared MQTT client for subscriptions
-   * @param broker_address MQTT broker address for creating transient publish clients
    *
-   * The mqtt_client is used for all wildcard subscriptions.
-   * The broker_address is used to create transient MQTT clients for publishing
-   * using vda5050_core::mqtt_client::create_default_client().
+   * The mqtt_client is used to create protocol adapters for each onboarded AGV
    *
    * Example usage:
    * @code
    * auto client = vda5050_core::mqtt_client::create_default_client(broker, "master");
-   * MyMaster master(client, broker);
+   * MyMaster master(client);
    * master.connect();
    * @endcode
    */
-  VDA5050Master(
-    std::shared_ptr<vda5050_core::mqtt_client::MqttClientInterface> mqtt_client,
-    const std::string& broker_address);
+  VDA5050Master(std::shared_ptr<vda5050_core::mqtt_client::MqttClientInterface>
+                  mqtt_client);
 
   /**
    * @brief Virtual destructor - disconnects MQTT client
@@ -92,7 +83,7 @@ public:
   // ============================================================================
 
   /**
-   * @brief Connect the MQTT client and setup wildcard subscriptions
+   * @brief Connect the MQTT client
    */
   void connect();
 
@@ -185,132 +176,19 @@ public:
     const std::string& manufacturer, const std::string& serial_number,
     const vda5050_types::InstantActions& actions);
 
-protected:
-  // ============================================================================
-  // Virtual callback methods - Override these in derived classes
-  // ============================================================================
-
-  /**
-   * @brief Called when a connection message is received from an onboarded AGV
-   * @param agv_id The AGV identifier (manufacturer/serial_number)
-   * @param msg The connection message
-   *
-   * Default implementation logs a warning. Override to handle connections.
-   */
-  virtual void on_connection(
-    const std::string& agv_id, const vda5050_types::Connection& msg);
-
-  /**
-   * @brief Called when a state message is received from an onboarded AGV
-   * @param agv_id The AGV identifier (manufacturer/serial_number)
-   * @param msg The state message
-   *
-   * Default implementation logs a warning. Override to handle states.
-   */
-  virtual void on_state(
-    const std::string& agv_id, const vda5050_types::State& msg);
-
-  /**
-   * @brief Called when a factsheet message is received from an onboarded AGV
-   * @param agv_id The AGV identifier (manufacturer/serial_number)
-   * @param msg The factsheet message
-   *
-   * Default implementation logs a warning. Override to handle factsheets.
-   */
-  virtual void on_factsheet(
-    const std::string& agv_id, const vda5050_types::Factsheet& msg);
-
-  /**
-   * @brief Called when a visualization message is received from an onboarded AGV
-   * @param agv_id The AGV identifier (manufacturer/serial_number)
-   * @param msg The visualization message
-   *
-   * Default implementation logs a warning. Override to handle visualizations.
-   */
-  virtual void on_visualization(
-    const std::string& agv_id, const vda5050_types::Visualization& msg);
-
 private:
-  // ============================================================================
-  // Subscription Management
-  // ============================================================================
-
-  void setup_subscriptions();
-  void cleanup_subscriptions();
-
-  // ============================================================================
-  // Topic Utilities
-  // ============================================================================
-
-  /**
-   * @brief Build a wildcard topic pattern for subscribing to all AGVs
-   * @param topic_name The topic name (e.g., "connection", "state")
-   * @return Wildcard topic pattern (e.g., "rmf2/v2/+/+/connection")
-   */
-  static std::string build_wildcard_topic(const std::string& topic_name);
-
-  /**
-   * @brief Parse manufacturer and serial number from a VDA5050 topic
-   * @param topic The full topic string (e.g., "rmf2/v2/Manu/SN001/state")
-   * @return Pair of (manufacturer, serial_number), or empty strings if parse fails
-   *
-   * Topic structure: {interfaceName}/{version}/{manufacturer}/{serialNumber}/{topic}
-   */
-  static std::pair<std::string, std::string> parse_topic(
-    const std::string& topic);
-
-  // ============================================================================
-  // Message Handlers (from MQTT callbacks)
-  // ============================================================================
-
-  /**
-   * @brief Generic message handler template
-   * @tparam MsgType The VDA5050 message type
-   * @param topic The MQTT topic
-   * @param payload The JSON payload
-   * @param message_type Type name for logging
-   * @param agv_handler Pointer to AGV handler method
-   * @param callback Pointer to callback method
-   */
-  template <typename MsgType>
-  void handle_message(
-    const std::string& topic, const std::string& payload,
-    const std::string& message_type, void (AGV::*agv_handler)(const MsgType&),
-    void (VDA5050Master::*callback)(const std::string&, const MsgType&));
-
-  void handle_connection_message(
-    const std::string& topic, const std::string& payload);
-  void handle_state_message(
-    const std::string& topic, const std::string& payload);
-  void handle_factsheet_message(
-    const std::string& topic, const std::string& payload);
-  void handle_visualization_message(
-    const std::string& topic, const std::string& payload);
-
   // ============================================================================
   // Internal AGV lookup
   // ============================================================================
 
   std::shared_ptr<AGV> get_agv_by_id(const std::string& agv_id) const;
 
-  /**
-   * @brief Get AGV from topic with validation and logging
-   * @param topic The MQTT topic
-   * @param message_type Type name for logging (e.g., "connection", "state")
-   * @return Pair of (agv_id, AGV pointer), AGV is nullptr if not onboarded
-   */
-  std::pair<std::string, std::shared_ptr<AGV>> get_agv_from_topic(
-    const std::string& topic, const std::string& message_type);
-
   // ============================================================================
   // Member Variables
   // ============================================================================
 
-  // Shared MQTT client for subscriptions
+  // Shared MQTT client for protocol adapters
   std::shared_ptr<vda5050_core::mqtt_client::MqttClientInterface> mqtt_client_;
-
-  // Broker address for creating transient MQTT clients (passed to AGVs)
-  std::string broker_address_;
 
   // Onboarded AGVs (shared_ptr allows safe access)
   mutable std::mutex agv_mutex_;

--- a/vda5050_master/package.xml
+++ b/vda5050_master/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>vda5050_core</depend>
+  <depend>vda5050_execution</depend>
   <depend>vda5050_types</depend>
   <depend>vda5050_json_utils</depend>
   <depend>rclcpp</depend>

--- a/vda5050_master/src/agv/agv.cpp
+++ b/vda5050_master/src/agv/agv.cpp
@@ -619,11 +619,24 @@ void AGV::process_queues()
 
 void AGV::publish_order(const vda5050_types::Order& order)
 {
+  if (!protocol_adapter_)
+  {
+    VDA5050_WARN(
+      "[AGV] Cannot publish order: no protocol adapter for {}", agv_id_);
+    return;
+  }
   protocol_adapter_->publish<vda5050_types::Order>(order, OrderQos);
 }
 
 void AGV::publish_instant_actions(const vda5050_types::InstantActions& actions)
 {
+  if (!protocol_adapter_)
+  {
+    VDA5050_WARN(
+      "[AGV] Cannot publish instant actions: no protocol adapter for {}",
+      agv_id_);
+    return;
+  }
   protocol_adapter_->publish<vda5050_types::InstantActions>(
     actions, InstantActionsQos);
 }

--- a/vda5050_master/src/agv/agv.cpp
+++ b/vda5050_master/src/agv/agv.cpp
@@ -22,7 +22,7 @@
 
 #include "nlohmann/json.hpp"
 #include "vda5050_core/logger/logger.hpp"
-#include "vda5050_core/mqtt_client/mqtt_client_interface.hpp"
+#include "vda5050_execution/protocol_adapter.hpp"
 #include "vda5050_json_utils/serialization.hpp"
 #include "vda5050_master/standard_names.hpp"
 
@@ -33,24 +33,20 @@ namespace vda5050_master {
 // ============================================================================
 
 AGV::AGV(
+  std::shared_ptr<vda5050_execution::ProtocolAdapter> protocol_adapter,
   const std::string& manufacturer, const std::string& serial_number,
-  const std::string& broker_address, size_t max_queue_size, bool drop_oldest,
-  int state_heartbeat_interval)
+  size_t max_queue_size, bool drop_oldest, int state_heartbeat_interval)
 : manufacturer_(manufacturer),
   serial_number_(serial_number),
   agv_id_(manufacturer + "/" + serial_number),
-  broker_address_(broker_address),
+  protocol_adapter_(protocol_adapter),
   state_heartbeat_interval_(state_heartbeat_interval),
   created_time_(Clock::now()),
   max_queue_size_(max_queue_size),
   drop_oldest_(drop_oldest)
 {
-  if (!broker_address_.empty())
-  {
-    mqtt_client_ = vda5050_core::mqtt_client::create_default_client(
-      broker_address_, agv_id_);
-  }
   VDA5050_INFO("[AGV] Created AGV instance: {}", agv_id_);
+  setup_subscriptions();
 }
 
 AGV::~AGV()
@@ -63,7 +59,52 @@ AGV::~AGV()
   // Cleanup heartbeat
   cleanup_heartbeat();
 
+  // TODO(tanjpg): additional cleanup protocol adapter.
+
   VDA5050_INFO("[AGV] AGV instance destroyed: {}", agv_id_);
+}
+
+template <typename MsgType>
+void AGV::create_subscription(void (AGV::*agv_handler)(const MsgType&), int qos)
+{
+  protocol_adapter_->subscribe<MsgType>(
+    [this, agv_handler](
+      MsgType msg, std::optional<vda5050_types::Error> error) {
+      if (error.has_value())
+      {
+        VDA5050_ERROR(
+          "[AGV] Failed to parse message for {}: {}", agv_id_,
+          error->error_description.value_or("unknown error"));
+        return;
+      }
+
+      try
+      {
+        (this->*agv_handler)(msg);
+      }
+      catch (const std::exception& e)
+      {
+        VDA5050_WARN(
+          "[AGV] Failed to handle message for {}: {}", agv_id_, e.what());
+      }
+    },
+    qos);
+}
+
+void AGV::setup_subscriptions()
+{
+  if (!protocol_adapter_)
+  {
+    return;
+  }
+
+  create_subscription<vda5050_types::Connection>(
+    &AGV::handle_connection, ConnectionQos);
+  create_subscription<vda5050_types::State>(&AGV::handle_state, StateQos);
+  create_subscription<vda5050_types::Factsheet>(
+    &AGV::handle_factsheet, FactsheetQos);
+  create_subscription<vda5050_types::Visualization>(
+    &AGV::handle_visualization, VisualizationQos);
 }
 
 void AGV::stop()
@@ -576,45 +617,15 @@ void AGV::process_queues()
 // Publishing
 // ============================================================================
 
-void AGV::publish_message(
-  const std::string& topic, const std::string& payload, int qos,
-  const std::string& label)
-{
-  if (!mqtt_client_)
-  {
-    VDA5050_WARN(
-      "[AGV] Cannot publish {}: no MQTT client for {}", label, agv_id_);
-    return;
-  }
-
-  try
-  {
-    mqtt_client_->connect();
-    mqtt_client_->publish(build_topic(topic), payload, qos);
-    mqtt_client_->disconnect();
-
-    VDA5050_INFO("[AGV] Published {} to AGV: {}", label, agv_id_);
-  }
-  catch (const std::exception& e)
-  {
-    VDA5050_WARN(
-      "[AGV] Failed to publish {} for {}: {}", label, agv_id_, e.what());
-  }
-}
-
 void AGV::publish_order(const vda5050_types::Order& order)
 {
-  nlohmann::json j;
-  vda5050_types::to_json(j, order);
-  publish_message(OrderTopic, j.dump(), OrderQos, "order");
+  protocol_adapter_->publish<vda5050_types::Order>(order, OrderQos);
 }
 
 void AGV::publish_instant_actions(const vda5050_types::InstantActions& actions)
 {
-  nlohmann::json j;
-  vda5050_types::to_json(j, actions);
-  publish_message(
-    InstantActionsTopic, j.dump(), InstantActionsQos, "instant actions");
+  protocol_adapter_->publish<vda5050_types::InstantActions>(
+    actions, InstantActionsQos);
 }
 
 // ============================================================================

--- a/vda5050_master/src/vda5050_master/master.cpp
+++ b/vda5050_master/src/vda5050_master/master.cpp
@@ -24,6 +24,7 @@
 
 #include "nlohmann/json.hpp"
 #include "vda5050_core/logger/logger.hpp"
+#include "vda5050_execution/protocol_adapter.hpp"
 #include "vda5050_json_utils/serialization.hpp"
 #include "vda5050_master/standard_names.hpp"
 
@@ -34,9 +35,8 @@ namespace vda5050_master {
 // ============================================================================
 
 VDA5050Master::VDA5050Master(
-  std::shared_ptr<vda5050_core::mqtt_client::MqttClientInterface> mqtt_client,
-  const std::string& broker_address)
-: mqtt_client_(std::move(mqtt_client)), broker_address_(broker_address)
+  std::shared_ptr<vda5050_core::mqtt_client::MqttClientInterface> mqtt_client)
+: mqtt_client_(std::move(mqtt_client))
 {
   VDA5050_INFO("[VDA5050Master] Created VDA5050Master instance");
 }
@@ -68,8 +68,6 @@ void VDA5050Master::connect()
 
   VDA5050_INFO("[VDA5050Master] Connecting MQTT client");
   mqtt_client_->connect();
-  setup_subscriptions();
-  VDA5050_INFO("[VDA5050Master] Connected and subscribed to wildcard topics");
 }
 
 void VDA5050Master::disconnect()
@@ -85,7 +83,6 @@ void VDA5050Master::disconnect()
   }
 
   VDA5050_INFO("[VDA5050Master] Disconnecting MQTT client");
-  cleanup_subscriptions();
   mqtt_client_->disconnect();
   VDA5050_INFO("[VDA5050Master] Disconnected");
 }
@@ -93,108 +90,6 @@ void VDA5050Master::disconnect()
 bool VDA5050Master::is_connected() const
 {
   return mqtt_client_ && mqtt_client_->connected();
-}
-
-// ============================================================================
-// Subscription Management
-// ============================================================================
-
-void VDA5050Master::setup_subscriptions()
-{
-  if (!mqtt_client_)
-  {
-    return;
-  }
-
-  // Subscribe to connection topic with wildcard
-  std::string connection_topic = build_wildcard_topic(ConnectionTopic);
-  mqtt_client_->subscribe(
-    connection_topic,
-    [this](const std::string& topic, const std::string& payload) {
-      handle_connection_message(topic, payload);
-    },
-    ConnectionQos);
-  VDA5050_INFO("[VDA5050Master] Subscribed to: {}", connection_topic);
-
-  // Subscribe to state topic with wildcard
-  std::string state_topic = build_wildcard_topic(StateTopic);
-  mqtt_client_->subscribe(
-    state_topic,
-    [this](const std::string& topic, const std::string& payload) {
-      handle_state_message(topic, payload);
-    },
-    StateQos);
-  VDA5050_INFO("[VDA5050Master] Subscribed to: {}", state_topic);
-
-  // Subscribe to factsheet topic with wildcard
-  std::string factsheet_topic = build_wildcard_topic(FactsheetTopic);
-  mqtt_client_->subscribe(
-    factsheet_topic,
-    [this](const std::string& topic, const std::string& payload) {
-      handle_factsheet_message(topic, payload);
-    },
-    FactsheetQos);
-  VDA5050_INFO("[VDA5050Master] Subscribed to: {}", factsheet_topic);
-
-  // Subscribe to visualization topic with wildcard
-  std::string visualization_topic = build_wildcard_topic(VisualizationTopic);
-  mqtt_client_->subscribe(
-    visualization_topic,
-    [this](const std::string& topic, const std::string& payload) {
-      handle_visualization_message(topic, payload);
-    },
-    VisualizationQos);
-  VDA5050_INFO("[VDA5050Master] Subscribed to: {}", visualization_topic);
-}
-
-void VDA5050Master::cleanup_subscriptions()
-{
-  if (!mqtt_client_)
-  {
-    return;
-  }
-
-  mqtt_client_->unsubscribe(build_wildcard_topic(ConnectionTopic));
-  mqtt_client_->unsubscribe(build_wildcard_topic(StateTopic));
-  mqtt_client_->unsubscribe(build_wildcard_topic(FactsheetTopic));
-  mqtt_client_->unsubscribe(build_wildcard_topic(VisualizationTopic));
-
-  VDA5050_INFO("[VDA5050Master] Unsubscribed from wildcard topics");
-}
-
-// ============================================================================
-// Topic Utilities
-// ============================================================================
-
-std::string VDA5050Master::build_wildcard_topic(const std::string& topic_name)
-{
-  return InterfaceName + "/" + Version + "/+/+/" + topic_name;
-}
-
-std::pair<std::string, std::string> VDA5050Master::parse_topic(
-  const std::string& topic)
-{
-  // Topic structure: {interfaceName}/{version}/{manufacturer}/{serialNumber}/{topic}
-  // Example: "rmf2/v2/MyManufacturer/AGV001/state"
-  // Parts:    [0]   [1]     [2]          [3]     [4]
-
-  std::vector<std::string> parts;
-  std::istringstream stream(topic);
-  std::string part;
-
-  while (std::getline(stream, part, '/'))
-  {
-    parts.push_back(part);
-  }
-
-  // We need at least 5 parts
-  if (parts.size() < 5)
-  {
-    return {"", ""};
-  }
-
-  // Return manufacturer (index 2) and serial number (index 3)
-  return {parts[2], parts[3]};
 }
 
 // ============================================================================
@@ -215,9 +110,11 @@ void VDA5050Master::onboard_agv(
     return;
   }
 
-  // Create AGV instance with broker address for transient publishing
+  // Create AGV instance with a new protocol adapter
   auto agv = std::make_shared<AGV>(
-    manufacturer, serial_number, broker_address_, max_queue_size, drop_oldest);
+    vda5050_execution::ProtocolAdapter::make(
+      mqtt_client_, InterfaceName, Version, manufacturer, serial_number),
+    manufacturer, serial_number, max_queue_size, drop_oldest);
 
   agvs_[agv_id] = std::move(agv);
 
@@ -272,39 +169,9 @@ std::shared_ptr<AGV> VDA5050Master::get_agv(
 std::shared_ptr<AGV> VDA5050Master::get_agv_by_id(
   const std::string& agv_id) const
 {
+  // Note: Caller must hold agv_mutex_
   auto it = agvs_.find(agv_id);
   return (it != agvs_.end()) ? it->second : nullptr;
-}
-
-std::pair<std::string, std::shared_ptr<AGV>> VDA5050Master::get_agv_from_topic(
-  const std::string& topic, const std::string& message_type)
-{
-  auto [manufacturer, serial_number] = parse_topic(topic);
-  if (manufacturer.empty() || serial_number.empty())
-  {
-    VDA5050_WARN(
-      "[VDA5050Master] Ignoring {} message: failed to parse topic: {}",
-      message_type, topic);
-    return {"", nullptr};
-  }
-
-  std::string agv_id = manufacturer + "/" + serial_number;
-
-  std::shared_ptr<AGV> agv;
-  {
-    std::lock_guard<std::mutex> lock(agv_mutex_);
-    agv = get_agv_by_id(agv_id);
-  }
-
-  if (!agv)
-  {
-    VDA5050_WARN(
-      "[VDA5050Master] Ignoring {} message from AGV not onboarded: {}",
-      message_type, agv_id);
-    return {agv_id, nullptr};
-  }
-
-  return {agv_id, agv};
 }
 
 // ============================================================================
@@ -351,109 +218,6 @@ bool VDA5050Master::publish_instant_actions(
   }
 
   return agv->send_instant_actions(actions);
-}
-
-// ============================================================================
-// Message Handlers
-// ============================================================================
-
-template <typename MsgType>
-void VDA5050Master::handle_message(
-  const std::string& topic, const std::string& payload,
-  const std::string& message_type, void (AGV::*agv_handler)(const MsgType&),
-  void (VDA5050Master::*callback)(const std::string&, const MsgType&))
-{
-  auto [agv_id, agv] = get_agv_from_topic(topic, message_type);
-  if (!agv)
-  {
-    return;
-  }
-
-  try
-  {
-    nlohmann::json j = nlohmann::json::parse(payload);
-    MsgType msg;
-    vda5050_types::from_json(j, msg);
-
-    (agv.get()->*agv_handler)(msg);
-    (this->*callback)(agv_id, msg);
-  }
-  catch (const std::exception& e)
-  {
-    VDA5050_WARN(
-      "[VDA5050Master] Failed to parse {} message from {}: {}", message_type,
-      agv_id, e.what());
-  }
-}
-
-void VDA5050Master::handle_connection_message(
-  const std::string& topic, const std::string& payload)
-{
-  handle_message<vda5050_types::Connection>(
-    topic, payload, "connection", &AGV::handle_connection,
-    &VDA5050Master::on_connection);
-}
-
-void VDA5050Master::handle_state_message(
-  const std::string& topic, const std::string& payload)
-{
-  handle_message<vda5050_types::State>(
-    topic, payload, "state", &AGV::handle_state, &VDA5050Master::on_state);
-}
-
-void VDA5050Master::handle_factsheet_message(
-  const std::string& topic, const std::string& payload)
-{
-  handle_message<vda5050_types::Factsheet>(
-    topic, payload, "factsheet", &AGV::handle_factsheet,
-    &VDA5050Master::on_factsheet);
-}
-
-void VDA5050Master::handle_visualization_message(
-  const std::string& topic, const std::string& payload)
-{
-  handle_message<vda5050_types::Visualization>(
-    topic, payload, "visualization", &AGV::handle_visualization,
-    &VDA5050Master::on_visualization);
-}
-
-// ============================================================================
-// Default Virtual Callback Implementations
-// ============================================================================
-
-void VDA5050Master::on_connection(
-  const std::string& agv_id, const vda5050_types::Connection& /*msg*/)
-{
-  VDA5050_WARN(
-    "[VDA5050Master] on_connection not overridden. Received connection from "
-    "AGV: {}",
-    agv_id);
-}
-
-void VDA5050Master::on_state(
-  const std::string& agv_id, const vda5050_types::State& /*msg*/)
-{
-  VDA5050_WARN(
-    "[VDA5050Master] on_state not overridden. Received state from AGV: {}",
-    agv_id);
-}
-
-void VDA5050Master::on_factsheet(
-  const std::string& agv_id, const vda5050_types::Factsheet& /*msg*/)
-{
-  VDA5050_WARN(
-    "[VDA5050Master] on_factsheet not overridden. Received factsheet from "
-    "AGV: {}",
-    agv_id);
-}
-
-void VDA5050Master::on_visualization(
-  const std::string& agv_id, const vda5050_types::Visualization& /*msg*/)
-{
-  VDA5050_WARN(
-    "[VDA5050Master] on_visualization not overridden. Received visualization "
-    "from AGV: {}",
-    agv_id);
 }
 
 }  // namespace vda5050_master

--- a/vda5050_master/test/agv/agv_test_fixture.hpp
+++ b/vda5050_master/test/agv/agv_test_fixture.hpp
@@ -52,17 +52,18 @@ protected:
 
   std::unique_ptr<AGV>& create_agv()
   {
-    // Use empty broker address for unit tests
-    agv_ = std::make_unique<AGV>(manufacturer_, serial_number_, "");
+    // Use nullptr for ProtocolAdapter in unit tests
+    agv_ = std::make_unique<AGV>(nullptr, manufacturer_, serial_number_);
     return agv_;
   }
 
   std::unique_ptr<AGV>& create_agv_with_heartbeat_interval(
     int state_heartbeat_interval)
   {
-    // Use empty broker address for unit tests
+    // Use nullptr for ProtocolAdapter in unit tests
     agv_ = std::make_unique<AGV>(
-      manufacturer_, serial_number_, "", 10, true, state_heartbeat_interval);
+      nullptr, manufacturer_, serial_number_, 10, true,
+      state_heartbeat_interval);
     return agv_;
   }
 

--- a/vda5050_master/test/master/master_logic_test.cpp
+++ b/vda5050_master/test/master/master_logic_test.cpp
@@ -64,7 +64,7 @@ protected:
   {
     auto client = vda5050_core::mqtt_client::create_default_client(
       MQTT_BROKER, "master_logic_test_" + std::to_string(test_id_++));
-    return std::make_unique<VDA5050Master>(client, MQTT_BROKER);
+    return std::make_unique<VDA5050Master>(client);
   }
 
   vda5050_types::Order create_test_order(const std::string& order_id)

--- a/vda5050_master/test/master/master_mqtt_test.cpp
+++ b/vda5050_master/test/master/master_mqtt_test.cpp
@@ -68,7 +68,7 @@ protected:
   {
     auto client = vda5050_core::mqtt_client::create_default_client(
       MQTT_BROKER, "master_mqtt_test_" + std::to_string(test_id_++));
-    return std::make_unique<VDA5050Master>(client, MQTT_BROKER);
+    return std::make_unique<VDA5050Master>(client);
   }
 
   std::string manufacturer_;


### PR DESCRIPTION
This PR changes the method in which the `VDA5050Master` Object and its' stored `AGV` objects handles MQTT communication with the newly added `ProtocolAdapter` by @sauk2 

Main Changes:

- There will only be 1 `vda5050_core::mqtt_client` , held by `VDA5050Master` , that will [assign `ProtocolAdapter`s to individual AGVs during onboarding](https://github.com/tanjpg/vda5050_client/blob/feat/master/vda5050-execution-integration/vda5050_master/src/vda5050_master/master.cpp#L115)
- The `VDA5050Master` will not be using wildcarded topics from now on. `ProtocolAdapter`s will be assigned to specific `AGV`s with `manufacturer` and `serialNumber`
- Subscriptions will be started in the `AGV` objects themselves. Removed from `VDA5050Master`
- Removed all [virtual callbacks that were meant for overriding by external creators of `VDA5050Master`](https://github.com/tanjpg/vda5050_client/commit/6c25f6d1f6a44543993ccc476606c3d0b3cd5b20#diff-ed4bbbf8018ce0e136468b33ef8194ad35ecbf1c85b55bbe95e5019a795be92aL189). I believe we will still need some callback mechanism insertion later on, but I will remove it now until we have a concrete plan

Future notes:
-  We need a proper cleanup for `ProtocolAdapter`. I have [left a TODO placeholder for this](https://github.com/tanjpg/vda5050_client/blob/feat/master/vda5050-execution-integration/vda5050_master/src/agv/agv.cpp#L62)
- I need time to look through the `ExecutionEngine`, `EventQueue` and the like to see how this ties in with the VDA5050 Master, if any. This will come in future PRs.