### PR TITLE
ci(gha): add asan and tsan for jazzy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         distro: [humble, jazzy]
-        compiler: [gcc, clang]
+        test_type: [gcc, clang, gcc-tsan, gcc-asan]
     env:
       ISOLATION: "shell"
     runs-on: ubuntu-latest
@@ -33,15 +33,31 @@ jobs:
           sleep 2  # Wait for broker to start
 
       # GCC
-      - if: ${{ matrix.compiler == 'gcc' }}
+      - if: ${{ matrix.test_type == 'gcc' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_DISTRO: ${{ matrix.distro }}
           UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
           TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'
 
+      # GCC with address sanitizer
+      - if: ${{ matrix.test_type == 'gcc-asan' }}
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_DISTRO: ${{ matrix.distro }}
+          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
+          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_C_FLAGS="-fsanitize=address" -DCMAKE_CXX_FLAGS="-fsanitize=address"'
+
+      # GCC with thread sanitizer
+      - if: ${{ matrix.test_type == 'gcc-tsan' }}
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_DISTRO: ${{ matrix.distro }}
+          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
+          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_C_FLAGS="-fsanitize=thread -O2 -g -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -O2 -g -fno-omit-frame-pointer"'
+
       # Clang
-      - if: ${{ matrix.compiler == 'clang' }}
+      - if: ${{ matrix.test_type == 'clang' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
       - develop
-      - feature/add-asan-tsan-rolling
+      - feature/add-asan-tsan
 
 jobs:
   industrial_ci:
@@ -22,6 +22,8 @@ jobs:
           - {distro: jazzy, test_type: gcc-tsan}
     env:
       ISOLATION: "shell"
+      UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp github:eclipse-paho/paho.mqtt.cpp#v1.5.0'
+      ROS_DISTRO: ${{ matrix.distro }}
     runs-on: ubuntu-latest
     container:
       image: ros:${{ matrix.distro }}-ros-core
@@ -40,32 +42,24 @@ jobs:
       - if: ${{ matrix.test_type == 'gcc' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
-          ROS_DISTRO: ${{ matrix.distro }}
-          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
           TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'
 
       # GCC with address sanitizer
       - if: ${{ matrix.test_type == 'gcc-asan' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
-          ROS_DISTRO: ${{ matrix.distro }}
-          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
           TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_C_FLAGS="-fsanitize=address" -DCMAKE_CXX_FLAGS="-fsanitize=address"'
 
       # GCC with thread sanitizer
       - if: ${{ matrix.test_type == 'gcc-tsan' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
-          ROS_DISTRO: ${{ matrix.distro }}
-          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
           TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_C_FLAGS="-fsanitize=thread -O2 -g -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -O2 -g -fno-omit-frame-pointer"'
 
       # Clang
       - if: ${{ matrix.test_type == 'clang' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
-          ROS_DISTRO: ${{ matrix.distro }}
-          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
           ADDITIONAL_DEBS: clang lld
           CC: "clang"
           CXX: "clang++"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         distro: [humble, jazzy]
-        test_type: [gcc, clang, gcc-tsan, gcc-asan]
+        test_type: [gcc, clang]
+        include:
+          - {distro: jazzy, test_type: gcc-asan}
+          - {distro: jazzy, test_type: gcc-tsan}
     env:
       ISOLATION: "shell"
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - develop
+      - feature/add-asan-tsan-rolling
 
 jobs:
   industrial_ci:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - develop
-      - feature/add-asan-tsan
 
 jobs:
   industrial_ci:


### PR DESCRIPTION
This PR enable ASAN and TSAN for jazzy.

It fixes the mqtt thread sanitizer error mentioned in https://github.com/eclipse-paho/paho.mqtt.cpp/issues/481 by bumping the version used in ci to `1.5.0`. 
I don't think this is needed for non-developers.