### PR TITLE
Added fixes to sanitizer test issues 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       - if: ${{ matrix.test_type == 'gcc-asan' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
-          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_C_FLAGS="-fsanitize=address" -DCMAKE_CXX_FLAGS="-fsanitize=address"'
+          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_C_FLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer"'
 
       # GCC with thread sanitizer
       - if: ${{ matrix.test_type == 'gcc-tsan' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,14 @@ jobs:
       fail-fast: false
       matrix:
         distro: [humble, jazzy]
-        compiler: [gcc, clang]
+        test_type: [gcc, clang]
+        include:
+          - {distro: jazzy, test_type: gcc-asan}
+          - {distro: jazzy, test_type: gcc-tsan}
     env:
       ISOLATION: "shell"
+      UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp github:eclipse-paho/paho.mqtt.cpp#v1.5.0'
+      ROS_DISTRO: ${{ matrix.distro }}
     runs-on: ubuntu-latest
     container:
       image: ros:${{ matrix.distro }}-ros-core
@@ -33,19 +38,27 @@ jobs:
           sleep 2  # Wait for broker to start
 
       # GCC
-      - if: ${{ matrix.compiler == 'gcc' }}
+      - if: ${{ matrix.test_type == 'gcc' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
-          ROS_DISTRO: ${{ matrix.distro }}
-          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
           TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON'
 
-      # Clang
-      - if: ${{ matrix.compiler == 'clang' }}
+      # GCC with address sanitizer
+      - if: ${{ matrix.test_type == 'gcc-asan' }}
         uses: 'ros-industrial/industrial_ci@master'
         env:
-          ROS_DISTRO: ${{ matrix.distro }}
-          UPSTREAM_WORKSPACE: 'github:sauk2/vda5050_interfaces#throwaway/temp'
+          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_C_FLAGS="-fsanitize=address" -DCMAKE_CXX_FLAGS="-fsanitize=address"'
+
+      # GCC with thread sanitizer
+      - if: ${{ matrix.test_type == 'gcc-tsan' }}
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
+          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_C_FLAGS="-fsanitize=thread -O2 -g -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -O2 -g -fno-omit-frame-pointer"'
+
+      # Clang
+      - if: ${{ matrix.test_type == 'clang' }}
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
           ADDITIONAL_DEBS: clang lld
           CC: "clang"
           CXX: "clang++"

--- a/vda5050_core/src/vda5050_core/logger/logger.cpp
+++ b/vda5050_core/src/vda5050_core/logger/logger.cpp
@@ -40,7 +40,8 @@ public:
   {
     auto now = std::chrono::system_clock::now();
     std::time_t now_t = std::chrono::system_clock::to_time_t(now);
-    std::tm localtime = *std::localtime(&now_t);
+    std::tm localtime;
+    localtime_r(&now_t, &localtime);
 
     std::cout << "[" << fmt::format("{:%Y-%m-%d %H:%M:%S}", localtime) << "]"
               << to_log_level_string(level) << ": " << message << std::endl;

--- a/vda5050_execution/test/unit/test_event_queue.cpp
+++ b/vda5050_execution/test/unit/test_event_queue.cpp
@@ -24,6 +24,8 @@
 #include "vda5050_execution/event.hpp"
 #include "vda5050_execution/event_queue.hpp"
 
+namespace {
+
 struct EventA : public vda5050_execution::EventBase
 {
   int arg;
@@ -70,6 +72,8 @@ struct ComplexEvent : public vda5050_execution::EventBase
     return std::type_index(typeid(ComplexEvent));
   }
 };
+
+}  // namespace
 
 TEST(EventQueueTest, MultiEventPop)
 {

--- a/vda5050_execution/test/unit/test_execution_engine.cpp
+++ b/vda5050_execution/test/unit/test_execution_engine.cpp
@@ -24,6 +24,8 @@
 #include "vda5050_execution/event.hpp"
 #include "vda5050_execution/execution_engine.hpp"
 
+namespace {
+
 struct EventA : public vda5050_execution::EventBase
 {
   std::type_index get_type() const override
@@ -39,6 +41,8 @@ struct EventB : public vda5050_execution::EventBase
     return typeid(EventB);
   }
 };
+
+}  // namespace
 
 TEST(ExecutionEngineTest, SingleEventDispatch)
 {

--- a/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
+++ b/vda5050_json_utils/include/vda5050_json_utils/traits.hpp
@@ -147,8 +147,11 @@ inline std::string to_iso8601(TimePoint time_point)
   auto duration = time_point.time_since_epoch();
   auto millisec = duration_cast<milliseconds>(duration).count() % 1000;
 
+  std::tm tm_buf;
+  gmtime_r(&time_sec, &tm_buf);
+
   std::ostringstream oss;
-  oss << std::put_time(std::gmtime(&time_sec), vda5050_types::ISO8601_FORMAT);
+  oss << std::put_time(&tm_buf, vda5050_types::ISO8601_FORMAT);
   oss << "." << std::setw(3) << std::setfill('0') << millisec << "Z";
   if (oss.fail())
   {

--- a/vda5050_master/src/agv/agv.cpp
+++ b/vda5050_master/src/agv/agv.cpp
@@ -231,6 +231,13 @@ void AGV::set_operational_state(AGVState state)
 
 void AGV::on_state_heartbeat_timeout()
 {
+  {
+    std::lock_guard<std::mutex> lock(heartbeat_mutex_);
+    if (!state_heartbeat_)
+    {
+      return;
+    }
+  }
   set_operational_state(AGVState::STATE_UNKNOWN);
   VDA5050_WARN("[AGV] State heartbeat timeout for {}", agv_id_);
 }
@@ -258,17 +265,21 @@ void AGV::setup_heartbeat()
 
 void AGV::cleanup_heartbeat()
 {
-  std::lock_guard<std::mutex> lock(heartbeat_mutex_);
+  std::unique_ptr<communication::HeartbeatListener> heartbeat_to_stop;
 
-  if (!state_heartbeat_)
   {
-    return;  // Nothing to clean up
+    std::lock_guard<std::mutex> lock(heartbeat_mutex_);
+    if (!state_heartbeat_)
+    {
+      return;  // Nothing to clean up
+    }
+
+    VDA5050_INFO("[AGV] Cleaning up heartbeat for {}", agv_id_);
+
+    heartbeat_to_stop = std::move(state_heartbeat_);
   }
 
-  VDA5050_INFO("[AGV] Cleaning up heartbeat for {}", agv_id_);
-
-  state_heartbeat_->stop_connection_heartbeat();
-  state_heartbeat_.reset();
+  heartbeat_to_stop->stop_connection_heartbeat();
 }
 
 // ============================================================================

--- a/vda5050_master/test/integration/heartbeat.cpp
+++ b/vda5050_master/test/integration/heartbeat.cpp
@@ -217,7 +217,8 @@ TEST(HeartbeatListenerTest, StateIsRunningWhileCallbackExecutes)
   std::atomic_bool was_running_during_callback{false};
 
   // We need a raw pointer to check get_state() from within callback
-  MockHeartbeatListener* listener_ptr = nullptr;
+  // Must be atomic because the callback thread may read it while main thread writes
+  std::atomic<MockHeartbeatListener*> listener_ptr{nullptr};
 
   auto hb_listener = std::make_unique<MockHeartbeatListener>(
     "test_listener", vda5050_master::ConnectionHeartbeatInterval,

--- a/vda5050_master/test/integration/heartbeat.cpp
+++ b/vda5050_master/test/integration/heartbeat.cpp
@@ -22,6 +22,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <thread>
 #include <vector>
 
@@ -142,7 +143,7 @@ TEST(HeartbeatListenerTest, HeartbeatReceivedNoTimeout)
 TEST(HeartbeatListenerTest, HeartbeatNotReceivedTimeout)
 {
   std::atomic_bool heartbeat_failed{false};
-  auto hb_listener = MockHeartbeatListener(
+  auto hb_listener = std::make_unique<MockHeartbeatListener>(
     "test_listener", vda5050_master::ConnectionHeartbeatInterval,
     [&heartbeat_failed]() {
       // Timeout callback
@@ -157,16 +158,16 @@ TEST(HeartbeatListenerTest, HeartbeatNotReceivedTimeout)
       // ASSERT_TRUE(heartbeat_failed->load());
     },
     vda5050_master::ConnectionHeartbeatInterval + 1);
-  hb_listener.trigger_timeout();
+  hb_listener->trigger_timeout();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  ASSERT_NO_THROW(hb_listener.~MockHeartbeatListener());
+  ASSERT_NO_THROW(hb_listener.reset());
   ASSERT_TRUE(heartbeat_failed.load());
 }
 
 TEST(HeartbeatListenerTest, HeartbeatReceivedTimeout)
 {
   std::atomic_bool heartbeat_failed{false};
-  auto hb_listener = MockHeartbeatListener(
+  auto hb_listener = std::make_unique<MockHeartbeatListener>(
     "test_listener", vda5050_master::ConnectionHeartbeatInterval,
     [&heartbeat_failed]() {
       // Timeout callback
@@ -175,11 +176,11 @@ TEST(HeartbeatListenerTest, HeartbeatReceivedTimeout)
     },
     vda5050_master::ConnectionHeartbeatInterval + 1);
 
-  hb_listener.trigger_timeout();
+  hb_listener->trigger_timeout();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  hb_listener.received_connection();
+  hb_listener->received_connection();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  ASSERT_NO_THROW(hb_listener.~MockHeartbeatListener());
+  ASSERT_NO_THROW(hb_listener.reset());
   ASSERT_TRUE(heartbeat_failed.load());
 }
 

--- a/vda5050_master/test/integration/heartbeat.cpp
+++ b/vda5050_master/test/integration/heartbeat.cpp
@@ -227,10 +227,11 @@ TEST(HeartbeatListenerTest, StateIsRunningWhileCallbackExecutes)
       callback_started.store(true);
 
       // Check get_state() during callback execution
-      if (listener_ptr)
+      auto* ptr = listener_ptr.load();
+      if (ptr)
       {
         was_running_during_callback.store(
-          listener_ptr->get_state() == HeartbeatState::RUNNING);
+          ptr->get_state() == HeartbeatState::RUNNING);
       }
 
       // Simulate work


### PR DESCRIPTION
This pull requests addresses issues faced when including TSAN/ASAN for sanitization tests in the CI

Note that I have [added in the minor change](https://github.com/tanjpg/vda5050_client/commit/2159ae3e7d8157306c851c7db0c811599fbdc331) made that was meant to be in [this PR](https://github.com/ros-industrial/vda5050_client/pull/34), so @Briancbn seek your advice if I should wait for your PR first before addressing the rest. 

The following changes were made to Address the failing sanitizer CI:

## 0. Potential missing flags in the CI

I think you [need the `-fno-omit-frame-pointer` ](https://github.com/tanjpg/vda5050_client/commit/8356e425b1c725de204d3a414998324b30906006)for the ASAN configuration as well. Not too sure exactly what is going on under the hood, but from testing it seems to be able to prevent the ASAN CI pipeline from failing. 

## 1. Using of `gmtime_r()' instead of gmtime() and localtime_r() instead of localtime()

As mentioned [here](https://en.cppreference.com/w/c/chrono/gmtime.html) it seems like `gmtime()` is not thread safe due to returning of a static shared buffer. [Same with localtime()](https://en.cppreference.com/w/c/chrono/localtime.html)

[This commit](https://github.com/tanjpg/vda5050_client/commit/8c5c69b3116b66fda498f6631bca65f4c13aa005) thus instead use the threadsafe `localtime_r()` and  `gmtime_r()` function that takes in a `std::tm` buffer as well

```cpp
std::tm localtime;
localtime_r(&now_t, &localtime);
```

```cpp
std::tm tm_buf;
gmtime_r(&time_sec, &tm_buf);
.....
oss << std::put_time(&tm_buf, vda5050_types::ISO8601_FORMAT);
```

## 2. Adding anonymous namespaces for `EventA` and `EventB`
 
There seems to be two `EventA` classes and `EventB` classes in [test_event_queue.cpp](https://github.com/ros-industrial/vda5050_client/blob/develop/vda5050_execution/test/unit/test_event_queue.cpp#L27) and [test_execution_engine.cpp](https://github.com/ros-industrial/vda5050_client/blob/develop/vda5050_execution/test/unit/test_execution_engine.cpp#L27), that i think may be causing a potential ODR violation.

I [added a simple anonymous namespace](https://github.com/tanjpg/vda5050_client/commit/0e44c0df2161a33ab9cd54ee44fa86a5c90a4144) to address this.

## 3. Issues with Mockheartbeat class (Used only in unit tests)

I [made the `MockHeartbeatListener` class atomic](https://github.com/tanjpg/vda5050_client/commit/142088693f9196984c65a59959701b1b5b72433c) to ensure no data races when `.get()` and `.load()` is being used in different threads

## 4. Mutex issues with `vda5050_master::AGV`

[Fixed the potential threading issues](https://github.com/tanjpg/vda5050_client/commit/f461331b5f0a0902b7339e334dc70bd0dbb960cb) where other threads may call the `HeartbeatListener` in the `vda5050_master::AGV` object when the `HeartbeatListener`'s `stop_connection_heartbeat()` method is triggered using mutexes and transfer of pointer ownership with `std::move`