### PR TITLE
feat: master-side order validators and topology map

### DIFF
--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -164,6 +164,8 @@ target_link_libraries(vda5050_master
     ${PROJECT_NAME}::json_utils
     ${PROJECT_NAME}::transport
     ${PROJECT_NAME}::execution
+    ${PROJECT_NAME}::order_utils
+    ${PROJECT_NAME}::errors
 )
 target_include_directories(vda5050_master
   PUBLIC
@@ -287,6 +289,16 @@ if(BUILD_TESTING)
     test/master/test_unit_agv.cpp
   )
   target_link_libraries(test_master vda5050_core::master)
+
+  ament_add_gmock(test_master_validation
+    test/master/test_unit_schema_validator.cpp
+    test/master/test_unit_pre_send_validator.cpp
+    test/master/test_unit_traversability_validator.cpp
+    test/master/test_unit_action_conflict_validator.cpp
+    test/master/test_unit_instant_action_mode_validator.cpp
+    test/master/test_unit_factsheet_alignment.cpp
+  )
+  target_link_libraries(test_master_validation vda5050_core::master)
 
   ament_add_gmock(test_master_map
     test/master/test_unit_map_loader.cpp

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -287,6 +287,13 @@ if(BUILD_TESTING)
     test/master/test_unit_agv.cpp
   )
   target_link_libraries(test_master vda5050_core::master)
+
+  ament_add_gmock(test_master_map
+    test/master/test_unit_map_loader.cpp
+  )
+  target_link_libraries(test_master_map vda5050_core::master)
+  target_compile_definitions(test_master_map PRIVATE
+    VDA5050_CORE__MASTER__SAMPLE_MAP_PATH="${CMAKE_CURRENT_SOURCE_DIR}/test/master/data/sample_map.json")
 endif()
 
 # Install linter macro

--- a/vda5050_core/include/vda5050_core/errors/error_codes.hpp
+++ b/vda5050_core/include/vda5050_core/errors/error_codes.hpp
@@ -28,6 +28,19 @@ namespace errors {
 // Error Codes for vda5050_types::Error::error_type field
 inline const std::string GraphValidationError = "graphValidationError";
 inline const std::string OrderUpdateError = "orderUpdateError";
+inline const std::string SchemaValidationError = "schemaValidationError";
+inline const std::string PreSendValidationError = "preSendValidationError";
+inline const std::string TraversabilityValidationError =
+  "traversabilityValidationError";
+inline const std::string ActionConflictValidationError =
+  "actionConflictValidationError";
+inline const std::string MapValidationError = "mapValidationError";
+
+// Mirrors the literal currently hardcoded in
+// vda5050_core::execution::ProtocolAdapter::subscribe<T>(); centralized here
+// so future call sites reference it symbolically.
+inline const std::string JsonDeserializationError =
+  "JSON_DESERIALIZATION_ERROR";
 
 // Reference key string for vda5050_types::ErrorReference::key
 inline const std::string RefOrderId = "orderId";
@@ -35,6 +48,7 @@ inline const std::string RefOrderUpdateId = "orderUpdateId";
 inline const std::string RefNodeId = "nodeId";
 inline const std::string RefEdgeId = "edgeId";
 inline const std::string RefSequenceId = "sequenceId";
+inline const std::string RefActionId = "actionId";
 
 }  // namespace errors
 }  // namespace vda5050_core

--- a/vda5050_core/include/vda5050_core/master/map/map.hpp
+++ b/vda5050_core/include/vda5050_core/master/map/map.hpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__MASTER__MAP__MAP_HPP_
+#define VDA5050_CORE__MASTER__MAP__MAP_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace vda5050_core::master {
+
+// Master-side static topology map (loaded once from JSON at startup).
+
+enum class MapStatus : std::uint8_t
+{
+  ENABLED = 0,
+  DISABLED = 1,
+};
+
+struct MapInfo
+{
+  std::string map_id;
+  std::string map_version;
+  MapStatus map_status = MapStatus::ENABLED;
+  std::string map_descriptor;
+};
+
+struct MapNode
+{
+  std::string node_id;
+  double x = 0.0;
+  double y = 0.0;
+  std::optional<double> theta;
+  std::optional<double> allowed_deviation_xy;
+  std::optional<double> allowed_deviation_theta;
+  std::string map_description;
+};
+
+struct MapEdge
+{
+  std::string edge_id;
+  std::string start_node_id;
+  std::string end_node_id;
+  bool bidirectional = false;
+  std::optional<double> max_speed;  ///< [m/s]
+  std::optional<double> length;     ///< [m]
+};
+
+struct Map
+{
+  MapInfo info;
+  std::vector<MapNode> nodes;
+  std::vector<MapEdge> edges;
+  std::unordered_map<std::string, std::size_t> node_index;
+  std::unordered_map<std::string, std::size_t> edge_index;
+  std::chrono::system_clock::time_point loaded_at;
+  std::string source_path;
+
+  const MapNode* find_node(const std::string& id) const;
+  const MapEdge* find_edge(const std::string& id) const;
+};
+
+}  // namespace vda5050_core::master
+
+#endif  // VDA5050_CORE__MASTER__MAP__MAP_HPP_

--- a/vda5050_core/include/vda5050_core/master/map/map_loader.hpp
+++ b/vda5050_core/include/vda5050_core/master/map/map_loader.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__MASTER__MAP__MAP_LOADER_HPP_
+#define VDA5050_CORE__MASTER__MAP__MAP_LOADER_HPP_
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "vda5050_core/master/map/map.hpp"
+
+namespace vda5050_core::master {
+
+// Loads one topology map from a JSON config file (lenient on unknown keys).
+
+enum class MapLoadErrorType : std::uint8_t
+{
+  FILE_NOT_FOUND,
+  FILE_READ_FAILED,
+  JSON_PARSE_ERROR,
+  MISSING_REQUIRED_FIELD,
+  DUPLICATE_NODE_ID,
+  DUPLICATE_EDGE_ID,
+  DANGLING_EDGE_REF,
+  EMPTY_MAP,
+};
+
+struct MapLoadError
+{
+  MapLoadErrorType type;
+  std::string description;
+};
+
+// Success: `map` set, `errors` empty (bool() true). Failure: the reverse.
+struct MapLoadResult
+{
+  std::optional<Map> map;
+  std::vector<MapLoadError> errors;
+
+  explicit operator bool() const
+  {
+    return errors.empty() && map.has_value();
+  }
+};
+
+MapLoadResult load_from_file(const std::string& path);
+
+MapLoadResult load_from_json(
+  const nlohmann::json& json, const std::string& source_path = "");
+
+}  // namespace vda5050_core::master
+
+#endif  // VDA5050_CORE__MASTER__MAP__MAP_LOADER_HPP_

--- a/vda5050_core/include/vda5050_core/master/standard_names.hpp
+++ b/vda5050_core/include/vda5050_core/master/standard_names.hpp
@@ -20,6 +20,7 @@
 #define VDA5050_CORE__MASTER__STANDARD_NAMES_HPP_
 
 #include <string>
+#include <vector>
 
 namespace vda5050_core {
 
@@ -61,6 +62,13 @@ constexpr QosLevel InstantActionsQos = QosLevel::AtMostOnce;
 
 constexpr int ConnectionHeartbeatInterval = 15;  // seconds
 constexpr int StateHeartbeatInterval = 30;       // seconds
+
+/// \brief VDA5050 protocol versions accepted by the schema validator.
+///
+/// The master rejects (outgoing) or drops (incoming) any message whose
+/// header.version is not in this set. Ships with 2.0.0 only; add a 2.1.0
+/// entry when that migration lands.
+inline const std::vector<std::string> SupportedSchemaVersions = {"2.0.0"};
 
 }  // namespace master
 }  // namespace vda5050_core

--- a/vda5050_core/include/vda5050_core/master/validation/action_conflict_validator.hpp
+++ b/vda5050_core/include/vda5050_core/master/validation/action_conflict_validator.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__MASTER__VALIDATION__ACTION_CONFLICT_VALIDATOR_HPP_
+#define VDA5050_CORE__MASTER__VALIDATION__ACTION_CONFLICT_VALIDATOR_HPP_
+
+#include "vda5050_core/master/validation/pre_send_validator.hpp"
+#include "vda5050_core/order_utils/validation_result.hpp"
+#include "vda5050_core/types/instant_actions.hpp"
+
+namespace vda5050_core::master {
+
+// Does an instant action collide with the AGV's running actions / driving?
+// (blocking_type: NONE ok; SOFT blocked while driving; HARD blocked while
+// driving or any active action.)
+
+vda5050_core::order_utils::ValidationResult validate_action_conflict(
+  const PreSendContext& ctx,
+  const vda5050_core::types::InstantActions& actions);
+
+}  // namespace vda5050_core::master
+
+#endif  // VDA5050_CORE__MASTER__VALIDATION__ACTION_CONFLICT_VALIDATOR_HPP_

--- a/vda5050_core/include/vda5050_core/master/validation/factsheet_alignment.hpp
+++ b/vda5050_core/include/vda5050_core/master/validation/factsheet_alignment.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__MASTER__VALIDATION__FACTSHEET_ALIGNMENT_HPP_
+#define VDA5050_CORE__MASTER__VALIDATION__FACTSHEET_ALIGNMENT_HPP_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "vda5050_core/master/map/map.hpp"
+#include "vda5050_core/types/factsheet.hpp"
+
+namespace vda5050_core::master {
+
+// Cross-checks a loaded Map against an AGV factsheet (speed capability).
+
+enum class AlignmentSeverity : std::uint8_t
+{
+  WARNING = 0,
+  ERROR = 1,
+};
+
+struct AlignmentFinding
+{
+  AlignmentSeverity severity;
+  std::string code;
+  std::string description;
+};
+
+struct FactsheetAlignmentResult
+{
+  std::vector<AlignmentFinding> findings;
+  bool has_error() const;
+};
+
+FactsheetAlignmentResult check_factsheet_alignment(
+  const Map& map, const vda5050_core::types::Factsheet& factsheet);
+
+}  // namespace vda5050_core::master
+
+#endif  // VDA5050_CORE__MASTER__VALIDATION__FACTSHEET_ALIGNMENT_HPP_

--- a/vda5050_core/include/vda5050_core/master/validation/instant_action_mode_validator.hpp
+++ b/vda5050_core/include/vda5050_core/master/validation/instant_action_mode_validator.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__MASTER__VALIDATION__INSTANT_ACTION_MODE_VALIDATOR_HPP_
+#define VDA5050_CORE__MASTER__VALIDATION__INSTANT_ACTION_MODE_VALIDATOR_HPP_
+
+#include <string>
+
+#include "vda5050_core/master/validation/pre_send_validator.hpp"
+#include "vda5050_core/order_utils/validation_result.hpp"
+#include "vda5050_core/types/instant_actions.hpp"
+
+namespace vda5050_core::master {
+
+// Operating-mode gate: in non-AUTOMATIC modes, only the predefined
+// instant-scope actions (is_mode_exempt_action_type) may be sent.
+
+vda5050_core::order_utils::ValidationResult validate_instant_action_mode(
+  const PreSendContext& ctx,
+  const vda5050_core::types::InstantActions& actions);
+
+bool is_mode_exempt_action_type(const std::string& action_type);
+
+}  // namespace vda5050_core::master
+
+#endif  // VDA5050_CORE__MASTER__VALIDATION__INSTANT_ACTION_MODE_VALIDATOR_HPP_

--- a/vda5050_core/include/vda5050_core/master/validation/pre_send_validator.hpp
+++ b/vda5050_core/include/vda5050_core/master/validation/pre_send_validator.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__MASTER__VALIDATION__PRE_SEND_VALIDATOR_HPP_
+#define VDA5050_CORE__MASTER__VALIDATION__PRE_SEND_VALIDATOR_HPP_
+
+#include <memory>
+#include <optional>
+
+#include "vda5050_core/master/agv.hpp"
+#include "vda5050_core/master/map/map.hpp"
+#include "vda5050_core/order_utils/validation_result.hpp"
+#include "vda5050_core/types/connection_state.hpp"
+#include "vda5050_core/types/factsheet.hpp"
+#include "vda5050_core/types/order.hpp"
+#include "vda5050_core/types/state.hpp"
+
+namespace vda5050_core::master {
+
+// AGV-readiness gate before publish.
+
+// Lock-free AGV snapshot captured once; serves the whole publish chain.
+struct PreSendContext
+{
+  vda5050_core::types::ConnectionState connection_status;
+  std::optional<vda5050_core::types::State> last_state;
+  std::optional<vda5050_core::types::Factsheet> last_factsheet;
+  AGVState operational_state;
+  std::optional<vda5050_core::types::Order> active_order;
+  std::shared_ptr<const Map> loaded_map;
+};
+
+vda5050_core::order_utils::ValidationResult validate_pre_send(
+  const PreSendContext& ctx);
+
+}  // namespace vda5050_core::master
+
+#endif  // VDA5050_CORE__MASTER__VALIDATION__PRE_SEND_VALIDATOR_HPP_

--- a/vda5050_core/include/vda5050_core/master/validation/schema_validator.hpp
+++ b/vda5050_core/include/vda5050_core/master/validation/schema_validator.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__MASTER__VALIDATION__SCHEMA_VALIDATOR_HPP_
+#define VDA5050_CORE__MASTER__VALIDATION__SCHEMA_VALIDATOR_HPP_
+
+#include "vda5050_core/order_utils/validation_result.hpp"
+#include "vda5050_core/types/connection.hpp"
+#include "vda5050_core/types/factsheet.hpp"
+#include "vda5050_core/types/instant_actions.hpp"
+#include "vda5050_core/types/order.hpp"
+#include "vda5050_core/types/state.hpp"
+#include "vda5050_core/types/visualization.hpp"
+
+namespace vda5050_core::master {
+
+// Structural field checks on a typed message (version, non-empty ids).
+
+vda5050_core::order_utils::ValidationResult validate_order_schema(
+  const vda5050_core::types::Order& order);
+
+vda5050_core::order_utils::ValidationResult validate_instant_actions_schema(
+  const vda5050_core::types::InstantActions& actions);
+
+vda5050_core::order_utils::ValidationResult validate_state_schema(
+  const vda5050_core::types::State& state);
+
+vda5050_core::order_utils::ValidationResult validate_connection_schema(
+  const vda5050_core::types::Connection& connection);
+
+vda5050_core::order_utils::ValidationResult validate_factsheet_schema(
+  const vda5050_core::types::Factsheet& factsheet);
+
+vda5050_core::order_utils::ValidationResult validate_visualization_schema(
+  const vda5050_core::types::Visualization& visualization);
+
+}  // namespace vda5050_core::master
+
+#endif  // VDA5050_CORE__MASTER__VALIDATION__SCHEMA_VALIDATOR_HPP_

--- a/vda5050_core/include/vda5050_core/master/validation/traversability_validator.hpp
+++ b/vda5050_core/include/vda5050_core/master/validation/traversability_validator.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__MASTER__VALIDATION__TRAVERSABILITY_VALIDATOR_HPP_
+#define VDA5050_CORE__MASTER__VALIDATION__TRAVERSABILITY_VALIDATOR_HPP_
+
+#include "vda5050_core/master/validation/pre_send_validator.hpp"
+#include "vda5050_core/order_utils/validation_result.hpp"
+#include "vda5050_core/types/instant_actions.hpp"
+#include "vda5050_core/types/order.hpp"
+
+namespace vda5050_core::master {
+
+// Can this AGV physically execute the message? (reachability + action
+// capability + array-size limits; factsheet checks skip when none cached).
+
+vda5050_core::order_utils::ValidationResult validate_traversability(
+  const PreSendContext& ctx, const vda5050_core::types::Order& order);
+
+vda5050_core::order_utils::ValidationResult validate_traversability(
+  const PreSendContext& ctx,
+  const vda5050_core::types::InstantActions& actions);
+
+}  // namespace vda5050_core::master
+
+#endif  // VDA5050_CORE__MASTER__VALIDATION__TRAVERSABILITY_VALIDATOR_HPP_

--- a/vda5050_core/src/master/map/map.cpp
+++ b/vda5050_core/src/master/map/map.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/master/map/map.hpp"
+
+namespace vda5050_core::master {
+
+const MapNode* Map::find_node(const std::string& id) const
+{
+  auto it = node_index.find(id);
+  if (it == node_index.end()) return nullptr;
+  return &nodes[it->second];
+}
+
+const MapEdge* Map::find_edge(const std::string& id) const
+{
+  auto it = edge_index.find(id);
+  if (it == edge_index.end()) return nullptr;
+  return &edges[it->second];
+}
+
+}  // namespace vda5050_core::master

--- a/vda5050_core/src/master/map/map_loader.cpp
+++ b/vda5050_core/src/master/map/map_loader.cpp
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/master/map/map_loader.hpp"
+
+#include <chrono>
+#include <fstream>
+#include <ios>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace vda5050_core::master {
+
+namespace {
+
+void add_error(
+  std::vector<MapLoadError>& errors, MapLoadErrorType type, std::string desc)
+{
+  errors.push_back({type, std::move(desc)});
+}
+
+// Defaults to ENABLED when the field is absent.
+MapStatus parse_map_status(const nlohmann::json& info)
+{
+  if (!info.contains("map_status")) return MapStatus::ENABLED;
+  const auto s = info.at("map_status").get<std::string>();
+  if (s == "DISABLED") return MapStatus::DISABLED;
+  return MapStatus::ENABLED;
+}
+
+bool parse_map_info(
+  const nlohmann::json& json, MapInfo& info, std::vector<MapLoadError>& errors)
+{
+  if (!json.contains("map_info") || !json.at("map_info").is_object())
+  {
+    add_error(
+      errors, MapLoadErrorType::MISSING_REQUIRED_FIELD,
+      "Top-level field 'map_info' is missing or not an object.");
+    return false;
+  }
+  const auto& mi = json.at("map_info");
+  if (!mi.contains("map_id") || !mi.at("map_id").is_string())
+  {
+    add_error(
+      errors, MapLoadErrorType::MISSING_REQUIRED_FIELD,
+      "map_info.map_id is missing or not a string.");
+    return false;
+  }
+  if (!mi.contains("map_version") || !mi.at("map_version").is_string())
+  {
+    add_error(
+      errors, MapLoadErrorType::MISSING_REQUIRED_FIELD,
+      "map_info.map_version is missing or not a string.");
+    return false;
+  }
+  info.map_id = mi.at("map_id").get<std::string>();
+  info.map_version = mi.at("map_version").get<std::string>();
+  info.map_status = parse_map_status(mi);
+  if (mi.contains("map_descriptor") && mi.at("map_descriptor").is_string())
+  {
+    info.map_descriptor = mi.at("map_descriptor").get<std::string>();
+  }
+  return true;
+}
+
+bool parse_node(const nlohmann::json& jn, MapNode& out, std::string& reason)
+{
+  if (!jn.contains("node_id") || !jn.at("node_id").is_string())
+  {
+    reason = "node missing required string field 'node_id'";
+    return false;
+  }
+  if (
+    !jn.contains("x") || !jn.at("x").is_number() || !jn.contains("y") ||
+    !jn.at("y").is_number())
+  {
+    reason = "node '" + jn.value("node_id", std::string{}) +
+             "' missing required numeric fields 'x' / 'y'";
+    return false;
+  }
+  out.node_id = jn.at("node_id").get<std::string>();
+  out.x = jn.at("x").get<double>();
+  out.y = jn.at("y").get<double>();
+  if (jn.contains("theta") && jn.at("theta").is_number())
+  {
+    out.theta = jn.at("theta").get<double>();
+  }
+  if (
+    jn.contains("allowed_deviation_xy") &&
+    jn.at("allowed_deviation_xy").is_number())
+  {
+    out.allowed_deviation_xy = jn.at("allowed_deviation_xy").get<double>();
+  }
+  if (
+    jn.contains("allowed_deviation_theta") &&
+    jn.at("allowed_deviation_theta").is_number())
+  {
+    out.allowed_deviation_theta =
+      jn.at("allowed_deviation_theta").get<double>();
+  }
+  if (jn.contains("map_description") && jn.at("map_description").is_string())
+  {
+    out.map_description = jn.at("map_description").get<std::string>();
+  }
+  return true;
+}
+
+bool parse_edge(const nlohmann::json& je, MapEdge& out, std::string& reason)
+{
+  if (!je.contains("edge_id") || !je.at("edge_id").is_string())
+  {
+    reason = "edge missing required string field 'edge_id'";
+    return false;
+  }
+  if (
+    !je.contains("start_node_id") || !je.at("start_node_id").is_string() ||
+    !je.contains("end_node_id") || !je.at("end_node_id").is_string())
+  {
+    reason = "edge '" + je.value("edge_id", std::string{}) +
+             "' missing required string fields 'start_node_id' / "
+             "'end_node_id'";
+    return false;
+  }
+  out.edge_id = je.at("edge_id").get<std::string>();
+  out.start_node_id = je.at("start_node_id").get<std::string>();
+  out.end_node_id = je.at("end_node_id").get<std::string>();
+  if (je.contains("bidirectional") && je.at("bidirectional").is_boolean())
+  {
+    out.bidirectional = je.at("bidirectional").get<bool>();
+  }
+  if (je.contains("max_speed") && je.at("max_speed").is_number())
+  {
+    out.max_speed = je.at("max_speed").get<double>();
+  }
+  if (je.contains("length") && je.at("length").is_number())
+  {
+    out.length = je.at("length").get<double>();
+  }
+  return true;
+}
+
+}  // namespace
+
+MapLoadResult load_from_file(const std::string& path)
+{
+  MapLoadResult result;
+  std::ifstream in(path);
+  if (!in.is_open())
+  {
+    add_error(
+      result.errors, MapLoadErrorType::FILE_NOT_FOUND,
+      "Cannot open map config file '" + path + "'.");
+    return result;
+  }
+  std::stringstream buf;
+  buf << in.rdbuf();
+  if (in.bad())
+  {
+    add_error(
+      result.errors, MapLoadErrorType::FILE_READ_FAILED,
+      "I/O error while reading map config file '" + path + "'.");
+    return result;
+  }
+  nlohmann::json parsed;
+  try
+  {
+    parsed = nlohmann::json::parse(buf.str());
+  }
+  catch (const nlohmann::json::parse_error& e)
+  {
+    add_error(
+      result.errors, MapLoadErrorType::JSON_PARSE_ERROR,
+      std::string("JSON parse error in '") + path + "': " + e.what());
+    return result;
+  }
+  return load_from_json(parsed, path);
+}
+
+MapLoadResult load_from_json(
+  const nlohmann::json& json, const std::string& source_path)
+{
+  MapLoadResult result;
+  if (!json.is_object())
+  {
+    add_error(
+      result.errors, MapLoadErrorType::JSON_PARSE_ERROR,
+      "Top-level JSON value is not an object.");
+    return result;
+  }
+
+  Map map;
+  map.source_path = source_path;
+  map.loaded_at = std::chrono::system_clock::now();
+
+  if (!parse_map_info(json, map.info, result.errors)) return result;
+
+  if (!json.contains("nodes") || !json.at("nodes").is_array())
+  {
+    add_error(
+      result.errors, MapLoadErrorType::MISSING_REQUIRED_FIELD,
+      "Top-level field 'nodes' is missing or not an array.");
+    return result;
+  }
+  const auto& jnodes = json.at("nodes");
+  if (jnodes.empty())
+  {
+    add_error(
+      result.errors, MapLoadErrorType::EMPTY_MAP,
+      "Map config has no nodes — at least one is required.");
+    return result;
+  }
+  std::unordered_set<std::string> seen_node_ids;
+  for (std::size_t i = 0; i < jnodes.size(); ++i)
+  {
+    MapNode n;
+    std::string reason;
+    if (!parse_node(jnodes[i], n, reason))
+    {
+      add_error(
+        result.errors, MapLoadErrorType::MISSING_REQUIRED_FIELD,
+        "nodes[" + std::to_string(i) + "]: " + reason);
+      continue;
+    }
+    if (!seen_node_ids.insert(n.node_id).second)
+    {
+      add_error(
+        result.errors, MapLoadErrorType::DUPLICATE_NODE_ID,
+        "Duplicate node_id '" + n.node_id + "' (nodes[" + std::to_string(i) +
+          "]).");
+      continue;
+    }
+    map.node_index.emplace(n.node_id, map.nodes.size());
+    map.nodes.push_back(std::move(n));
+  }
+
+  // Edges (optional — a map with only nodes is legal).
+  if (json.contains("edges") && json.at("edges").is_array())
+  {
+    const auto& jedges = json.at("edges");
+    std::unordered_set<std::string> seen_edge_ids;
+    for (std::size_t i = 0; i < jedges.size(); ++i)
+    {
+      MapEdge e;
+      std::string reason;
+      if (!parse_edge(jedges[i], e, reason))
+      {
+        add_error(
+          result.errors, MapLoadErrorType::MISSING_REQUIRED_FIELD,
+          "edges[" + std::to_string(i) + "]: " + reason);
+        continue;
+      }
+      if (!seen_edge_ids.insert(e.edge_id).second)
+      {
+        add_error(
+          result.errors, MapLoadErrorType::DUPLICATE_EDGE_ID,
+          "Duplicate edge_id '" + e.edge_id + "' (edges[" + std::to_string(i) +
+            "]).");
+        continue;
+      }
+      if (
+        seen_node_ids.find(e.start_node_id) == seen_node_ids.end() ||
+        seen_node_ids.find(e.end_node_id) == seen_node_ids.end())
+      {
+        add_error(
+          result.errors, MapLoadErrorType::DANGLING_EDGE_REF,
+          "Edge '" + e.edge_id + "' references unknown node id '" +
+            e.start_node_id + "' or '" + e.end_node_id + "'.");
+        continue;
+      }
+      map.edge_index.emplace(e.edge_id, map.edges.size());
+      map.edges.push_back(std::move(e));
+    }
+  }
+
+  if (!result.errors.empty()) return result;
+
+  result.map = std::move(map);
+  return result;
+}
+
+}  // namespace vda5050_core::master

--- a/vda5050_core/src/master/validation/action_conflict_validator.cpp
+++ b/vda5050_core/src/master/validation/action_conflict_validator.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/master/validation/action_conflict_validator.hpp"
+
+#include <string>
+#include <vector>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/errors/error_factory.hpp"
+
+namespace vda5050_core::master {
+
+namespace {
+
+using ::vda5050_core::errors::ActionConflictValidationError;
+using ::vda5050_core::errors::create_error;
+using ::vda5050_core::errors::RefActionId;
+using ::vda5050_core::order_utils::ValidationResult;
+using ::vda5050_core::types::ActionStatus;
+using ::vda5050_core::types::BlockingType;
+using ::vda5050_core::types::ErrorReference;
+
+// Diagnostic keywords embedded in error_description; callers map errors back
+// to decision cases by substring lookup.
+constexpr const char* kKeyHardBlocked = "HARD_ACTION_BLOCKED";
+constexpr const char* kKeyBlockedByDriving = "ACTION_BLOCKED_BY_DRIVING";
+
+// Active statuses: the AGV is committed to the action. PAUSED is included
+// (mid-pause HARD could collide on resume); FINISHED / FAILED are not.
+constexpr bool is_active_status(ActionStatus s)
+{
+  return s == ActionStatus::WAITING || s == ActionStatus::INITIALIZING ||
+         s == ActionStatus::RUNNING || s == ActionStatus::PAUSED;
+}
+
+}  // namespace
+
+ValidationResult validate_action_conflict(
+  const PreSendContext& ctx, const vda5050_core::types::InstantActions& actions)
+{
+  ValidationResult res;
+
+  auto add_error =
+    [&](const std::string& description, std::vector<ErrorReference> refs) {
+      res.errors.push_back(
+        create_error(ActionConflictValidationError, description, refs));
+    };
+
+  // No reported state => no view of actions/driving; pass through.
+  if (!ctx.last_state.has_value()) return res;
+
+  const auto& state = ctx.last_state.value();
+  const bool driving = state.driving;
+
+  bool any_active = false;
+  for (const auto& as : state.action_states)
+  {
+    if (is_active_status(as.action_status))
+    {
+      any_active = true;
+      break;
+    }
+  }
+
+  for (const auto& action : actions.actions)
+  {
+    switch (action.blocking_type)
+    {
+      case BlockingType::NONE:
+        break;
+      case BlockingType::SOFT:
+        if (driving)
+        {
+          add_error(
+            std::string(kKeyBlockedByDriving) + ": SOFT-blocking action '" +
+              action.action_type +
+              "' rejected because AGV is driving (vehicle must "
+              "not drive)",
+            {{RefActionId, action.action_id}});
+          return res;
+        }
+        break;
+      case BlockingType::HARD:
+        if (driving)
+        {
+          add_error(
+            std::string(kKeyBlockedByDriving) + ": HARD-blocking action '" +
+              action.action_type +
+              "' rejected because AGV is driving (vehicle must "
+              "not drive)",
+            {{RefActionId, action.action_id}});
+          return res;
+        }
+        if (any_active)
+        {
+          add_error(
+            std::string(kKeyHardBlocked) + ": HARD-blocking action '" +
+              action.action_type +
+              "' rejected because AGV has active actions in flight "
+              "(must not be executed in parallel)",
+            {{RefActionId, action.action_id}});
+          return res;
+        }
+        break;
+    }
+  }
+
+  return res;
+}
+
+}  // namespace vda5050_core::master

--- a/vda5050_core/src/master/validation/factsheet_alignment.cpp
+++ b/vda5050_core/src/master/validation/factsheet_alignment.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/master/validation/factsheet_alignment.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+
+namespace vda5050_core::master {
+
+bool FactsheetAlignmentResult::has_error() const
+{
+  return std::any_of(findings.begin(), findings.end(), [](const auto& f) {
+    return f.severity == AlignmentSeverity::ERROR;
+  });
+}
+
+FactsheetAlignmentResult check_factsheet_alignment(
+  const Map& map, const vda5050_core::types::Factsheet& factsheet)
+{
+  FactsheetAlignmentResult result;
+
+  // SpeedExceedsCapability: flag edges whose max_speed exceeds the AGV's.
+  const double agv_speed_max = factsheet.physical_parameters.speed_max;
+  for (const auto& edge : map.edges)
+  {
+    if (!edge.max_speed.has_value()) continue;
+    const double edge_max = edge.max_speed.value();
+    if (edge_max > agv_speed_max)
+    {
+      std::ostringstream oss;
+      oss << "Edge '" << edge.edge_id << "' max_speed=" << edge_max
+          << " m/s exceeds AGV factsheet physical_parameters.speed_max="
+          << agv_speed_max << " m/s.";
+      result.findings.push_back(
+        {AlignmentSeverity::ERROR, "SpeedExceedsCapability", oss.str()});
+    }
+  }
+
+  return result;
+}
+
+}  // namespace vda5050_core::master

--- a/vda5050_core/src/master/validation/instant_action_mode_validator.cpp
+++ b/vda5050_core/src/master/validation/instant_action_mode_validator.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/master/validation/instant_action_mode_validator.hpp"
+
+#include <set>
+#include <string>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/errors/error_factory.hpp"
+
+namespace vda5050_core::master {
+
+namespace {
+
+// Predefined instant-scope actions exempt from the mode gate.
+const std::set<std::string>& exempt_action_types()
+{
+  static const std::set<std::string> kExempt = {
+    "stateRequest", "factsheetRequest", "logReport",
+    "cancelOrder",  "initPosition",     "startPause",
+    "stopPause",    "startCharging",    "stopCharging"};
+  return kExempt;
+}
+
+// Diagnostic keyword embedded in error_description for caller substring lookup.
+constexpr const char* kKeyModeNotAuto = "MODE_NOT_AUTOMATIC";
+
+}  // namespace
+
+bool is_mode_exempt_action_type(const std::string& action_type)
+{
+  return exempt_action_types().count(action_type) != 0;
+}
+
+vda5050_core::order_utils::ValidationResult validate_instant_action_mode(
+  const PreSendContext& ctx, const vda5050_core::types::InstantActions& actions)
+{
+  vda5050_core::order_utils::ValidationResult res;
+
+  // No reported state => unknown mode; pass through.
+  if (!ctx.last_state.has_value()) return res;
+
+  const auto mode = ctx.last_state->operating_mode;
+
+  if (
+    mode == vda5050_core::types::OperatingMode::AUTOMATIC ||
+    mode == vda5050_core::types::OperatingMode::SEMIAUTOMATIC)
+  {
+    return res;
+  }
+
+  for (const auto& action : actions.actions)
+  {
+    if (is_mode_exempt_action_type(action.action_type)) continue;
+
+    res.errors.push_back(vda5050_core::errors::create_error(
+      vda5050_core::errors::PreSendValidationError,
+      std::string(kKeyModeNotAuto) + ": action_type '" + action.action_type +
+        "' is not on the instant-scope allowlist and AGV is not in "
+        "AUTOMATIC / SEMIAUTOMATIC operating_mode (master must "
+        "not send driving orders or non-recovery actions in MANUAL / "
+        "SERVICE / TEACHIN)",
+      {{vda5050_core::errors::RefActionId, action.action_id}}));
+    return res;  // short-circuit on first failure
+  }
+
+  return res;
+}
+
+}  // namespace vda5050_core::master

--- a/vda5050_core/src/master/validation/pre_send_validator.cpp
+++ b/vda5050_core/src/master/validation/pre_send_validator.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/master/validation/pre_send_validator.hpp"
+
+#include <string>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/errors/error_factory.hpp"
+
+namespace vda5050_core::master {
+
+vda5050_core::order_utils::ValidationResult validate_pre_send(
+  const PreSendContext& ctx)
+{
+  vda5050_core::order_utils::ValidationResult res;
+
+  auto add_error = [&](const std::string& description) {
+    res.errors.push_back(vda5050_core::errors::create_error(
+      vda5050_core::errors::PreSendValidationError, description, {}));
+  };
+
+  // No-map gate: can't validate node/edge ids without a loaded topology.
+  if (ctx.loaded_map == nullptr)
+  {
+    res.errors.push_back(vda5050_core::errors::create_error(
+      vda5050_core::errors::MapValidationError,
+      "Master has no map loaded — call load_map_from_config() before "
+      "publishing.",
+      {}));
+    return res;
+  }
+
+  if (ctx.connection_status != vda5050_core::types::ConnectionState::ONLINE)
+  {
+    add_error("AGV connection_status is not ONLINE");
+  }
+
+  if (
+    ctx.operational_state == AGVState::ERROR ||
+    ctx.operational_state == AGVState::STATE_UNKNOWN)
+  {
+    add_error(
+      std::string("AGV operational_state is ") +
+      (ctx.operational_state == AGVState::ERROR ? "ERROR" : "STATE_UNKNOWN"));
+  }
+
+  if (!ctx.last_state.has_value())
+  {
+    add_error("AGV has not yet reported any State");
+    return res;
+  }
+
+  if (
+    ctx.last_state->operating_mode !=
+    vda5050_core::types::OperatingMode::AUTOMATIC)
+  {
+    add_error("AGV operating_mode is not AUTOMATIC");
+  }
+
+  if (
+    !ctx.last_state->agv_position.has_value() ||
+    !ctx.last_state->agv_position->position_initialized)
+  {
+    add_error("AGV position is not initialized");
+  }
+
+  return res;
+}
+
+}  // namespace vda5050_core::master

--- a/vda5050_core/src/master/validation/schema_validator.cpp
+++ b/vda5050_core/src/master/validation/schema_validator.cpp
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/master/validation/schema_validator.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/errors/error_factory.hpp"
+#include "vda5050_core/master/standard_names.hpp"
+
+namespace vda5050_core::master {
+
+namespace {
+
+using ::vda5050_core::errors::create_error;
+using ::vda5050_core::errors::SchemaValidationError;
+using ::vda5050_core::order_utils::ValidationResult;
+using ::vda5050_core::types::ErrorReference;
+
+using AddErrorFn =
+  std::function<void(const std::string&, std::vector<ErrorReference>)>;
+
+void validate_header_common(
+  const ::vda5050_core::types::Header& header, const AddErrorFn& add_error)
+{
+  const auto& supported = SupportedSchemaVersions;
+  if (
+    std::find(supported.begin(), supported.end(), header.version) ==
+    supported.end())
+  {
+    add_error(
+      "header.version '" + header.version +
+        "' is not in SupportedSchemaVersions",
+      {});
+  }
+
+  if (header.manufacturer.empty())
+  {
+    add_error("header.manufacturer must be non-empty", {});
+  }
+
+  if (header.serial_number.empty())
+  {
+    add_error("header.serial_number must be non-empty", {});
+  }
+}
+
+void validate_action_schema(
+  const ::vda5050_core::types::Action& action, const AddErrorFn& add_error)
+{
+  if (action.action_id.empty())
+  {
+    add_error("Action.action_id must be non-empty", {});
+  }
+  if (action.action_type.empty())
+  {
+    add_error(
+      "Action.action_type must be non-empty (action_id='" + action.action_id +
+        "')",
+      {});
+  }
+}
+
+}  // namespace
+
+ValidationResult validate_order_schema(
+  const ::vda5050_core::types::Order& order)
+{
+  ValidationResult res;
+
+  auto add_error =
+    [&](const std::string& description, std::vector<ErrorReference> refs) {
+      refs.push_back({::vda5050_core::errors::RefOrderId, order.order_id});
+      refs.push_back(
+        {::vda5050_core::errors::RefOrderUpdateId,
+         std::to_string(order.order_update_id)});
+      res.errors.push_back(
+        create_error(SchemaValidationError, description, refs));
+    };
+
+  validate_header_common(order.header, add_error);
+
+  if (order.order_id.empty())
+  {
+    add_error("Order.order_id must be non-empty", {});
+  }
+
+  for (const auto& node : order.nodes)
+  {
+    if (node.node_id.empty())
+    {
+      add_error(
+        "Node.node_id must be non-empty",
+        {{::vda5050_core::errors::RefSequenceId,
+          std::to_string(node.sequence_id)}});
+    }
+    for (const auto& action : node.actions)
+    {
+      validate_action_schema(action, add_error);
+    }
+  }
+
+  for (const auto& edge : order.edges)
+  {
+    if (edge.edge_id.empty())
+    {
+      add_error(
+        "Edge.edge_id must be non-empty",
+        {{::vda5050_core::errors::RefSequenceId,
+          std::to_string(edge.sequence_id)}});
+    }
+    for (const auto& action : edge.actions)
+    {
+      validate_action_schema(action, add_error);
+    }
+  }
+
+  return res;
+}
+
+ValidationResult validate_instant_actions_schema(
+  const ::vda5050_core::types::InstantActions& actions)
+{
+  ValidationResult res;
+
+  auto add_error =
+    [&](const std::string& description, std::vector<ErrorReference> refs) {
+      res.errors.push_back(
+        create_error(SchemaValidationError, description, refs));
+    };
+
+  validate_header_common(actions.header, add_error);
+
+  for (const auto& action : actions.actions)
+  {
+    validate_action_schema(action, add_error);
+  }
+
+  return res;
+}
+
+ValidationResult validate_state_schema(
+  const ::vda5050_core::types::State& state)
+{
+  ValidationResult res;
+
+  auto add_error =
+    [&](const std::string& description, std::vector<ErrorReference> refs) {
+      res.errors.push_back(
+        create_error(SchemaValidationError, description, refs));
+    };
+
+  validate_header_common(state.header, add_error);
+
+  // order_id may legitimately be empty (no current order).
+  for (const auto& ns : state.node_states)
+  {
+    if (ns.node_id.empty())
+    {
+      add_error(
+        "State.node_states[].node_id must be non-empty when populated",
+        {{::vda5050_core::errors::RefSequenceId,
+          std::to_string(ns.sequence_id)}});
+    }
+  }
+
+  for (const auto& as : state.action_states)
+  {
+    if (as.action_id.empty())
+    {
+      add_error("State.action_states[].action_id must be non-empty", {});
+    }
+  }
+
+  for (const auto& err : state.errors)
+  {
+    if (err.error_type.empty())
+    {
+      add_error("State.errors[].error_type must be non-empty", {});
+    }
+  }
+
+  return res;
+}
+
+ValidationResult validate_connection_schema(
+  const ::vda5050_core::types::Connection& connection)
+{
+  ValidationResult res;
+
+  auto add_error =
+    [&](const std::string& description, std::vector<ErrorReference> refs) {
+      res.errors.push_back(
+        create_error(SchemaValidationError, description, refs));
+    };
+
+  validate_header_common(connection.header, add_error);
+  return res;
+}
+
+ValidationResult validate_factsheet_schema(
+  const ::vda5050_core::types::Factsheet& factsheet)
+{
+  ValidationResult res;
+
+  auto add_error =
+    [&](const std::string& description, std::vector<ErrorReference> refs) {
+      res.errors.push_back(
+        create_error(SchemaValidationError, description, refs));
+    };
+
+  validate_header_common(factsheet.header, add_error);
+  return res;
+}
+
+ValidationResult validate_visualization_schema(
+  const ::vda5050_core::types::Visualization& visualization)
+{
+  ValidationResult res;
+
+  auto add_error =
+    [&](const std::string& description, std::vector<ErrorReference> refs) {
+      res.errors.push_back(
+        create_error(SchemaValidationError, description, refs));
+    };
+
+  validate_header_common(visualization.header, add_error);
+  return res;
+}
+
+}  // namespace vda5050_core::master

--- a/vda5050_core/src/master/validation/traversability_validator.cpp
+++ b/vda5050_core/src/master/validation/traversability_validator.cpp
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/master/validation/traversability_validator.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/errors/error_factory.hpp"
+
+namespace vda5050_core::master {
+
+namespace {
+
+using ::vda5050_core::errors::create_error;
+using ::vda5050_core::errors::TraversabilityValidationError;
+using ::vda5050_core::order_utils::ValidationResult;
+using ::vda5050_core::types::AGVAction;
+using ::vda5050_core::types::ErrorReference;
+
+using AddErrorFn =
+  std::function<void(const std::string&, std::vector<ErrorReference>)>;
+
+const AGVAction* find_agv_action(
+  const vda5050_core::types::Factsheet& fs, const std::string& action_type)
+{
+  const auto& actions = fs.protocol_features.agv_actions;
+  auto it = std::find_if(
+    actions.begin(), actions.end(),
+    [&](const AGVAction& a) { return a.action_type == action_type; });
+  return (it == actions.end()) ? nullptr : &(*it);
+}
+
+void validate_action_against_factsheet(
+  const vda5050_core::types::Action& action,
+  vda5050_core::types::ActionScope expected_scope,
+  const vda5050_core::types::Factsheet& factsheet, const AddErrorFn& add_error)
+{
+  const AGVAction* agv_action = find_agv_action(factsheet, action.action_type);
+  if (agv_action == nullptr)
+  {
+    add_error(
+      "Action.action_type '" + action.action_type +
+        "' is not supported by AGV (not present in factsheet.agv_actions).",
+      {});
+    return;
+  }
+
+  const auto& scopes = agv_action->action_scopes;
+  if (std::find(scopes.begin(), scopes.end(), expected_scope) == scopes.end())
+  {
+    add_error(
+      "Action.action_type '" + action.action_type +
+        "' does not declare the required scope for its placement.",
+      {});
+  }
+
+  if (
+    action.action_parameters.has_value() &&
+    agv_action->action_parameters.has_value())
+  {
+    const auto& declared = agv_action->action_parameters.value();
+    for (const auto& p : action.action_parameters.value())
+    {
+      auto it = std::find_if(
+        declared.begin(), declared.end(),
+        [&](const vda5050_core::types::ActionParameterFactsheet& d) {
+          return d.key == p.key;
+        });
+      if (it == declared.end())
+      {
+        add_error(
+          "Action parameter key '" + p.key +
+            "' not declared by AGV for action_type '" + action.action_type +
+            "'.",
+          {});
+      }
+    }
+  }
+}
+
+// Reachability (state-driven; runs without a factsheet).
+void validate_reachability(
+  const PreSendContext& ctx, const vda5050_core::types::Order& order,
+  const AddErrorFn& add_error)
+{
+  if (order.nodes.empty())
+  {
+    return;  // the graph validator already rejects this
+  }
+
+  const auto& first = order.nodes.front();
+
+  if (!ctx.last_state.has_value())
+  {
+    add_error(
+      "Cannot determine reachability: AGV has not yet reported any State.", {});
+    return;
+  }
+  const auto& state = ctx.last_state.value();
+
+  if (state.last_node_id == first.node_id) return;
+
+  if (!first.node_position.has_value() || !state.agv_position.has_value())
+  {
+    add_error(
+      "Cannot determine reachability: AGV is not on first node and "
+      "either node_position or agv_position is missing.",
+      {{::vda5050_core::errors::RefNodeId, first.node_id}});
+    return;
+  }
+
+  const auto& np = first.node_position.value();
+  const auto& ap = state.agv_position.value();
+
+  // No declared deviation => must be exactly on the node.
+  const double allowed = np.allowed_deviation_x_y.value_or(0.0);
+
+  const double dx = ap.x - np.x;
+  const double dy = ap.y - np.y;
+  const double distance = std::hypot(dx, dy);
+
+  if (distance > allowed)
+  {
+    add_error(
+      "AGV is not within the first node's allowed_deviation_x_y "
+      "(distance=" +
+        std::to_string(distance) + " m, allowed=" + std::to_string(allowed) +
+        " m).",
+      {{::vda5050_core::errors::RefNodeId, first.node_id}});
+  }
+}
+
+void check_limit(
+  const std::optional<uint32_t>& limit, std::size_t actual,
+  const std::string& field_name, const AddErrorFn& add_error)
+{
+  if (limit.has_value() && actual > limit.value())
+  {
+    add_error(
+      "Order exceeds factsheet limit for " + field_name +
+        " (size=" + std::to_string(actual) +
+        ", max=" + std::to_string(limit.value()) + ").",
+      {});
+  }
+}
+
+// Fallback node-position tolerance when a Map node declares none.
+constexpr double kDefaultMapPositionDeviation = 0.5;
+
+// Pre: ctx.loaded_map non-null (guaranteed by pre_send's no-map gate).
+void validate_map_integrity_locked(
+  const PreSendContext& ctx, const vda5050_core::types::Order& order,
+  const AddErrorFn& add_error)
+{
+  const auto& m = *ctx.loaded_map;
+
+  for (const auto& node : order.nodes)
+  {
+    const auto* mn = m.find_node(node.node_id);
+    if (mn == nullptr)
+    {
+      add_error(
+        "Order node_id '" + node.node_id +
+          "' is not present in the master's loaded map.",
+        {{::vda5050_core::errors::RefNodeId, node.node_id}});
+      continue;
+    }
+    if (!node.node_position.has_value()) continue;
+    const auto& np = node.node_position.value();
+    const double allowed =
+      mn->allowed_deviation_xy.value_or(kDefaultMapPositionDeviation);
+    const double dx = np.x - mn->x;
+    const double dy = np.y - mn->y;
+    const double distance = std::hypot(dx, dy);
+    if (distance > allowed)
+    {
+      add_error(
+        "Order node '" + node.node_id +
+          "' nodePosition is outside the map's allowed_deviation_xy "
+          "(distance=" +
+          std::to_string(distance) + " m, allowed=" + std::to_string(allowed) +
+          " m).",
+        {{::vda5050_core::errors::RefNodeId, node.node_id}});
+    }
+  }
+
+  for (const auto& edge : order.edges)
+  {
+    const auto* me = m.find_edge(edge.edge_id);
+    if (me == nullptr)
+    {
+      add_error(
+        "Order edge_id '" + edge.edge_id +
+          "' is not present in the master's loaded map.",
+        {{::vda5050_core::errors::RefEdgeId, edge.edge_id}});
+      continue;
+    }
+    const bool forward =
+      (me->start_node_id == edge.start_node_id &&
+       me->end_node_id == edge.end_node_id);
+    const bool reverse =
+      me->bidirectional && (me->start_node_id == edge.end_node_id &&
+                            me->end_node_id == edge.start_node_id);
+    if (!forward && !reverse)
+    {
+      add_error(
+        "Order edge '" + edge.edge_id + "' endpoints (" + edge.start_node_id +
+          "->" + edge.end_node_id + ") do not match the map's edge (" +
+          me->start_node_id + "->" + me->end_node_id +
+          (me->bidirectional ? ", bidirectional" : ", one-way") + ").",
+        {{::vda5050_core::errors::RefEdgeId, edge.edge_id}});
+    }
+  }
+}
+
+}  // namespace
+
+ValidationResult validate_traversability(
+  const PreSendContext& ctx, const vda5050_core::types::Order& order)
+{
+  ValidationResult res;
+
+  auto add_error =
+    [&](const std::string& description, std::vector<ErrorReference> refs) {
+      refs.push_back({::vda5050_core::errors::RefOrderId, order.order_id});
+      res.errors.push_back(
+        create_error(TraversabilityValidationError, description, refs));
+    };
+
+  validate_reachability(ctx, order, add_error);
+
+  if (ctx.loaded_map != nullptr)
+  {
+    validate_map_integrity_locked(ctx, order, add_error);
+  }
+
+  // Capability + limit checks need a factsheet.
+  if (!ctx.last_factsheet.has_value()) return res;
+
+  const auto& fs = ctx.last_factsheet.value();
+  const auto& limits = fs.protocol_limits.max_array_lens;
+
+  check_limit(limits.order_nodes, order.nodes.size(), "order_nodes", add_error);
+  check_limit(limits.order_edges, order.edges.size(), "order_edges", add_error);
+
+  for (const auto& node : order.nodes)
+  {
+    check_limit(
+      limits.node_actions, node.actions.size(), "node_actions", add_error);
+    for (const auto& action : node.actions)
+    {
+      check_limit(
+        limits.actions_actions_parameters,
+        action.action_parameters.has_value() ? action.action_parameters->size()
+                                             : 0,
+        "actions_actions_parameters", add_error);
+      validate_action_against_factsheet(
+        action, vda5050_core::types::ActionScope::NODE, fs, add_error);
+    }
+  }
+
+  for (const auto& edge : order.edges)
+  {
+    check_limit(
+      limits.edge_actions, edge.actions.size(), "edge_actions", add_error);
+    for (const auto& action : edge.actions)
+    {
+      check_limit(
+        limits.actions_actions_parameters,
+        action.action_parameters.has_value() ? action.action_parameters->size()
+                                             : 0,
+        "actions_actions_parameters", add_error);
+      validate_action_against_factsheet(
+        action, vda5050_core::types::ActionScope::EDGE, fs, add_error);
+    }
+  }
+
+  return res;
+}
+
+ValidationResult validate_traversability(
+  const PreSendContext& ctx, const vda5050_core::types::InstantActions& actions)
+{
+  ValidationResult res;
+
+  auto add_error =
+    [&](const std::string& description, std::vector<ErrorReference> refs) {
+      res.errors.push_back(
+        create_error(TraversabilityValidationError, description, refs));
+    };
+
+  // No graph => no reachability; capability/limits need a factsheet.
+  if (!ctx.last_factsheet.has_value()) return res;
+
+  const auto& fs = ctx.last_factsheet.value();
+  const auto& limits = fs.protocol_limits.max_array_lens;
+
+  check_limit(
+    limits.instant_actions, actions.actions.size(), "instant_actions",
+    add_error);
+
+  for (const auto& action : actions.actions)
+  {
+    check_limit(
+      limits.actions_actions_parameters,
+      action.action_parameters.has_value() ? action.action_parameters->size()
+                                           : 0,
+      "actions_actions_parameters", add_error);
+    validate_action_against_factsheet(
+      action, vda5050_core::types::ActionScope::INSTANT, fs, add_error);
+  }
+
+  return res;
+}
+
+}  // namespace vda5050_core::master

--- a/vda5050_core/test/master/data/sample_map.json
+++ b/vda5050_core/test/master/data/sample_map.json
@@ -1,0 +1,75 @@
+{
+  "map_info": {
+    "map_id": "warehouse_floor1",
+    "map_version": "1.0",
+    "map_status": "ENABLED",
+    "map_descriptor": "Floor 1 main warehouse — 4-node demo grid"
+  },
+
+  "nodes": [
+    {
+      "node_id": "N0",
+      "x": 0.0,
+      "y": 0.0,
+      "theta": 0.0,
+      "allowed_deviation_xy": 0.5,
+      "allowed_deviation_theta": 0.1,
+      "map_description": "Pickup zone A"
+    },
+    {
+      "node_id": "N1",
+      "x": 5.0,
+      "y": 0.0,
+      "theta": 0.0,
+      "allowed_deviation_xy": 0.5
+    },
+    {
+      "node_id": "N2",
+      "x": 5.0,
+      "y": 5.0,
+      "allowed_deviation_xy": 0.5,
+      "map_description": "Drop zone"
+    },
+    {
+      "node_id": "N3",
+      "x": 0.0,
+      "y": 5.0,
+      "allowed_deviation_xy": 0.5
+    }
+  ],
+
+  "edges": [
+    {
+      "edge_id": "E1",
+      "start_node_id": "N0",
+      "end_node_id": "N1",
+      "bidirectional": true,
+      "max_speed": 1.0,
+      "length": 5.0
+    },
+    {
+      "edge_id": "E2",
+      "start_node_id": "N1",
+      "end_node_id": "N2",
+      "bidirectional": true,
+      "max_speed": 1.0,
+      "length": 5.0
+    },
+    {
+      "edge_id": "E3",
+      "start_node_id": "N2",
+      "end_node_id": "N3",
+      "bidirectional": true,
+      "max_speed": 1.0,
+      "length": 5.0
+    },
+    {
+      "edge_id": "E4",
+      "start_node_id": "N3",
+      "end_node_id": "N0",
+      "bidirectional": false,
+      "max_speed": 0.5,
+      "length": 5.0
+    }
+  ]
+}

--- a/vda5050_core/test/master/test_unit_action_conflict_validator.cpp
+++ b/vda5050_core/test/master/test_unit_action_conflict_validator.cpp
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/master/validation/action_conflict_validator.hpp"
+#include "vda5050_core/types/action.hpp"
+#include "vda5050_core/types/action_state.hpp"
+#include "vda5050_core/types/action_status.hpp"
+#include "vda5050_core/types/blocking_type.hpp"
+#include "vda5050_core/types/instant_actions.hpp"
+#include "vda5050_core/types/state.hpp"
+
+namespace vda5050_core::master {
+namespace test {
+
+namespace {
+
+vda5050_core::types::Action make_action(
+  const std::string& type, vda5050_core::types::BlockingType blocking,
+  const std::string& id = "act-1")
+{
+  vda5050_core::types::Action a;
+  a.action_type = type;
+  a.action_id = id;
+  a.blocking_type = blocking;
+  return a;
+}
+
+vda5050_core::types::ActionState make_action_state(
+  const std::string& id, vda5050_core::types::ActionStatus status)
+{
+  vda5050_core::types::ActionState s;
+  s.action_id = id;
+  s.action_status = status;
+  return s;
+}
+
+vda5050_core::types::State make_state(
+  bool driving,
+  std::vector<vda5050_core::types::ActionState> action_states = {})
+{
+  vda5050_core::types::State s;
+  s.driving = driving;
+  s.action_states = std::move(action_states);
+  return s;
+}
+
+PreSendContext make_ctx(const vda5050_core::types::State& state)
+{
+  return PreSendContext{
+    vda5050_core::types::ConnectionState::ONLINE,
+    state,
+    std::nullopt,
+    AGVState::AVAILABLE,
+    std::nullopt,
+    nullptr};
+}
+
+vda5050_core::types::InstantActions wrap(
+  const std::vector<vda5050_core::types::Action>& actions)
+{
+  vda5050_core::types::InstantActions msg;
+  msg.actions = actions;
+  return msg;
+}
+
+}  // namespace
+
+// =============================================================================
+// Defensive / no-state cases
+// =============================================================================
+
+TEST(ActionConflictValidator, EmptyActionsList_Passes)
+{
+  PreSendContext ctx{
+    vda5050_core::types::ConnectionState::ONLINE,
+    make_state(true),
+    std::nullopt,
+    AGVState::AVAILABLE,
+    std::nullopt,
+    nullptr};
+  auto res = validate_action_conflict(ctx, wrap({}));
+  EXPECT_TRUE(static_cast<bool>(res));
+  EXPECT_TRUE(res.errors.empty());
+}
+
+TEST(ActionConflictValidator, NoStateInContext_Passes)
+{
+  // Degraded mode: AGV never reported state. No info on driving or
+  // action_states[]; conservative = pass through (matches PreSend pattern).
+  PreSendContext ctx{
+    vda5050_core::types::ConnectionState::ONLINE,
+    std::nullopt,
+    std::nullopt,
+    AGVState::AVAILABLE,
+    std::nullopt,
+    nullptr};
+  auto res = validate_action_conflict(
+    ctx,
+    wrap({make_action("anything", vda5050_core::types::BlockingType::HARD)}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+// =============================================================================
+// NONE blocking — always allowed
+// =============================================================================
+
+TEST(ActionConflictValidator, NoneBlockingAction_AlwaysAllowed)
+{
+  // Even when AGV is driving AND has active actions, NONE is OK.
+  auto state = make_state(
+    true, {make_action_state(
+            "inflight", vda5050_core::types::ActionStatus::RUNNING)});
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap(
+      {make_action("stateRequest", vda5050_core::types::BlockingType::NONE)}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+// =============================================================================
+// SOFT blocking
+// =============================================================================
+
+TEST(ActionConflictValidator, SoftBlockingNotDriving_Allowed)
+{
+  auto state = make_state(false);
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap(
+      {make_action("doSomething", vda5050_core::types::BlockingType::SOFT)}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+TEST(ActionConflictValidator, SoftBlockingDriving_RejectedWith_BlockedByDriving)
+{
+  auto state = make_state(true);
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap(
+      {make_action("doSomething", vda5050_core::types::BlockingType::SOFT)}));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_FALSE(res.errors.empty());
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("ACTION_BLOCKED_BY_DRIVING"),
+    std::string::npos);
+}
+
+// =============================================================================
+// HARD blocking
+// =============================================================================
+
+TEST(ActionConflictValidator, HardBlockingNoActiveActions_NotDriving_Allowed)
+{
+  auto state = make_state(false);
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap({make_action("hardAction", vda5050_core::types::BlockingType::HARD)}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+TEST(
+  ActionConflictValidator,
+  HardBlockingActiveRunningAction_RejectedWith_HardBlocked)
+{
+  auto state = make_state(
+    false, {make_action_state(
+             "inflight", vda5050_core::types::ActionStatus::RUNNING)});
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap({make_action("hardAction", vda5050_core::types::BlockingType::HARD)}));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_FALSE(res.errors.empty());
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("HARD_ACTION_BLOCKED"),
+    std::string::npos);
+}
+
+TEST(
+  ActionConflictValidator,
+  HardBlockingActiveWaitingAction_RejectedWith_HardBlocked)
+{
+  auto state = make_state(
+    false,
+    {make_action_state("queued", vda5050_core::types::ActionStatus::WAITING)});
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap({make_action("hardAction", vda5050_core::types::BlockingType::HARD)}));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("HARD_ACTION_BLOCKED"),
+    std::string::npos);
+}
+
+TEST(
+  ActionConflictValidator,
+  HardBlockingActivePausedAction_RejectedWith_HardBlocked)
+{
+  // PAUSED is conservatively considered active — a paused action could
+  // resume any time and conflict with the candidate HARD.
+  auto state = make_state(
+    false,
+    {make_action_state("paused", vda5050_core::types::ActionStatus::PAUSED)});
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap({make_action("hardAction", vda5050_core::types::BlockingType::HARD)}));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("HARD_ACTION_BLOCKED"),
+    std::string::npos);
+}
+
+TEST(
+  ActionConflictValidator,
+  HardBlockingActiveInitializingAction_RejectedWith_HardBlocked)
+{
+  // INITIALIZING is one of the four active statuses (alongside WAITING,
+  // RUNNING, PAUSED). Without this test, that branch of is_active_status
+  // would be uncovered.
+  auto state = make_state(
+    false, {make_action_state(
+             "init", vda5050_core::types::ActionStatus::INITIALIZING)});
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap({make_action("hardAction", vda5050_core::types::BlockingType::HARD)}));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("HARD_ACTION_BLOCKED"),
+    std::string::npos);
+}
+
+TEST(
+  ActionConflictValidator,
+  HardBlockingMixOfFinishedAndRunning_RejectedByRunning)
+{
+  // Mix of active + non-active actions in state: the iteration must find
+  // the active one and reject. Order in the array shouldn't matter — try
+  // FINISHED first, then RUNNING.
+  auto state = make_state(
+    false,
+    {make_action_state("done", vda5050_core::types::ActionStatus::FINISHED),
+     make_action_state(
+       "inflight", vda5050_core::types::ActionStatus::RUNNING)});
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap({make_action("hardAction", vda5050_core::types::BlockingType::HARD)}));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("HARD_ACTION_BLOCKED"),
+    std::string::npos);
+}
+
+TEST(ActionConflictValidator, HardBlockingFinishedActionsOnly_Allowed)
+{
+  // FINISHED / FAILED actions are non-active — should NOT block HARD.
+  auto state = make_state(
+    false,
+    {make_action_state("done1", vda5050_core::types::ActionStatus::FINISHED),
+     make_action_state("done2", vda5050_core::types::ActionStatus::FAILED)});
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap({make_action("hardAction", vda5050_core::types::BlockingType::HARD)}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+TEST(ActionConflictValidator, HardBlockingDriving_RejectedWith_BlockedByDriving)
+{
+  // The driving check fires before the active-action check (HARD must
+  // not drive). Even with no active actions, driving alone rejects HARD.
+  auto state = make_state(true);
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap({make_action("hardAction", vda5050_core::types::BlockingType::HARD)}));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("ACTION_BLOCKED_BY_DRIVING"),
+    std::string::npos);
+}
+
+// =============================================================================
+// Batch semantics + tagging
+// =============================================================================
+
+TEST(
+  ActionConflictValidator, MultipleActionsBatch_FirstConflict_StopsAndReturns)
+{
+  // Order in batch: [NONE OK, HARD blocked]. Validator should reach the
+  // HARD action and return — single error, focused on the first conflict.
+  auto state = make_state(
+    false, {make_action_state(
+             "inflight", vda5050_core::types::ActionStatus::RUNNING)});
+  std::vector<vda5050_core::types::Action> batch = {
+    make_action("stateRequest", vda5050_core::types::BlockingType::NONE, "ok"),
+    make_action("hardAction", vda5050_core::types::BlockingType::HARD, "bad")};
+  auto res = validate_action_conflict(make_ctx(state), wrap(batch));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_EQ(res.errors.size(), 1u);
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  // The error should reference the second action's id ("bad"), confirming
+  // we made it past the first NONE-action without rejecting it.
+  EXPECT_NE(
+    res.errors.front().error_description->find("hardAction"),
+    std::string::npos);
+}
+
+TEST(ActionConflictValidator, AllErrorsHaveActionConflictType)
+{
+  auto state = make_state(true);
+  auto res = validate_action_conflict(
+    make_ctx(state),
+    wrap({make_action("hardAction", vda5050_core::types::BlockingType::HARD)}));
+  ASSERT_FALSE(res.errors.empty());
+  for (const auto& err : res.errors)
+  {
+    EXPECT_EQ(
+      err.error_type, vda5050_core::errors::ActionConflictValidationError);
+  }
+}
+
+}  // namespace test
+}  // namespace vda5050_core::master

--- a/vda5050_core/test/master/test_unit_factsheet_alignment.cpp
+++ b/vda5050_core/test/master/test_unit_factsheet_alignment.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "vda5050_core/master/map/map.hpp"
+#include "vda5050_core/master/validation/factsheet_alignment.hpp"
+#include "vda5050_core/types/factsheet.hpp"
+
+namespace vda5050_core::master::test {
+
+namespace {
+
+// Build a small map with a single edge whose max_speed is 1.0 m/s.
+Map make_map_with_edge_max_speed(double edge_max_speed)
+{
+  Map m;
+  m.info.map_id = "M1";
+  m.info.map_version = "1.0";
+  MapNode n0;
+  n0.node_id = "N0";
+  MapNode n1;
+  n1.node_id = "N1";
+  MapEdge e;
+  e.edge_id = "E1";
+  e.start_node_id = "N0";
+  e.end_node_id = "N1";
+  e.max_speed = edge_max_speed;
+  m.nodes = {n0, n1};
+  m.edges = {e};
+  return m;
+}
+
+vda5050_core::types::Factsheet make_factsheet_with_speed(double speed_max)
+{
+  vda5050_core::types::Factsheet fs;
+  fs.physical_parameters.speed_max = speed_max;
+  return fs;
+}
+
+bool has_finding_with_code(
+  const FactsheetAlignmentResult& r, const std::string& code)
+{
+  return std::any_of(r.findings.begin(), r.findings.end(), [&](const auto& f) {
+    return f.code == code;
+  });
+}
+
+}  // namespace
+
+// ============================================================================
+// SpeedExceedsCapability rule (the one enforced check)
+// ============================================================================
+
+TEST(FactsheetAlignmentTest, AgvSpeedExceedsAllEdges_NoFindings)
+{
+  auto m = make_map_with_edge_max_speed(1.0);
+  auto fs = make_factsheet_with_speed(2.0);  // headroom
+
+  auto r = check_factsheet_alignment(m, fs);
+  EXPECT_TRUE(r.findings.empty());
+  EXPECT_FALSE(r.has_error());
+}
+
+TEST(FactsheetAlignmentTest, AgvSpeedEqualsEdgeMax_NoFindings)
+{
+  auto m = make_map_with_edge_max_speed(1.0);
+  auto fs = make_factsheet_with_speed(1.0);  // exact match accepted
+
+  auto r = check_factsheet_alignment(m, fs);
+  EXPECT_TRUE(r.findings.empty());
+  EXPECT_FALSE(r.has_error());
+}
+
+TEST(FactsheetAlignmentTest, AgvSpeedBelowEdgeMax_ReturnsError)
+{
+  auto m = make_map_with_edge_max_speed(2.0);
+  auto fs = make_factsheet_with_speed(1.5);
+
+  auto r = check_factsheet_alignment(m, fs);
+  EXPECT_TRUE(r.has_error());
+  ASSERT_EQ(r.findings.size(), 1u);
+  EXPECT_EQ(r.findings[0].severity, AlignmentSeverity::ERROR);
+  EXPECT_EQ(r.findings[0].code, "SpeedExceedsCapability");
+  EXPECT_TRUE(has_finding_with_code(r, "SpeedExceedsCapability"));
+}
+
+TEST(FactsheetAlignmentTest, EdgeWithoutMaxSpeed_SkippedFromCheck)
+{
+  // Edge declares no max_speed → no finding regardless of factsheet.
+  Map m;
+  m.info.map_id = "M1";
+  m.info.map_version = "1.0";
+  MapNode n0;
+  n0.node_id = "N0";
+  MapNode n1;
+  n1.node_id = "N1";
+  MapEdge e;
+  e.edge_id = "E1";
+  e.start_node_id = "N0";
+  e.end_node_id = "N1";
+  // e.max_speed left unset.
+  m.nodes = {n0, n1};
+  m.edges = {e};
+
+  auto fs = make_factsheet_with_speed(0.1);  // very slow AGV — but no rule
+  auto r = check_factsheet_alignment(m, fs);
+  EXPECT_TRUE(r.findings.empty());
+  EXPECT_FALSE(r.has_error());
+}
+
+TEST(FactsheetAlignmentTest, MultipleEdgesExceeded_AllReported)
+{
+  Map m;
+  m.info.map_id = "M1";
+  m.info.map_version = "1.0";
+  MapNode n0;
+  n0.node_id = "N0";
+  MapNode n1;
+  n1.node_id = "N1";
+  MapEdge e1;
+  e1.edge_id = "E1";
+  e1.start_node_id = "N0";
+  e1.end_node_id = "N1";
+  e1.max_speed = 2.0;
+  MapEdge e2;
+  e2.edge_id = "E2";
+  e2.start_node_id = "N1";
+  e2.end_node_id = "N0";
+  e2.max_speed = 3.0;
+  m.nodes = {n0, n1};
+  m.edges = {e1, e2};
+
+  auto fs = make_factsheet_with_speed(1.0);
+  auto r = check_factsheet_alignment(m, fs);
+  EXPECT_TRUE(r.has_error());
+  EXPECT_EQ(r.findings.size(), 2u);
+}
+
+TEST(FactsheetAlignmentTest, EmptyMap_NoFindings)
+{
+  // Map with nodes but no edges (legal config).
+  Map m;
+  m.info.map_id = "M1";
+  m.info.map_version = "1.0";
+  MapNode n;
+  n.node_id = "N0";
+  m.nodes = {n};
+  // No edges — nothing to align.
+
+  auto fs = make_factsheet_with_speed(0.0);
+  auto r = check_factsheet_alignment(m, fs);
+  EXPECT_TRUE(r.findings.empty());
+  EXPECT_FALSE(r.has_error());
+}
+
+}  // namespace vda5050_core::master::test

--- a/vda5050_core/test/master/test_unit_instant_action_mode_validator.cpp
+++ b/vda5050_core/test/master/test_unit_instant_action_mode_validator.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/master/validation/instant_action_mode_validator.hpp"
+#include "vda5050_core/types/action.hpp"
+#include "vda5050_core/types/blocking_type.hpp"
+#include "vda5050_core/types/instant_actions.hpp"
+#include "vda5050_core/types/operating_mode.hpp"
+#include "vda5050_core/types/state.hpp"
+
+namespace vda5050_core::master {
+namespace test {
+
+namespace {
+
+vda5050_core::types::Action make_action(
+  const std::string& type, const std::string& id = "act-1")
+{
+  vda5050_core::types::Action a;
+  a.action_type = type;
+  a.action_id = id;
+  a.blocking_type = vda5050_core::types::BlockingType::NONE;
+  return a;
+}
+
+vda5050_core::types::State make_state(vda5050_core::types::OperatingMode mode)
+{
+  vda5050_core::types::State s;
+  s.operating_mode = mode;
+  return s;
+}
+
+PreSendContext make_ctx(const vda5050_core::types::State& state)
+{
+  return PreSendContext{
+    vda5050_core::types::ConnectionState::ONLINE,
+    state,
+    std::nullopt,
+    AGVState::AVAILABLE,
+    std::nullopt,
+    nullptr};
+}
+
+vda5050_core::types::InstantActions wrap(
+  const std::vector<vda5050_core::types::Action>& actions)
+{
+  vda5050_core::types::InstantActions msg;
+  msg.actions = actions;
+  return msg;
+}
+
+}  // namespace
+
+// =============================================================================
+// Allowlist membership
+// =============================================================================
+
+TEST(InstantActionModeValidator, ExemptList_MatchesPredefinedInstantScope)
+{
+  // Instant-scope predefined actions designed for non-AUTOMATIC use.
+  EXPECT_TRUE(is_mode_exempt_action_type("stateRequest"));
+  EXPECT_TRUE(is_mode_exempt_action_type("factsheetRequest"));
+  EXPECT_TRUE(is_mode_exempt_action_type("logReport"));
+  EXPECT_TRUE(is_mode_exempt_action_type("cancelOrder"));
+  EXPECT_TRUE(is_mode_exempt_action_type("initPosition"));
+  EXPECT_TRUE(is_mode_exempt_action_type("startPause"));
+  EXPECT_TRUE(is_mode_exempt_action_type("stopPause"));
+  EXPECT_TRUE(is_mode_exempt_action_type("startCharging"));
+  EXPECT_TRUE(is_mode_exempt_action_type("stopCharging"));
+}
+
+TEST(InstantActionModeValidator, NonExempt_ActionTypes_Rejected)
+{
+  // Common operational actions that are NOT instant-scope
+  // (typically node/edge actions or custom).
+  EXPECT_FALSE(is_mode_exempt_action_type("pick"));
+  EXPECT_FALSE(is_mode_exempt_action_type("drop"));
+  EXPECT_FALSE(is_mode_exempt_action_type("detectObject"));
+  EXPECT_FALSE(is_mode_exempt_action_type("finePositioning"));
+  EXPECT_FALSE(is_mode_exempt_action_type("waitForTrigger"));
+  // Custom action types
+  EXPECT_FALSE(is_mode_exempt_action_type("customAction"));
+  EXPECT_FALSE(is_mode_exempt_action_type(""));
+}
+
+// =============================================================================
+// Validator behavior — degraded mode
+// =============================================================================
+
+TEST(InstantActionModeValidator, NoStateInContext_Passes)
+{
+  PreSendContext ctx{
+    vda5050_core::types::ConnectionState::ONLINE,
+    std::nullopt,
+    std::nullopt,
+    AGVState::AVAILABLE,
+    std::nullopt,
+    nullptr};
+  auto res =
+    validate_instant_action_mode(ctx, wrap({make_action("customAction")}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+// =============================================================================
+// Validator behavior — AUTOMATIC / SEMIAUTOMATIC always pass
+// =============================================================================
+
+TEST(InstantActionModeValidator, Automatic_NonExemptAction_Passes)
+{
+  auto state = make_state(vda5050_core::types::OperatingMode::AUTOMATIC);
+  auto res =
+    validate_instant_action_mode(make_ctx(state), wrap({make_action("pick")}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+TEST(InstantActionModeValidator, Semiautomatic_NonExemptAction_Passes)
+{
+  // SEMIAUTOMATIC has the master "in control"; treated like AUTOMATIC.
+  auto state = make_state(vda5050_core::types::OperatingMode::SEMIAUTOMATIC);
+  auto res = validate_instant_action_mode(
+    make_ctx(state), wrap({make_action("customAction")}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+// =============================================================================
+// Validator behavior — non-AUTOMATIC modes enforce allowlist
+// =============================================================================
+
+TEST(InstantActionModeValidator, Manual_ExemptAction_Passes)
+{
+  auto state = make_state(vda5050_core::types::OperatingMode::MANUAL);
+  auto res = validate_instant_action_mode(
+    make_ctx(state), wrap({make_action("stateRequest")}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+TEST(InstantActionModeValidator, Manual_NonExemptAction_Rejected)
+{
+  auto state = make_state(vda5050_core::types::OperatingMode::MANUAL);
+  auto res =
+    validate_instant_action_mode(make_ctx(state), wrap({make_action("pick")}));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_FALSE(res.errors.empty());
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("MODE_NOT_AUTOMATIC"),
+    std::string::npos);
+}
+
+TEST(InstantActionModeValidator, Service_NonExemptAction_Rejected)
+{
+  auto state = make_state(vda5050_core::types::OperatingMode::SERVICE);
+  auto res = validate_instant_action_mode(
+    make_ctx(state), wrap({make_action("customAction")}));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("MODE_NOT_AUTOMATIC"),
+    std::string::npos);
+}
+
+TEST(InstantActionModeValidator, Teachin_ExemptAction_Passes)
+{
+  // initPosition during TEACHIN is a legitimate use case (mapping teaching
+  // includes pose initialization).
+  auto state = make_state(vda5050_core::types::OperatingMode::TEACHIN);
+  auto res = validate_instant_action_mode(
+    make_ctx(state), wrap({make_action("initPosition")}));
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+TEST(
+  InstantActionModeValidator, Manual_MixedBatch_NonExemptShortCircuitsRejection)
+{
+  // Batch order: [stateRequest (exempt), pick (non-exempt)]. Validator
+  // walks the batch and rejects on the first non-exempt action in
+  // non-AUTOMATIC mode.
+  auto state = make_state(vda5050_core::types::OperatingMode::MANUAL);
+  std::vector<vda5050_core::types::Action> batch = {
+    make_action("stateRequest", "ok"),
+    make_action("pick", "bad"),
+  };
+  auto res = validate_instant_action_mode(make_ctx(state), wrap(batch));
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_EQ(res.errors.size(), 1u);
+  ASSERT_TRUE(res.errors.front().error_description.has_value());
+  EXPECT_NE(
+    res.errors.front().error_description->find("pick"), std::string::npos);
+}
+
+// =============================================================================
+// Tagging
+// =============================================================================
+
+TEST(InstantActionModeValidator, RejectionTaggedAsPreSendValidationError)
+{
+  auto state = make_state(vda5050_core::types::OperatingMode::MANUAL);
+  auto res =
+    validate_instant_action_mode(make_ctx(state), wrap({make_action("pick")}));
+  ASSERT_FALSE(res.errors.empty());
+  EXPECT_EQ(
+    res.errors.front().error_type,
+    vda5050_core::errors::PreSendValidationError);
+}
+
+}  // namespace test
+}  // namespace vda5050_core::master

--- a/vda5050_core/test/master/test_unit_map_loader.cpp
+++ b/vda5050_core/test/master/test_unit_map_loader.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include "vda5050_core/master/map/map.hpp"
+#include "vda5050_core/master/map/map_loader.hpp"
+
+namespace vda5050_core::master::test {
+
+namespace {
+
+// Minimal valid map JSON used as the baseline; tests mutate copies for
+// individual error paths.
+nlohmann::json minimal_valid_json()
+{
+  return nlohmann::json::parse(R"({
+    "map_info": { "map_id": "M1", "map_version": "1.0" },
+    "nodes": [
+      {"node_id": "N0", "x": 0.0, "y": 0.0},
+      {"node_id": "N1", "x": 5.0, "y": 0.0}
+    ],
+    "edges": [
+      {"edge_id": "E1", "start_node_id": "N0", "end_node_id": "N1"}
+    ]
+  })");
+}
+
+bool has_error_of_type(const MapLoadResult& r, MapLoadErrorType t)
+{
+  return std::any_of(r.errors.begin(), r.errors.end(), [&](const auto& e) {
+    return e.type == t;
+  });
+}
+
+}  // namespace
+
+// ============================================================================
+// File-level errors
+// ============================================================================
+
+TEST(MapLoaderTest, LoadFromFile_NotFound_ReturnsFileNotFound)
+{
+  auto r = load_from_file("/nonexistent/path/to/map.json");
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::FILE_NOT_FOUND));
+}
+
+TEST(MapLoaderTest, LoadFromJson_TopLevelNotObject_ReturnsParseError)
+{
+  nlohmann::json arr = nlohmann::json::array();
+  auto r = load_from_json(arr);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::JSON_PARSE_ERROR));
+}
+
+// ============================================================================
+// map_info validation
+// ============================================================================
+
+TEST(MapLoaderTest, LoadFromJson_MissingMapInfo_ReturnsMissingField)
+{
+  auto j = minimal_valid_json();
+  j.erase("map_info");
+  auto r = load_from_json(j);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::MISSING_REQUIRED_FIELD));
+}
+
+TEST(MapLoaderTest, LoadFromJson_MissingMapId_ReturnsMissingField)
+{
+  auto j = minimal_valid_json();
+  j["map_info"].erase("map_id");
+  auto r = load_from_json(j);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::MISSING_REQUIRED_FIELD));
+}
+
+TEST(MapLoaderTest, LoadFromJson_MissingMapVersion_ReturnsMissingField)
+{
+  auto j = minimal_valid_json();
+  j["map_info"].erase("map_version");
+  auto r = load_from_json(j);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::MISSING_REQUIRED_FIELD));
+}
+
+// ============================================================================
+// Nodes validation
+// ============================================================================
+
+TEST(MapLoaderTest, LoadFromJson_EmptyNodes_ReturnsEmptyMap)
+{
+  auto j = minimal_valid_json();
+  j["nodes"] = nlohmann::json::array();
+  auto r = load_from_json(j);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::EMPTY_MAP));
+}
+
+TEST(MapLoaderTest, LoadFromJson_NodeMissingNodeId_ReturnsMissingField)
+{
+  auto j = minimal_valid_json();
+  j["nodes"][0].erase("node_id");
+  auto r = load_from_json(j);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::MISSING_REQUIRED_FIELD));
+}
+
+TEST(MapLoaderTest, LoadFromJson_NodeMissingX_ReturnsMissingField)
+{
+  auto j = minimal_valid_json();
+  j["nodes"][0].erase("x");
+  auto r = load_from_json(j);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::MISSING_REQUIRED_FIELD));
+}
+
+TEST(MapLoaderTest, LoadFromJson_DuplicateNodeId_ReturnsDuplicateNodeId)
+{
+  auto j = minimal_valid_json();
+  j["nodes"].push_back(
+    nlohmann::json::parse(R"({"node_id": "N0", "x": 1.0, "y": 1.0})"));
+  auto r = load_from_json(j);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::DUPLICATE_NODE_ID));
+}
+
+// ============================================================================
+// Edges validation
+// ============================================================================
+
+TEST(MapLoaderTest, LoadFromJson_DuplicateEdgeId_ReturnsDuplicateEdgeId)
+{
+  auto j = minimal_valid_json();
+  j["edges"].push_back(nlohmann::json::parse(
+    R"({"edge_id": "E1", "start_node_id": "N0", "end_node_id": "N1"})"));
+  auto r = load_from_json(j);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::DUPLICATE_EDGE_ID));
+}
+
+TEST(MapLoaderTest, LoadFromJson_EdgeRefersUnknownNode_ReturnsDanglingEdgeRef)
+{
+  auto j = minimal_valid_json();
+  j["edges"][0]["end_node_id"] = "DOES_NOT_EXIST";
+  auto r = load_from_json(j);
+  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_TRUE(has_error_of_type(r, MapLoadErrorType::DANGLING_EDGE_REF));
+}
+
+// ============================================================================
+// Happy path + parsing details
+// ============================================================================
+
+TEST(MapLoaderTest, LoadFromJson_HappyPath_PopulatesAllFields)
+{
+  auto j = nlohmann::json::parse(R"({
+    "map_info": {
+      "map_id": "warehouse_floor1",
+      "map_version": "2.3",
+      "map_status": "ENABLED",
+      "map_descriptor": "Floor 1"
+    },
+    "nodes": [
+      {"node_id": "N0", "x": 1.5, "y": 2.5, "theta": 0.7,
+       "allowed_deviation_xy": 0.4, "allowed_deviation_theta": 0.05,
+       "map_description": "Pickup"}
+    ],
+    "edges": []
+  })");
+  auto r = load_from_json(j, "/configs/floor1.json");
+  ASSERT_TRUE(static_cast<bool>(r));
+  ASSERT_TRUE(r.map.has_value());
+  EXPECT_EQ(r.map->info.map_id, "warehouse_floor1");
+  EXPECT_EQ(r.map->info.map_version, "2.3");
+  EXPECT_EQ(r.map->info.map_status, MapStatus::ENABLED);
+  EXPECT_EQ(r.map->info.map_descriptor, "Floor 1");
+  ASSERT_EQ(r.map->nodes.size(), 1u);
+  EXPECT_EQ(r.map->nodes[0].node_id, "N0");
+  EXPECT_DOUBLE_EQ(r.map->nodes[0].x, 1.5);
+  EXPECT_DOUBLE_EQ(r.map->nodes[0].y, 2.5);
+  ASSERT_TRUE(r.map->nodes[0].theta.has_value());
+  EXPECT_DOUBLE_EQ(*r.map->nodes[0].theta, 0.7);
+  ASSERT_TRUE(r.map->nodes[0].allowed_deviation_xy.has_value());
+  EXPECT_DOUBLE_EQ(*r.map->nodes[0].allowed_deviation_xy, 0.4);
+  EXPECT_EQ(r.map->nodes[0].map_description, "Pickup");
+  EXPECT_EQ(r.map->source_path, "/configs/floor1.json");
+}
+
+TEST(MapLoaderTest, LoadFromJson_OptionalFieldsAbsent_DefaultsApplied)
+{
+  // No theta / allowed_deviation_* / map_description / map_descriptor.
+  auto j = minimal_valid_json();
+  auto r = load_from_json(j);
+  ASSERT_TRUE(static_cast<bool>(r));
+  ASSERT_TRUE(r.map.has_value());
+  EXPECT_EQ(r.map->info.map_status, MapStatus::ENABLED);  // default
+  EXPECT_TRUE(r.map->info.map_descriptor.empty());
+  EXPECT_FALSE(r.map->nodes[0].theta.has_value());
+  EXPECT_FALSE(r.map->nodes[0].allowed_deviation_xy.has_value());
+  EXPECT_FALSE(r.map->edges[0].max_speed.has_value());
+  EXPECT_FALSE(r.map->edges[0].length.has_value());
+}
+
+TEST(MapLoaderTest, LoadFromJson_BidirectionalDefaultFalse)
+{
+  auto j = minimal_valid_json();
+  // Edge does not declare bidirectional.
+  auto r = load_from_json(j);
+  ASSERT_TRUE(static_cast<bool>(r));
+  ASSERT_EQ(r.map->edges.size(), 1u);
+  EXPECT_FALSE(r.map->edges[0].bidirectional);
+}
+
+TEST(MapLoaderTest, LoadFromJson_PopulatesNodeAndEdgeIndex)
+{
+  auto j = minimal_valid_json();
+  auto r = load_from_json(j);
+  ASSERT_TRUE(static_cast<bool>(r));
+  EXPECT_NE(r.map->find_node("N0"), nullptr);
+  EXPECT_NE(r.map->find_node("N1"), nullptr);
+  EXPECT_EQ(r.map->find_node("MISSING"), nullptr);
+  EXPECT_NE(r.map->find_edge("E1"), nullptr);
+  EXPECT_EQ(r.map->find_edge("MISSING"), nullptr);
+}
+
+TEST(MapLoaderTest, LoadFromJson_LenientOnUnknownFields)
+{
+  auto j = minimal_valid_json();
+  // Add a v2.1.0-shaped field the loader doesn't know about.
+  j["map_info"]["map_download_link"] = "https://maps.example/floor1.bin";
+  j["nodes"][0]["custom_extension_key"] = 42;
+  auto r = load_from_json(j);
+  EXPECT_TRUE(static_cast<bool>(r));
+}
+
+TEST(MapLoaderTest, MapStatusDisabledParsedCorrectly)
+{
+  auto j = minimal_valid_json();
+  j["map_info"]["map_status"] = "DISABLED";
+  auto r = load_from_json(j);
+  ASSERT_TRUE(static_cast<bool>(r));
+  EXPECT_EQ(r.map->info.map_status, MapStatus::DISABLED);
+}
+
+// ============================================================================
+// Round-trip with sample data
+// ============================================================================
+
+TEST(MapLoaderTest, LoadFromFile_RoundTripSampleData)
+{
+#ifdef VDA5050_CORE__MASTER__SAMPLE_MAP_PATH
+  auto r = load_from_file(VDA5050_CORE__MASTER__SAMPLE_MAP_PATH);
+  ASSERT_TRUE(static_cast<bool>(r))
+    << "Sample map at " << VDA5050_CORE__MASTER__SAMPLE_MAP_PATH
+    << " did not load";
+  ASSERT_TRUE(r.map.has_value());
+  EXPECT_EQ(r.map->info.map_id, "warehouse_floor1");
+  EXPECT_GE(r.map->nodes.size(), 1u);
+  EXPECT_GE(r.map->edges.size(), 1u);
+#else
+  GTEST_SKIP()
+    << "VDA5050_CORE__MASTER__SAMPLE_MAP_PATH not defined at compile time";
+#endif
+}
+
+}  // namespace vda5050_core::master::test

--- a/vda5050_core/test/master/test_unit_pre_send_validator.cpp
+++ b/vda5050_core/test/master/test_unit_pre_send_validator.cpp
@@ -1,0 +1,315 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/master/map/map.hpp"
+#include "vda5050_core/master/validation/pre_send_validator.hpp"
+
+namespace {
+
+// Returns true iff every error in `res` has type PreSendValidationError.
+::testing::AssertionResult AllErrorsHavePreSendType(
+  const vda5050_core::order_utils::ValidationResult& res)
+{
+  for (const auto& e : res.errors)
+  {
+    if (e.error_type != vda5050_core::errors::PreSendValidationError)
+    {
+      return ::testing::AssertionFailure()
+             << "found error with type '" << e.error_type
+             << "' (expected PreSendValidationError)";
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+// Returns true iff at least one error's description contains `needle`.
+::testing::AssertionResult AnyErrorMentions(
+  const vda5050_core::order_utils::ValidationResult& res,
+  const std::string& needle)
+{
+  for (const auto& e : res.errors)
+  {
+    if (
+      e.error_description &&
+      e.error_description->find(needle) != std::string::npos)
+    {
+      return ::testing::AssertionSuccess();
+    }
+  }
+  return ::testing::AssertionFailure()
+         << "no error description mentions '" << needle << "'";
+}
+
+}  // namespace
+
+namespace vda5050_core::master::test {
+
+namespace {
+
+// Builds a State that satisfies all PreSend checks: AUTOMATIC mode +
+// initialized position. Tests clobber individual fields to exercise
+// specific failure paths.
+vda5050_core::types::State make_ready_state()
+{
+  vda5050_core::types::State s;
+  s.operating_mode = vda5050_core::types::OperatingMode::AUTOMATIC;
+  vda5050_core::types::AGVPosition pos;
+  pos.position_initialized = true;
+  s.agv_position = pos;
+  return s;
+}
+
+// Minimal in-memory map satisfying the no-map gate.
+std::shared_ptr<const Map> make_minimal_map()
+{
+  Map m;
+  m.info.map_id = "test_map";
+  m.info.map_version = "1.0";
+  return std::make_shared<const Map>(std::move(m));
+}
+
+// Builds a PreSendContext that satisfies all readiness checks AND the
+// no-map gate. Tests that exercise the no-map gate explicitly clear
+// `loaded_map` after calling this.
+PreSendContext make_ready_context()
+{
+  return PreSendContext{
+    vda5050_core::types::ConnectionState::ONLINE,
+    make_ready_state(),
+    std::nullopt /* last_factsheet — not used by PreSend */,
+    AGVState::AVAILABLE,
+    std::nullopt /* active_order — not used by PreSend */,
+    make_minimal_map()};
+}
+
+}  // namespace
+
+// ============================================================================
+// Happy path — same gate is shared between Order + InstantActions publishers,
+// so a single ctx-passes test locks in the both publishers' outgoing paths.
+// ============================================================================
+
+TEST(PreSendValidatorTest, ValidContextPasses)
+{
+  auto ctx = make_ready_context();
+  auto res = validate_pre_send(ctx);
+  EXPECT_TRUE(static_cast<bool>(res));
+  EXPECT_TRUE(res.errors.empty());
+}
+
+// ============================================================================
+// Connection status
+// ============================================================================
+
+TEST(PreSendValidatorTest, OfflineConnectionRejected)
+{
+  auto ctx = make_ready_context();
+  ctx.connection_status = vda5050_core::types::ConnectionState::OFFLINE;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "connection_status"));
+}
+
+TEST(PreSendValidatorTest, ConnectionBrokenRejected)
+{
+  auto ctx = make_ready_context();
+  ctx.connection_status =
+    vda5050_core::types::ConnectionState::CONNECTIONBROKEN;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "connection_status"));
+}
+
+// ============================================================================
+// Operational state
+// ============================================================================
+
+TEST(PreSendValidatorTest, ErrorOperationalStateRejected)
+{
+  auto ctx = make_ready_context();
+  ctx.operational_state = AGVState::ERROR;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "operational_state"));
+  EXPECT_TRUE(AnyErrorMentions(res, "ERROR"));
+}
+
+// Silent AGV (state heartbeat exceeded 30s) must be rejected
+// at pre-send. The PreSendContext snapshot may still carry a valid
+// last_state from before the silence, so the existing "no last_state"
+// short-circuit doesn't catch this case.
+TEST(PreSendValidatorTest, StateUnknownOperationalStateRejected)
+{
+  auto ctx = make_ready_context();
+  ctx.operational_state = AGVState::STATE_UNKNOWN;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "operational_state"));
+  EXPECT_TRUE(AnyErrorMentions(res, "STATE_UNKNOWN"));
+}
+
+// ============================================================================
+// last_state absent — short-circuit
+// ============================================================================
+
+TEST(PreSendValidatorTest, AbsentLastStateRejectedAndShortCircuits)
+{
+  auto ctx = make_ready_context();
+  ctx.last_state.reset();
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  // Only the "no State reported" error should fire — mode and position
+  // checks are unreachable without last_state.
+  EXPECT_EQ(res.errors.size(), 1u);
+  EXPECT_TRUE(AnyErrorMentions(res, "State"));
+}
+
+// ============================================================================
+// Operating mode (strict AUTOMATIC)
+// ============================================================================
+
+TEST(PreSendValidatorTest, SemiAutomaticModeRejected)
+{
+  auto ctx = make_ready_context();
+  ctx.last_state->operating_mode =
+    vda5050_core::types::OperatingMode::SEMIAUTOMATIC;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "operating_mode"));
+}
+
+TEST(PreSendValidatorTest, ManualModeRejected)
+{
+  auto ctx = make_ready_context();
+  ctx.last_state->operating_mode = vda5050_core::types::OperatingMode::MANUAL;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "operating_mode"));
+}
+
+TEST(PreSendValidatorTest, ServiceModeRejected)
+{
+  auto ctx = make_ready_context();
+  ctx.last_state->operating_mode = vda5050_core::types::OperatingMode::SERVICE;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+}
+
+TEST(PreSendValidatorTest, TeachInModeRejected)
+{
+  // TEACHIN: AGV being taught (mapping / programming). Per VDA5050, the
+  // master is not in control during TEACHIN.
+  auto ctx = make_ready_context();
+  ctx.last_state->operating_mode = vda5050_core::types::OperatingMode::TEACHIN;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+}
+
+// ============================================================================
+// Position
+// ============================================================================
+
+TEST(PreSendValidatorTest, AbsentAgvPositionRejected)
+{
+  auto ctx = make_ready_context();
+  ctx.last_state->agv_position.reset();
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "position"));
+}
+
+TEST(PreSendValidatorTest, UninitializedPositionRejected)
+{
+  auto ctx = make_ready_context();
+  ctx.last_state->agv_position->position_initialized = false;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "position"));
+}
+
+// ============================================================================
+// Error accumulation — non-fatal preconditions report ALL pending issues
+// ============================================================================
+
+TEST(PreSendValidatorTest, MultipleErrorsAccumulate)
+{
+  auto ctx = make_ready_context();
+  ctx.connection_status = vda5050_core::types::ConnectionState::OFFLINE;
+  ctx.last_state->operating_mode = vda5050_core::types::OperatingMode::MANUAL;
+  ctx.last_state->agv_position->position_initialized = false;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_GE(res.errors.size(), 3u);
+  EXPECT_TRUE(AllErrorsHavePreSendType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "connection_status"));
+  EXPECT_TRUE(AnyErrorMentions(res, "operating_mode"));
+  EXPECT_TRUE(AnyErrorMentions(res, "position"));
+}
+
+// ============================================================================
+// No-map gate
+// ============================================================================
+//
+// The master must reject every Order / InstantActions if no topology map
+// has been loaded. Without a map, downstream traversability map-integrity
+// checks have no truth source and AGVs would silently accept node ids
+// that are not in the warehouse. Hard-reject is the correct posture.
+
+TEST(PreSendValidatorTest, NoMapLoadedRejectedAndShortCircuits)
+{
+  auto ctx = make_ready_context();
+  ctx.loaded_map = nullptr;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  // Only the no-map error fires — remaining checks are short-circuited.
+  ASSERT_EQ(res.errors.size(), 1u);
+  EXPECT_EQ(
+    res.errors.front().error_type, vda5050_core::errors::MapValidationError);
+}
+
+TEST(PreSendValidatorTest, NoMapLoadedShortCircuitsBeforeOtherErrors)
+{
+  // Even with multiple other failures, no-map should be the only error
+  // surfaced — fail-fast on missing config.
+  auto ctx = make_ready_context();
+  ctx.loaded_map = nullptr;
+  ctx.connection_status = vda5050_core::types::ConnectionState::OFFLINE;
+  ctx.last_state->operating_mode = vda5050_core::types::OperatingMode::MANUAL;
+  auto res = validate_pre_send(ctx);
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_EQ(res.errors.size(), 1u);
+  EXPECT_EQ(
+    res.errors.front().error_type, vda5050_core::errors::MapValidationError);
+}
+
+}  // namespace vda5050_core::master::test

--- a/vda5050_core/test/master/test_unit_schema_validator.cpp
+++ b/vda5050_core/test/master/test_unit_schema_validator.cpp
@@ -1,0 +1,392 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/master/validation/schema_validator.hpp"
+
+namespace {
+
+// Returns true iff every error in `res` has type SchemaValidationError.
+::testing::AssertionResult AllErrorsHaveSchemaType(
+  const vda5050_core::order_utils::ValidationResult& res)
+{
+  for (const auto& e : res.errors)
+  {
+    if (e.error_type != vda5050_core::errors::SchemaValidationError)
+    {
+      return ::testing::AssertionFailure()
+             << "found error with type '" << e.error_type
+             << "' (expected SchemaValidationError)";
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+// Returns true iff at least one error's description contains `needle`.
+::testing::AssertionResult AnyErrorMentions(
+  const vda5050_core::order_utils::ValidationResult& res,
+  const std::string& needle)
+{
+  for (const auto& e : res.errors)
+  {
+    if (
+      e.error_description &&
+      e.error_description->find(needle) != std::string::npos)
+    {
+      return ::testing::AssertionSuccess();
+    }
+  }
+  return ::testing::AssertionFailure()
+         << "no error description mentions '" << needle << "'";
+}
+
+}  // namespace
+
+namespace vda5050_core::master::test {
+
+namespace {
+
+// Fill a Header with valid mandatory fields. Tests can clobber individual
+// fields to exercise specific failure paths.
+void fill_valid_header(vda5050_core::types::Header& h)
+{
+  h.version = "2.0.0";
+  h.manufacturer = "ACME";
+  h.serial_number = "AGV001";
+}
+
+vda5050_core::types::Order make_valid_order()
+{
+  vda5050_core::types::Order o;
+  fill_valid_header(o.header);
+  o.order_id = "ORDER_1";
+  o.order_update_id = 0;
+
+  vda5050_core::types::Node n;
+  n.node_id = "N0";
+  n.sequence_id = 0;
+  n.released = true;
+  o.nodes.push_back(n);
+  return o;
+}
+
+vda5050_core::types::InstantActions make_valid_instant_actions()
+{
+  vda5050_core::types::InstantActions ia;
+  fill_valid_header(ia.header);
+
+  vda5050_core::types::Action a;
+  a.action_id = "A1";
+  a.action_type = "stateRequest";
+  a.blocking_type = vda5050_core::types::BlockingType::NONE;
+  ia.actions.push_back(a);
+  return ia;
+}
+
+vda5050_core::types::State make_valid_state()
+{
+  vda5050_core::types::State s;
+  fill_valid_header(s.header);
+  s.order_id = "";  // legitimately empty when no current order
+  return s;
+}
+
+vda5050_core::types::Connection make_valid_connection()
+{
+  vda5050_core::types::Connection c;
+  fill_valid_header(c.header);
+  c.connection_state = vda5050_core::types::ConnectionState::ONLINE;
+  return c;
+}
+
+vda5050_core::types::Factsheet make_valid_factsheet()
+{
+  vda5050_core::types::Factsheet f;
+  fill_valid_header(f.header);
+  return f;
+}
+
+vda5050_core::types::Visualization make_valid_visualization()
+{
+  vda5050_core::types::Visualization v;
+  fill_valid_header(v.header);
+  return v;
+}
+
+}  // namespace
+
+// ============================================================================
+// Header — common to all messages.
+// ============================================================================
+
+TEST(SchemaValidatorTest, HeaderVersionMatch)
+{
+  auto o = make_valid_order();
+  auto res = validate_order_schema(o);
+  EXPECT_TRUE(static_cast<bool>(res));
+  EXPECT_TRUE(res.errors.empty());
+}
+
+TEST(SchemaValidatorTest, HeaderVersionMismatchRejected)
+{
+  auto o = make_valid_order();
+  o.header.version = "1.3.2";
+  auto res = validate_order_schema(o);
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_FALSE(res.errors.empty());
+  EXPECT_EQ(
+    res.errors.front().error_type, vda5050_core::errors::SchemaValidationError);
+}
+
+TEST(SchemaValidatorTest, HeaderEmptyManufacturerRejected)
+{
+  auto o = make_valid_order();
+  o.header.manufacturer = "";
+  auto res = validate_order_schema(o);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "manufacturer"));
+}
+
+// ============================================================================
+// Order
+// ============================================================================
+
+TEST(SchemaValidatorTest, OrderValidPasses)
+{
+  auto o = make_valid_order();
+  EXPECT_TRUE(static_cast<bool>(validate_order_schema(o)));
+}
+
+TEST(SchemaValidatorTest, OrderEmptyOrderIdRejected)
+{
+  auto o = make_valid_order();
+  o.order_id = "";
+  auto res = validate_order_schema(o);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "order_id"));
+}
+
+TEST(SchemaValidatorTest, OrderNodeWithEmptyNodeIdRejected)
+{
+  auto o = make_valid_order();
+  o.nodes.front().node_id = "";
+  auto res = validate_order_schema(o);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "node_id"));
+}
+
+TEST(SchemaValidatorTest, OrderActionWithEmptyActionTypeRejected)
+{
+  auto o = make_valid_order();
+  vda5050_core::types::Action a;
+  a.action_id = "A1";
+  a.action_type = "";  // bad
+  a.blocking_type = vda5050_core::types::BlockingType::NONE;
+  o.nodes.front().actions.push_back(a);
+  auto res = validate_order_schema(o);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "action_type"));
+}
+
+TEST(SchemaValidatorTest, OrderEdgeWithEmptyEdgeIdRejected)
+{
+  auto o = make_valid_order();
+  // Add a second node + connecting edge with empty edge_id.
+  vda5050_core::types::Node n1;
+  n1.node_id = "N1";
+  n1.sequence_id = 2;
+  n1.released = true;
+  o.nodes.push_back(n1);
+
+  vda5050_core::types::Edge e;
+  e.edge_id = "";  // bad
+  e.sequence_id = 1;
+  e.start_node_id = "N0";
+  e.end_node_id = "N1";
+  e.released = true;
+  o.edges.push_back(e);
+
+  auto res = validate_order_schema(o);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "edge_id"));
+}
+
+TEST(SchemaValidatorTest, OrderWithEmptyNodesPasses)
+{
+  // Schema-validator does NOT enforce graph topology — empty `nodes`
+  // is the graph validator's concern. Locks in layer separation:
+  // schema only checks shape, graph checks topology.
+  auto o = make_valid_order();
+  o.nodes.clear();
+  EXPECT_TRUE(static_cast<bool>(validate_order_schema(o)));
+}
+
+// ============================================================================
+// InstantActions
+// ============================================================================
+
+TEST(SchemaValidatorTest, InstantActionsValidPasses)
+{
+  auto ia = make_valid_instant_actions();
+  EXPECT_TRUE(static_cast<bool>(validate_instant_actions_schema(ia)));
+}
+
+TEST(SchemaValidatorTest, InstantActionsEmptyActionIdRejected)
+{
+  auto ia = make_valid_instant_actions();
+  ia.actions.front().action_id = "";
+  auto res = validate_instant_actions_schema(ia);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "action_id"));
+}
+
+TEST(SchemaValidatorTest, InstantActionsEmptyActionTypeRejected)
+{
+  auto ia = make_valid_instant_actions();
+  ia.actions.front().action_type = "";
+  auto res = validate_instant_actions_schema(ia);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "action_type"));
+}
+
+// ============================================================================
+// State
+// ============================================================================
+
+TEST(SchemaValidatorTest, StateValidPasses)
+{
+  auto s = make_valid_state();
+  EXPECT_TRUE(static_cast<bool>(validate_state_schema(s)));
+}
+
+TEST(SchemaValidatorTest, StateEmptyOrderIdPassesByDesign)
+{
+  // Spec allows empty order_id when AGV has no current order. Schema
+  // validator must NOT reject this — a State with empty order_id is
+  // structurally valid.
+  auto s = make_valid_state();
+  s.order_id = "";
+  EXPECT_TRUE(static_cast<bool>(validate_state_schema(s)));
+}
+
+TEST(SchemaValidatorTest, StateNodeStateWithEmptyNodeIdRejected)
+{
+  auto s = make_valid_state();
+  vda5050_core::types::NodeState ns;
+  ns.node_id = "";
+  ns.sequence_id = 1;
+  ns.released = true;
+  s.node_states.push_back(ns);
+  auto res = validate_state_schema(s);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "node_id"));
+}
+
+TEST(SchemaValidatorTest, StateErrorWithEmptyErrorTypeRejected)
+{
+  auto s = make_valid_state();
+  vda5050_core::types::Error err;
+  err.error_type = "";
+  err.error_level = vda5050_core::types::ErrorLevel::WARNING;
+  s.errors.push_back(err);
+  auto res = validate_state_schema(s);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "error_type"));
+}
+
+// ============================================================================
+// Connection / Factsheet / Visualization — minimal beyond header
+// ============================================================================
+
+TEST(SchemaValidatorTest, ConnectionValidPasses)
+{
+  auto c = make_valid_connection();
+  EXPECT_TRUE(static_cast<bool>(validate_connection_schema(c)));
+}
+
+TEST(SchemaValidatorTest, FactsheetValidPasses)
+{
+  auto f = make_valid_factsheet();
+  EXPECT_TRUE(static_cast<bool>(validate_factsheet_schema(f)));
+}
+
+TEST(SchemaValidatorTest, VisualizationValidPasses)
+{
+  auto v = make_valid_visualization();
+  EXPECT_TRUE(static_cast<bool>(validate_visualization_schema(v)));
+}
+
+// ============================================================================
+// Header version negative paths
+// ============================================================================
+
+TEST(SchemaValidatorTest, HeaderVersionEmptyRejected)
+{
+  auto c = make_valid_connection();
+  c.header.version = "";
+  auto res = validate_connection_schema(c);
+  EXPECT_FALSE(static_cast<bool>(res));
+  ASSERT_FALSE(res.errors.empty());
+  EXPECT_EQ(
+    res.errors.front().error_type, vda5050_core::errors::SchemaValidationError);
+}
+
+TEST(SchemaValidatorTest, HeaderEmptySerialNumberRejected)
+{
+  auto f = make_valid_factsheet();
+  f.header.serial_number = "";
+  auto res = validate_factsheet_schema(f);
+  EXPECT_FALSE(static_cast<bool>(res));
+}
+
+// ============================================================================
+// ValidationResult plumbing — multiple errors accumulate
+// ============================================================================
+
+TEST(SchemaValidatorTest, MultipleErrorsAccumulate)
+{
+  auto o = make_valid_order();
+  o.order_id = "";               // -> 1 error
+  o.header.version = "9.9.9";    // -> 1 error
+  o.header.manufacturer = "";    // -> 1 error
+  o.nodes.front().node_id = "";  // -> 1 error
+  auto res = validate_order_schema(o);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_GE(res.errors.size(), 4u);
+  EXPECT_TRUE(AllErrorsHaveSchemaType(res));
+  // Spot-check that each independent issue surfaced its own message.
+  EXPECT_TRUE(AnyErrorMentions(res, "order_id"));
+  EXPECT_TRUE(AnyErrorMentions(res, "version"));
+  EXPECT_TRUE(AnyErrorMentions(res, "manufacturer"));
+  EXPECT_TRUE(AnyErrorMentions(res, "node_id"));
+}
+
+}  // namespace vda5050_core::master::test

--- a/vda5050_core/test/master/test_unit_traversability_validator.cpp
+++ b/vda5050_core/test/master/test_unit_traversability_validator.cpp
@@ -1,0 +1,601 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/master/map/map.hpp"
+#include "vda5050_core/master/validation/traversability_validator.hpp"
+
+namespace {
+
+::testing::AssertionResult AllErrorsHaveTraversabilityType(
+  const vda5050_core::order_utils::ValidationResult& res)
+{
+  for (const auto& e : res.errors)
+  {
+    if (e.error_type != vda5050_core::errors::TraversabilityValidationError)
+    {
+      return ::testing::AssertionFailure()
+             << "found error with type '" << e.error_type
+             << "' (expected TraversabilityValidationError)";
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult AnyErrorMentions(
+  const vda5050_core::order_utils::ValidationResult& res,
+  const std::string& needle)
+{
+  for (const auto& e : res.errors)
+  {
+    if (
+      e.error_description &&
+      e.error_description->find(needle) != std::string::npos)
+    {
+      return ::testing::AssertionSuccess();
+    }
+  }
+  return ::testing::AssertionFailure()
+         << "no error description mentions '" << needle << "'";
+}
+
+}  // namespace
+
+namespace vda5050_core::master::test {
+
+namespace {
+
+// Build a Factsheet that supports the typical happy-path Order: generous
+// limits, one supported action_type "pick" available on NODE/EDGE/INSTANT
+// scopes with a "loadId" parameter key.
+vda5050_core::types::Factsheet make_factsheet()
+{
+  vda5050_core::types::Factsheet fs;
+  fs.protocol_limits.max_array_lens.order_nodes = 100;
+  fs.protocol_limits.max_array_lens.order_edges = 100;
+  fs.protocol_limits.max_array_lens.node_actions = 10;
+  fs.protocol_limits.max_array_lens.edge_actions = 10;
+  fs.protocol_limits.max_array_lens.actions_actions_parameters = 10;
+  fs.protocol_limits.max_array_lens.instant_actions = 10;
+
+  vda5050_core::types::AGVAction supported;
+  supported.action_type = "pick";
+  supported.action_scopes = {
+    vda5050_core::types::ActionScope::NODE,
+    vda5050_core::types::ActionScope::EDGE,
+    vda5050_core::types::ActionScope::INSTANT};
+  vda5050_core::types::ActionParameterFactsheet param;
+  param.key = "loadId";
+  supported.action_parameters =
+    std::vector<vda5050_core::types::ActionParameterFactsheet>{param};
+  fs.protocol_features.agv_actions = {supported};
+  return fs;
+}
+
+// State where AGV is on node "N0" — trivial reachability for an order whose
+// first node is "N0".
+vda5050_core::types::State make_state_on_node(const std::string& node_id)
+{
+  vda5050_core::types::State s;
+  s.last_node_id = node_id;
+  vda5050_core::types::AGVPosition pos;
+  pos.position_initialized = true;
+  pos.x = 0.0;
+  pos.y = 0.0;
+  s.agv_position = pos;
+  return s;
+}
+
+PreSendContext make_ctx(
+  const vda5050_core::types::State& state,
+  const vda5050_core::types::Factsheet& fs)
+{
+  return PreSendContext{
+    vda5050_core::types::ConnectionState::ONLINE,
+    state,
+    fs,
+    AGVState::AVAILABLE,
+    std::nullopt,
+    nullptr};
+}
+
+vda5050_core::types::Order make_minimal_order()
+{
+  vda5050_core::types::Order o;
+  o.order_id = "ORDER_T1";
+  o.order_update_id = 0;
+  vda5050_core::types::Node n;
+  n.node_id = "N0";
+  n.sequence_id = 0;
+  n.released = true;
+  o.nodes.push_back(n);
+  return o;
+}
+
+vda5050_core::types::Action make_pick_action()
+{
+  vda5050_core::types::Action a;
+  a.action_id = "A1";
+  a.action_type = "pick";
+  a.blocking_type = vda5050_core::types::BlockingType::NONE;
+  return a;
+}
+
+}  // namespace
+
+// ============================================================================
+// Order — happy paths
+// ============================================================================
+
+TEST(TraversabilityValidatorTest, OrderHappyPathOnNode)
+{
+  auto ctx = make_ctx(make_state_on_node("N0"), make_factsheet());
+  auto order = make_minimal_order();
+  auto res = validate_traversability(ctx, order);
+  EXPECT_TRUE(static_cast<bool>(res));
+  EXPECT_TRUE(res.errors.empty());
+}
+
+TEST(TraversabilityValidatorTest, OrderHappyPathByPositionWithinDeviation)
+{
+  auto state = make_state_on_node("OTHER");  // AGV not on first node
+  state.agv_position->x = 0.05;              // 5cm offset
+  state.agv_position->y = 0.0;
+  auto ctx = make_ctx(state, make_factsheet());
+
+  auto order = make_minimal_order();
+  vda5050_core::types::NodePosition np;
+  np.x = 0.0;
+  np.y = 0.0;
+  np.allowed_deviation_x_y = 0.10;  // 10cm tolerance
+  order.nodes.front().node_position = np;
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+// ============================================================================
+// Order — reachability rejections
+// ============================================================================
+
+TEST(TraversabilityValidatorTest, OrderRejectFirstNodeUnreachable)
+{
+  auto state = make_state_on_node("OTHER");
+  state.agv_position->x = 5.0;  // 5m away
+  state.agv_position->y = 0.0;
+  auto ctx = make_ctx(state, make_factsheet());
+
+  auto order = make_minimal_order();
+  vda5050_core::types::NodePosition np;
+  np.x = 0.0;
+  np.y = 0.0;
+  np.allowed_deviation_x_y = 0.10;  // 10cm tolerance
+  order.nodes.front().node_position = np;
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "deviation"));
+}
+
+TEST(TraversabilityValidatorTest, OrderRejectInsufficientReachabilityData)
+{
+  // AGV not on node, AND first node has no node_position.
+  auto state = make_state_on_node("OTHER");
+  auto ctx = make_ctx(state, make_factsheet());
+  auto order = make_minimal_order();
+  // node_position omitted
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "Cannot determine reachability"));
+}
+
+// ============================================================================
+// Order — action capability rejections
+// ============================================================================
+
+TEST(TraversabilityValidatorTest, OrderRejectActionTypeNotInFactsheet)
+{
+  auto ctx = make_ctx(make_state_on_node("N0"), make_factsheet());
+  auto order = make_minimal_order();
+  vda5050_core::types::Action unsupported;
+  unsupported.action_id = "A1";
+  unsupported.action_type = "fly";  // not in factsheet
+  unsupported.blocking_type = vda5050_core::types::BlockingType::NONE;
+  order.nodes.front().actions = {unsupported};
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "fly"));
+}
+
+TEST(TraversabilityValidatorTest, OrderRejectActionScopeNotNode)
+{
+  // Build factsheet where "pick" is INSTANT-only — not allowed on Nodes.
+  auto fs = make_factsheet();
+  fs.protocol_features.agv_actions[0].action_scopes = {
+    vda5050_core::types::ActionScope::INSTANT};
+  auto ctx = make_ctx(make_state_on_node("N0"), fs);
+
+  auto order = make_minimal_order();
+  order.nodes.front().actions = {make_pick_action()};
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "scope"));
+}
+
+TEST(TraversabilityValidatorTest, OrderRejectActionParameterKeyNotInFactsheet)
+{
+  auto ctx = make_ctx(make_state_on_node("N0"), make_factsheet());
+  auto order = make_minimal_order();
+  auto a = make_pick_action();
+  vda5050_core::types::ActionParameter p;
+  p.key = "weirdKey";  // not declared by factsheet
+  p.value = "x";
+  a.action_parameters = std::vector<vda5050_core::types::ActionParameter>{p};
+  order.nodes.front().actions = {a};
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "weirdKey"));
+}
+
+// ============================================================================
+// Order — array-size limit rejections
+// ============================================================================
+
+TEST(TraversabilityValidatorTest, OrderRejectExceedsMaxNodes)
+{
+  auto fs = make_factsheet();
+  fs.protocol_limits.max_array_lens.order_nodes = 1;  // tight limit
+  auto ctx = make_ctx(make_state_on_node("N0"), fs);
+
+  auto order = make_minimal_order();
+  vda5050_core::types::Node n2;
+  n2.node_id = "N1";
+  n2.sequence_id = 2;
+  n2.released = true;
+  order.nodes.push_back(n2);
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "order_nodes"));
+}
+
+TEST(TraversabilityValidatorTest, OrderRejectExceedsMaxNodeActions)
+{
+  auto fs = make_factsheet();
+  fs.protocol_limits.max_array_lens.node_actions = 1;
+  auto ctx = make_ctx(make_state_on_node("N0"), fs);
+
+  auto order = make_minimal_order();
+  order.nodes.front().actions = {make_pick_action(), make_pick_action()};
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "node_actions"));
+}
+
+// ============================================================================
+// InstantActions — capability + limit
+// ============================================================================
+
+TEST(TraversabilityValidatorTest, InstantActionsHappyPath)
+{
+  auto ctx = make_ctx(make_state_on_node("N0"), make_factsheet());
+  vda5050_core::types::InstantActions ia;
+  ia.actions = {make_pick_action()};
+  auto res = validate_traversability(ctx, ia);
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+TEST(TraversabilityValidatorTest, InstantActionsRejectActionTypeNotInFactsheet)
+{
+  auto ctx = make_ctx(make_state_on_node("N0"), make_factsheet());
+  vda5050_core::types::InstantActions ia;
+  vda5050_core::types::Action unsupported;
+  unsupported.action_id = "A1";
+  unsupported.action_type = "teleport";
+  unsupported.blocking_type = vda5050_core::types::BlockingType::NONE;
+  ia.actions = {unsupported};
+  auto res = validate_traversability(ctx, ia);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "teleport"));
+}
+
+TEST(TraversabilityValidatorTest, InstantActionsRejectScopeNotInstant)
+{
+  auto fs = make_factsheet();
+  fs.protocol_features.agv_actions[0].action_scopes = {
+    vda5050_core::types::ActionScope::NODE};  // NODE only, NOT INSTANT
+  auto ctx = make_ctx(make_state_on_node("N0"), fs);
+  vda5050_core::types::InstantActions ia;
+  ia.actions = {make_pick_action()};
+  auto res = validate_traversability(ctx, ia);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "scope"));
+}
+
+TEST(TraversabilityValidatorTest, InstantActionsRejectExceedsMaxLength)
+{
+  auto fs = make_factsheet();
+  fs.protocol_limits.max_array_lens.instant_actions = 1;
+  auto ctx = make_ctx(make_state_on_node("N0"), fs);
+  vda5050_core::types::InstantActions ia;
+  ia.actions = {make_pick_action(), make_pick_action()};
+  auto res = validate_traversability(ctx, ia);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "instant_actions"));
+}
+
+// ============================================================================
+// Skip-when-factsheet-missing
+// ============================================================================
+
+TEST(TraversabilityValidatorTest, OrderSkipsCapabilityChecksWhenNoFactsheet)
+{
+  // No factsheet → skip capability + limit checks. Reachability still runs;
+  // AGV is on first node so it passes.
+  PreSendContext ctx{
+    vda5050_core::types::ConnectionState::ONLINE,
+    make_state_on_node("N0"),
+    std::nullopt,
+    AGVState::AVAILABLE,
+    std::nullopt,
+    nullptr};
+  auto order = make_minimal_order();
+  auto res = validate_traversability(ctx, order);
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+TEST(
+  TraversabilityValidatorTest,
+  InstantActionsSkipsCapabilityChecksWhenNoFactsheet)
+{
+  // No factsheet → no capability check on InstantActions; passes silently.
+  PreSendContext ctx{
+    vda5050_core::types::ConnectionState::ONLINE,
+    make_state_on_node("N0"),
+    std::nullopt,
+    AGVState::AVAILABLE,
+    std::nullopt,
+    nullptr};
+  vda5050_core::types::InstantActions ia;
+  vda5050_core::types::Action a;
+  a.action_id = "A1";
+  a.action_type = "anything_goes";
+  a.blocking_type = vda5050_core::types::BlockingType::NONE;
+  ia.actions = {a};
+  auto res = validate_traversability(ctx, ia);
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+// ============================================================================
+// Multi-error accumulation
+// ============================================================================
+
+TEST(TraversabilityValidatorTest, MultipleErrorsAccumulate)
+{
+  auto fs = make_factsheet();
+  fs.protocol_limits.max_array_lens.order_nodes = 1;  // tight limit
+  auto ctx = make_ctx(make_state_on_node("N0"), fs);
+
+  auto order = make_minimal_order();
+  // Add a second node to exceed limit
+  vda5050_core::types::Node n2;
+  n2.node_id = "N1";
+  n2.sequence_id = 2;
+  n2.released = true;
+  order.nodes.push_back(n2);
+  // Add an unsupported action type
+  vda5050_core::types::Action unsupported;
+  unsupported.action_id = "A1";
+  unsupported.action_type = "fly";
+  unsupported.blocking_type = vda5050_core::types::BlockingType::NONE;
+  order.nodes.front().actions = {unsupported};
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_GE(res.errors.size(), 2u);
+  EXPECT_TRUE(AllErrorsHaveTraversabilityType(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "order_nodes"));
+  EXPECT_TRUE(AnyErrorMentions(res, "fly"));
+}
+
+// ============================================================================
+// Map integrity — cross-checks Order graph against loaded map.
+// ============================================================================
+//
+// These tests exercise the new validate_map_integrity sub-check, which
+// runs only when ctx.loaded_map is non-null. The pre_send_validator
+// no-map gate covers the nullptr case separately.
+
+namespace {
+
+std::shared_ptr<const Map> make_two_node_map()
+{
+  Map m;
+  m.info.map_id = "M1";
+  m.info.map_version = "1.0";
+  MapNode n0;
+  n0.node_id = "N0";
+  n0.x = 0.0;
+  n0.y = 0.0;
+  n0.allowed_deviation_xy = 0.5;
+  MapNode n1;
+  n1.node_id = "N1";
+  n1.x = 5.0;
+  n1.y = 0.0;
+  n1.allowed_deviation_xy = 0.5;
+  m.nodes = {n0, n1};
+  m.node_index = {{"N0", 0}, {"N1", 1}};
+  MapEdge e1;
+  e1.edge_id = "E1";
+  e1.start_node_id = "N0";
+  e1.end_node_id = "N1";
+  e1.bidirectional = false;
+  m.edges = {e1};
+  m.edge_index = {{"E1", 0}};
+  return std::make_shared<const Map>(std::move(m));
+}
+
+PreSendContext make_ctx_with_map(
+  const vda5050_core::types::State& state,
+  const vda5050_core::types::Factsheet& fs, std::shared_ptr<const Map> mp)
+{
+  return PreSendContext{
+    vda5050_core::types::ConnectionState::ONLINE,
+    state,
+    fs,
+    AGVState::AVAILABLE,
+    std::nullopt,
+    std::move(mp)};
+}
+
+}  // namespace
+
+TEST(TraversabilityValidatorTest, MapIntegrity_OrderNodeNotInMap_Rejects)
+{
+  auto ctx = make_ctx_with_map(
+    make_state_on_node("N0"), make_factsheet(), make_two_node_map());
+  auto order = make_minimal_order();
+  order.nodes.front().node_id = "GHOST";  // not in the map
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "GHOST"));
+  EXPECT_TRUE(AnyErrorMentions(res, "not present in the master's loaded map"));
+}
+
+TEST(TraversabilityValidatorTest, MapIntegrity_OrderEdgeNotInMap_Rejects)
+{
+  auto ctx = make_ctx_with_map(
+    make_state_on_node("N0"), make_factsheet(), make_two_node_map());
+  auto order = make_minimal_order();
+  vda5050_core::types::Edge e;
+  e.edge_id = "GHOST_EDGE";
+  e.sequence_id = 1;
+  e.released = true;
+  e.start_node_id = "N0";
+  e.end_node_id = "N1";
+  order.edges.push_back(e);
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "GHOST_EDGE"));
+}
+
+TEST(TraversabilityValidatorTest, MapIntegrity_EdgeEndpointMismatch_Rejects)
+{
+  auto ctx = make_ctx_with_map(
+    make_state_on_node("N0"), make_factsheet(), make_two_node_map());
+  auto order = make_minimal_order();
+  vda5050_core::types::Edge e;
+  e.edge_id = "E1";
+  e.sequence_id = 1;
+  e.released = true;
+  e.start_node_id = "N1";  // map has N0->N1, not N1->N0 (one-way)
+  e.end_node_id = "N0";
+  order.edges.push_back(e);
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "endpoints"));
+}
+
+TEST(TraversabilityValidatorTest, MapIntegrity_BidirectionalAllowsReverse)
+{
+  // Mark E1 bidirectional and request reverse traversal.
+  Map m;
+  m.info.map_id = "M1";
+  m.info.map_version = "1.0";
+  MapNode n0;
+  n0.node_id = "N0";
+  MapNode n1;
+  n1.node_id = "N1";
+  m.nodes = {n0, n1};
+  m.node_index = {{"N0", 0}, {"N1", 1}};
+  MapEdge e1;
+  e1.edge_id = "E1";
+  e1.start_node_id = "N0";
+  e1.end_node_id = "N1";
+  e1.bidirectional = true;
+  m.edges = {e1};
+  m.edge_index = {{"E1", 0}};
+  auto mp = std::make_shared<const Map>(std::move(m));
+
+  auto ctx = make_ctx_with_map(make_state_on_node("N0"), make_factsheet(), mp);
+  auto order = make_minimal_order();
+  vda5050_core::types::Edge e;
+  e.edge_id = "E1";
+  e.sequence_id = 1;
+  e.released = true;
+  e.start_node_id = "N1";
+  e.end_node_id = "N0";
+  order.edges.push_back(e);
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_TRUE(static_cast<bool>(res)) << "bidirectional edge should accept "
+                                         "reverse-traversal endpoints";
+}
+
+TEST(TraversabilityValidatorTest, MapIntegrity_PositionWithinDeviation_Accepts)
+{
+  auto ctx = make_ctx_with_map(
+    make_state_on_node("N0"), make_factsheet(), make_two_node_map());
+  auto order = make_minimal_order();
+  vda5050_core::types::NodePosition np;
+  np.x = 0.3;  // map N0 is at (0,0), tolerance 0.5 → ok
+  np.y = 0.0;
+  order.nodes.front().node_position = np;
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_TRUE(static_cast<bool>(res));
+}
+
+TEST(TraversabilityValidatorTest, MapIntegrity_PositionExceedsDeviation_Rejects)
+{
+  auto ctx = make_ctx_with_map(
+    make_state_on_node("N0"), make_factsheet(), make_two_node_map());
+  auto order = make_minimal_order();
+  vda5050_core::types::NodePosition np;
+  np.x = 2.0;  // map N0 is at (0,0), tolerance 0.5 → way out
+  np.y = 0.0;
+  order.nodes.front().node_position = np;
+
+  auto res = validate_traversability(ctx, order);
+  EXPECT_FALSE(static_cast<bool>(res));
+  EXPECT_TRUE(AnyErrorMentions(res, "outside the map's allowed_deviation_xy"));
+}
+
+}  // namespace vda5050_core::master::test


### PR DESCRIPTION
## Summary

Adds the master-side topology map and outgoing order / instant-action validation chain to `vda5050_core` as standalone, unit-tested library modules.

These are reusable building blocks only. Wiring them into the per-AGV publish path is out of scope for this PR.

## What's Included

### Topology Map (`master/map/`)

- `Map` / `MapInfo` / `MapNode` / `MapEdge` — master-internal static topology types for identity and geometry, kept separate from Order-wire `types::Node` / `types::Edge`.
- `map_loader` — loads one map from JSON config via `load_from_file` / `load_from_json`, with categorical `MapLoadErrorType` errors for file / parse errors, missing fields, duplicate IDs, dangling edge refs, and empty maps.

> Note: The map types and JSON config are master-side internal representations, not VDA5050 wire formats.

### Validation Chain (`master/validation/`)

All validators are stateless free functions returning `order_utils::ValidationResult`.

- `schema_validator` — structural field checks for order, instant actions, state, connection, factsheet, and visualization.
- `pre_send_validator` — AGV-readiness gate for connection, operating mode, position, and loaded map, via a lock-free `PreSendContext` snapshot.
- `traversability_validator` — first-node reachability, action capability vs. factsheet, and array-size limits.
- `action_conflict_validator` — `blocking_type` conflict check against running actions / driving state.
- `instant_action_mode_validator` — operating-mode gate with the predefined instant-scope allowlist.
- `factsheet_alignment` — cross-checks a loaded map against an AGV factsheet for speed capability.