### PR TITLE
feat: add method to suspend engine indefinitely

### DIFF
--- a/vda5050_core/include/vda5050_core/execution/engine.hpp
+++ b/vda5050_core/include/vda5050_core/execution/engine.hpp
@@ -23,6 +23,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -68,30 +69,17 @@ public:
   }
 
   template <typename UpdateT>
+  void suspend(std::function<bool(std::shared_ptr<UpdateT>)> predicate)
+  {
+    register_internal_wait<UpdateT>(std::nullopt, predicate);
+  }
+
+  template <typename UpdateT>
   void suspend_for(
     std::chrono::milliseconds timeout,
     std::function<bool(std::shared_ptr<UpdateT>)> predicate = nullptr)
   {
-    static_assert(
-      std::is_base_of_v<UpdateBase, UpdateT>,
-      "Update must be derived from UpdateBase");
-
-    std::lock_guard<std::mutex> lock(wait_mutex_);
-    wait_timeout_ = std::chrono::steady_clock::now() + timeout;
-
-    wait_predicate_ = [predicate](std::shared_ptr<UpdateBase> update) -> bool {
-      if (update->get_type() == std::type_index(typeid(UpdateT)))
-      {
-        auto update_t = std::static_pointer_cast<UpdateT>(update);
-        if (predicate)
-        {
-          return predicate(update_t);
-        }
-      }
-      return true;
-    };
-
-    waiting_ = true;
+    register_internal_wait<UpdateT>(timeout, predicate);
   }
 
   void notify(std::shared_ptr<UpdateBase> update);
@@ -101,6 +89,38 @@ public:
   bool waiting() const;
 
 private:
+  template <typename UpdateT>
+  void register_internal_wait(
+    std::optional<std::chrono::milliseconds> timeout,
+    std::function<bool(std::shared_ptr<UpdateT>)> predicate)
+  {
+    static_assert(
+      std::is_base_of_v<UpdateBase, UpdateT>,
+      "Update must be derived from UpdateBase");
+
+    std::lock_guard<std::mutex> lock(wait_mutex_);
+
+    if (timeout.has_value())
+    {
+      wait_timeout_ = std::chrono::steady_clock::now() + timeout.value();
+    }
+    else
+    {
+      wait_timeout_ = std::nullopt;
+    }
+
+    wait_predicate_ = [predicate](std::shared_ptr<UpdateBase> update) -> bool {
+      if (update->get_type() == std::type_index(typeid(UpdateT)))
+      {
+        auto update_t = std::static_pointer_cast<UpdateT>(update);
+        if (predicate) return predicate(update_t);
+      }
+      return false;
+    };
+
+    waiting_ = true;
+  }
+
   void reset_internal_wait() const;
 
   void check_timeout() const;
@@ -111,11 +131,9 @@ private:
   std::unordered_map<std::type_index, std::vector<ErasedCallback>> callbacks_;
   std::mutex registry_mutex_;
 
-  mutable bool waiting_ = false;
-  mutable std::chrono::steady_clock::time_point wait_timeout_ =
-    std::chrono::steady_clock::time_point::min();
-  mutable std::function<bool(std::shared_ptr<UpdateBase>)> wait_predicate_ =
-    nullptr;
+  mutable bool waiting_;
+  mutable std::optional<std::chrono::steady_clock::time_point> wait_timeout_;
+  mutable std::function<bool(std::shared_ptr<UpdateBase>)> wait_predicate_;
   mutable std::mutex wait_mutex_;
 };
 

--- a/vda5050_core/src/execution/engine.cpp
+++ b/vda5050_core/src/execution/engine.cpp
@@ -44,7 +44,7 @@ void Engine::step()
   std::shared_ptr<EventBase> event;
   {
     std::lock_guard<std::mutex> lock(wait_mutex_);
-    check_timeout();
+    if (wait_timeout_.has_value()) check_timeout();
     event = waiting_ ? event_queue_.pop_critical_only() : event_queue_.pop();
   }
 
@@ -67,7 +67,7 @@ void Engine::step()
 bool Engine::waiting() const
 {
   std::lock_guard<std::mutex> lock(wait_mutex_);
-  check_timeout();
+  if (wait_timeout_.has_value()) check_timeout();
   return waiting_;
 }
 
@@ -75,6 +75,7 @@ bool Engine::waiting() const
 void Engine::reset_internal_wait() const
 {
   waiting_ = false;
+  wait_timeout_ = std::nullopt;
   wait_predicate_ = nullptr;
 }
 

--- a/vda5050_core/test/execution/test_engine.cpp
+++ b/vda5050_core/test/execution/test_engine.cpp
@@ -212,7 +212,7 @@ TEST_F(EngineTest, WaitConditionSucess)
   EXPECT_FALSE(engine->waiting());
 }
 
-TEST_F(EngineTest, WaitTimeout)
+TEST_F(EngineTest, SuspendWithTimeoutNoPredicate)
 {
   std::vector<std::string> execution_log;
 
@@ -235,6 +235,63 @@ TEST_F(EngineTest, WaitTimeout)
   engine->step();
   ASSERT_EQ(execution_log.size(), 1);
   EXPECT_EQ(execution_log[0], "node_delayed");
+}
+
+TEST_F(EngineTest, SuspendWithTimeoutAndPredicate)
+{
+  std::vector<std::string> execution_log;
+
+  engine->on<MockNavigationCommand>(
+    [&](auto event) { execution_log.push_back(event->node_id); });
+
+  engine->emit<MockNavigationCommand>(Priority::NORMAL, "node_delayed");
+
+  engine->suspend_for<MockNavigationAcknowledgement>(
+    std::chrono::milliseconds(50),
+    [&](auto update) -> bool { return update->node_id == "node_previous"; });
+
+  EXPECT_TRUE(engine->waiting());
+
+  engine->step();
+  EXPECT_TRUE(execution_log.empty());
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  EXPECT_TRUE(engine->waiting());
+
+  engine->notify(
+    std::make_shared<MockNavigationAcknowledgement>("node_previous"));
+
+  EXPECT_FALSE(engine->waiting());
+
+  engine->step();
+  ASSERT_EQ(execution_log.size(), 1);
+  EXPECT_EQ(execution_log[0], "node_delayed");
+}
+
+TEST_F(EngineTest, SuspendIndefinitely)
+{
+  std::atomic_bool recevied = false;
+
+  engine->suspend<MockNavigationAcknowledgement>([&](auto update) -> bool {
+    if (update->node_id == "node_1")
+    {
+      recevied = true;
+      return true;
+    }
+    return false;
+  });
+
+  EXPECT_TRUE(engine->waiting());
+
+  engine->step();
+  EXPECT_TRUE(engine->waiting());
+
+  engine->notify(std::make_shared<MockNavigationAcknowledgement>("node_1"));
+
+  engine->step();
+  EXPECT_FALSE(engine->waiting());
+  EXPECT_TRUE(recevied);
 }
 
 TEST_F(EngineTest, ConcurrentEmitAndStep)


### PR DESCRIPTION
Closes #40 

## Summary

This PR adds a new method to `Engine` to suspend it indefinitely without a timeout. The new `suspend` method takes in only a predicate and the existing `suspend_for` methods still remains unchanged. 