### PR TITLE
feat(master): change interface_name to be configurable in vda5050_core::master

### DIFF
--- a/vda5050_core/include/vda5050_core/master/agv.hpp
+++ b/vda5050_core/include/vda5050_core/master/agv.hpp
@@ -123,9 +123,9 @@ public:
    */
   AGV(
     std::shared_ptr<execution::ProtocolAdapter> protocol_adapter,
-    const std::string& interface_name,
-    const std::string& manufacturer, const std::string& serial_number,
-    size_t max_queue_size = 10, bool drop_oldest = true,
+    const std::string& interface_name, const std::string& manufacturer,
+    const std::string& serial_number, size_t max_queue_size = 10,
+    bool drop_oldest = true,
     int state_heartbeat_interval = StateHeartbeatInterval,
     std::weak_ptr<VDA5050Master> parent = {});
 

--- a/vda5050_core/include/vda5050_core/master/agv.hpp
+++ b/vda5050_core/include/vda5050_core/master/agv.hpp
@@ -123,6 +123,7 @@ public:
    */
   AGV(
     std::shared_ptr<execution::ProtocolAdapter> protocol_adapter,
+    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number,
     size_t max_queue_size = 10, bool drop_oldest = true,
     int state_heartbeat_interval = StateHeartbeatInterval,
@@ -143,6 +144,13 @@ public:
   // Identity
   // ============================================================================
 
+  /**
+   * @brief Get the interface name
+   */
+  const std::string& get_interface_name() const
+  {
+    return interface_name_;
+  }
   /**
    * @brief Get the manufacturer name
    */
@@ -435,6 +443,7 @@ private:
   // ============================================================================
 
   // Identity
+  std::string interface_name_;
   std::string manufacturer_;
   std::string serial_number_;
   std::string agv_id_;

--- a/vda5050_core/include/vda5050_core/master/master.hpp
+++ b/vda5050_core/include/vda5050_core/master/master.hpp
@@ -139,6 +139,7 @@ public:
    * will be routed to the appropriate handlers.
    */
   void onboard_agv(
+    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number,
     size_t max_queue_size = 10, bool drop_oldest = true);
 
@@ -151,6 +152,7 @@ public:
    * will be ignored with a warning.
    */
   void offboard_agv(
+    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number);
 
   /**
@@ -160,6 +162,7 @@ public:
    * @return true if AGV is onboarded
    */
   bool is_agv_onboarded(
+    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number) const;
 
   // ============================================================================
@@ -173,6 +176,7 @@ public:
    * @return Shared pointer to AGV, or nullptr if not onboarded
    */
   std::shared_ptr<AGV> get_agv(
+    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number) const;
 
   // ============================================================================
@@ -188,6 +192,7 @@ public:
    * @throws std::runtime_error if AGV is not onboarded
    */
   bool publish_order(
+    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number,
     const Order& order);
 
@@ -200,6 +205,7 @@ public:
    * @throws std::runtime_error if AGV is not onboarded
    */
   bool publish_instant_actions(
+    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number,
     const InstantActions& actions);
 

--- a/vda5050_core/include/vda5050_core/master/master.hpp
+++ b/vda5050_core/include/vda5050_core/master/master.hpp
@@ -137,11 +137,27 @@ public:
    *
    * Creates an AGV instance in the allowed list. Messages from this AGV
    * will be routed to the appropriate handlers.
+   * The interface name is set to "uagv" by default.
    */
   void onboard_agv(
-    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number,
     size_t max_queue_size = 10, bool drop_oldest = true);
+
+  /**
+   * @brief Onboard an AGV with a custom interface_name to allow message routing
+   * @param interface_name Interface name
+   * @param manufacturer Manufacturer name
+   * @param serial_number Serial number
+   * @param max_queue_size Maximum number of outgoing messages to queue (default: 10)
+   * @param drop_oldest If true, drop oldest message when queue full; if false, reject new message (default: true)
+   *
+   * Creates an AGV instance in the allowed list. Messages from this AGV
+   * will be routed to the appropriate handlers.
+   */
+  void onboard_agv(
+    const std::string& interface_name, const std::string& manufacturer,
+    const std::string& serial_number, size_t max_queue_size = 10,
+    bool drop_oldest = true);
 
   /**
    * @brief Offboard an AGV to stop message routing
@@ -152,7 +168,6 @@ public:
    * will be ignored with a warning.
    */
   void offboard_agv(
-    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number);
 
   /**
@@ -162,7 +177,6 @@ public:
    * @return true if AGV is onboarded
    */
   bool is_agv_onboarded(
-    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number) const;
 
   // ============================================================================
@@ -176,7 +190,6 @@ public:
    * @return Shared pointer to AGV, or nullptr if not onboarded
    */
   std::shared_ptr<AGV> get_agv(
-    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number) const;
 
   // ============================================================================
@@ -192,7 +205,6 @@ public:
    * @throws std::runtime_error if AGV is not onboarded
    */
   bool publish_order(
-    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number,
     const Order& order);
 
@@ -205,7 +217,6 @@ public:
    * @throws std::runtime_error if AGV is not onboarded
    */
   bool publish_instant_actions(
-    const std::string& interface_name,
     const std::string& manufacturer, const std::string& serial_number,
     const InstantActions& actions);
 

--- a/vda5050_core/include/vda5050_core/master/standard_names.hpp
+++ b/vda5050_core/include/vda5050_core/master/standard_names.hpp
@@ -37,6 +37,7 @@ enum class QosLevel : int
 };
 
 const std::string Version = "v2";                          // NOLINT
+const std::string DefaultInterfaceName = "uagv";           // NOLINT
 const std::string ConnectionTopic = "connection";          // NOLINT
 const std::string FactsheetTopic = "factsheet";            // NOLINT
 const std::string OrderTopic = "order";                    // NOLINT

--- a/vda5050_core/include/vda5050_core/master/standard_names.hpp
+++ b/vda5050_core/include/vda5050_core/master/standard_names.hpp
@@ -37,7 +37,6 @@ enum class QosLevel : int
 };
 
 const std::string Version = "v2";                          // NOLINT
-const std::string InterfaceName = "rmf2";                  // NOLINT
 const std::string ConnectionTopic = "connection";          // NOLINT
 const std::string FactsheetTopic = "factsheet";            // NOLINT
 const std::string OrderTopic = "order";                    // NOLINT

--- a/vda5050_core/src/master/agv.cpp
+++ b/vda5050_core/src/master/agv.cpp
@@ -31,14 +31,13 @@ namespace master {
 //=============================================================================
 AGV::AGV(
   std::shared_ptr<ProtocolAdapter> protocol_adapter,
-  const std::string& interface_name,
-  const std::string& manufacturer, const std::string& serial_number,
-  size_t max_queue_size, bool drop_oldest, int state_heartbeat_interval,
-  std::weak_ptr<VDA5050Master> parent)
+  const std::string& interface_name, const std::string& manufacturer,
+  const std::string& serial_number, size_t max_queue_size, bool drop_oldest,
+  int state_heartbeat_interval, std::weak_ptr<VDA5050Master> parent)
 : interface_name_(interface_name),
   manufacturer_(manufacturer),
   serial_number_(serial_number),
-  agv_id_(interface_name + "/" + manufacturer + "/" + serial_number),
+  agv_id_(manufacturer + "/" + serial_number),
   protocol_adapter_(protocol_adapter),
   parent_(std::move(parent)),
   state_heartbeat_interval_(state_heartbeat_interval),

--- a/vda5050_core/src/master/agv.cpp
+++ b/vda5050_core/src/master/agv.cpp
@@ -31,12 +31,14 @@ namespace master {
 //=============================================================================
 AGV::AGV(
   std::shared_ptr<ProtocolAdapter> protocol_adapter,
+  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number,
   size_t max_queue_size, bool drop_oldest, int state_heartbeat_interval,
   std::weak_ptr<VDA5050Master> parent)
-: manufacturer_(manufacturer),
+: interface_name_(interface_name),
+  manufacturer_(manufacturer),
   serial_number_(serial_number),
-  agv_id_(manufacturer + "/" + serial_number),
+  agv_id_(interface_name + "/" + manufacturer + "/" + serial_number),
   protocol_adapter_(protocol_adapter),
   parent_(std::move(parent)),
   state_heartbeat_interval_(state_heartbeat_interval),
@@ -675,7 +677,7 @@ void AGV::publish_instant_actions(const InstantActions& actions)
 //=============================================================================
 std::string AGV::build_topic(const std::string& topic_name) const
 {
-  return InterfaceName + "/" + Version + "/" + manufacturer_ + "/" +
+  return interface_name_ + "/" + Version + "/" + manufacturer_ + "/" +
          serial_number_ + "/" + topic_name;
 }
 

--- a/vda5050_core/src/master/master.cpp
+++ b/vda5050_core/src/master/master.cpp
@@ -87,10 +87,11 @@ bool VDA5050Master::is_connected() const
 
 //=============================================================================
 void VDA5050Master::onboard_agv(
+  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number,
   size_t max_queue_size, bool drop_oldest)
 {
-  std::string agv_id = manufacturer + "/" + serial_number;
+  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
 
   std::lock_guard<std::mutex> lock(agv_mutex_);
 
@@ -106,8 +107,8 @@ void VDA5050Master::onboard_agv(
   // detecting master destruction cleanly via lock().
   auto agv = std::make_shared<AGV>(
     ProtocolAdapter::make(
-      mqtt_client_, InterfaceName, Version, manufacturer, serial_number),
-    manufacturer, serial_number, max_queue_size, drop_oldest,
+      mqtt_client_, interface_name, Version, manufacturer, serial_number),
+    interface_name, manufacturer, serial_number, max_queue_size, drop_oldest,
     StateHeartbeatInterval, weak_from_this());
 
   // Subscriptions are wired here (not in AGV's ctor) so that
@@ -122,9 +123,10 @@ void VDA5050Master::onboard_agv(
 
 //=============================================================================
 void VDA5050Master::offboard_agv(
+  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number)
 {
-  std::string agv_id = manufacturer + "/" + serial_number;
+  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
 
   std::shared_ptr<AGV> agv;
   {
@@ -151,19 +153,21 @@ void VDA5050Master::offboard_agv(
 
 //=============================================================================
 bool VDA5050Master::is_agv_onboarded(
+  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number) const
 {
   std::lock_guard<std::mutex> lock(agv_mutex_);
-  std::string agv_id = manufacturer + "/" + serial_number;
+  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
   return get_agv_by_id(agv_id) != nullptr;
 }
 
 //=============================================================================
 std::shared_ptr<AGV> VDA5050Master::get_agv(
+  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number) const
 {
   std::lock_guard<std::mutex> lock(agv_mutex_);
-  std::string agv_id = manufacturer + "/" + serial_number;
+  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
   return get_agv_by_id(agv_id);
 }
 
@@ -178,10 +182,11 @@ std::shared_ptr<AGV> VDA5050Master::get_agv_by_id(
 
 //=============================================================================
 bool VDA5050Master::publish_order(
+  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number,
   const Order& order)
 {
-  std::string agv_id = manufacturer + "/" + serial_number;
+  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
 
   std::shared_ptr<AGV> agv;
   {
@@ -200,10 +205,11 @@ bool VDA5050Master::publish_order(
 
 //=============================================================================
 bool VDA5050Master::publish_instant_actions(
+  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number,
   const InstantActions& actions)
 {
-  std::string agv_id = manufacturer + "/" + serial_number;
+  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
 
   std::shared_ptr<AGV> agv;
   {

--- a/vda5050_core/src/master/master.cpp
+++ b/vda5050_core/src/master/master.cpp
@@ -124,7 +124,9 @@ void VDA5050Master::onboard_agv(
   const std::string& manufacturer, const std::string& serial_number,
   size_t max_queue_size, bool drop_oldest)
 {
-  onboard_agv(DefaultInterfaceName, manufacturer, serial_number, max_queue_size, drop_oldest);
+  onboard_agv(
+    DefaultInterfaceName, manufacturer, serial_number, max_queue_size,
+    drop_oldest);
 }
 
 //=============================================================================

--- a/vda5050_core/src/master/master.cpp
+++ b/vda5050_core/src/master/master.cpp
@@ -124,7 +124,7 @@ void VDA5050Master::onboard_agv(
   const std::string& manufacturer, const std::string& serial_number,
   size_t max_queue_size, bool drop_oldest)
 {
-  onboard_agv("uagv", manufacturer, serial_number, max_queue_size, drop_oldest);
+  onboard_agv(DefaultInterfaceName, manufacturer, serial_number, max_queue_size, drop_oldest);
 }
 
 //=============================================================================

--- a/vda5050_core/src/master/master.cpp
+++ b/vda5050_core/src/master/master.cpp
@@ -87,11 +87,10 @@ bool VDA5050Master::is_connected() const
 
 //=============================================================================
 void VDA5050Master::onboard_agv(
-  const std::string& interface_name,
-  const std::string& manufacturer, const std::string& serial_number,
-  size_t max_queue_size, bool drop_oldest)
+  const std::string& interface_name, const std::string& manufacturer,
+  const std::string& serial_number, size_t max_queue_size, bool drop_oldest)
 {
-  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
+  std::string agv_id = manufacturer + "/" + serial_number;
 
   std::lock_guard<std::mutex> lock(agv_mutex_);
 
@@ -121,12 +120,18 @@ void VDA5050Master::onboard_agv(
   VDA5050_INFO("[VDA5050Master] Onboarded AGV: {}", agv_id);
 }
 
+void VDA5050Master::onboard_agv(
+  const std::string& manufacturer, const std::string& serial_number,
+  size_t max_queue_size, bool drop_oldest)
+{
+  onboard_agv("uagv", manufacturer, serial_number, max_queue_size, drop_oldest);
+}
+
 //=============================================================================
 void VDA5050Master::offboard_agv(
-  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number)
 {
-  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
+  std::string agv_id = manufacturer + "/" + serial_number;
 
   std::shared_ptr<AGV> agv;
   {
@@ -153,21 +158,19 @@ void VDA5050Master::offboard_agv(
 
 //=============================================================================
 bool VDA5050Master::is_agv_onboarded(
-  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number) const
 {
   std::lock_guard<std::mutex> lock(agv_mutex_);
-  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
+  std::string agv_id = manufacturer + "/" + serial_number;
   return get_agv_by_id(agv_id) != nullptr;
 }
 
 //=============================================================================
 std::shared_ptr<AGV> VDA5050Master::get_agv(
-  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number) const
 {
   std::lock_guard<std::mutex> lock(agv_mutex_);
-  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
+  std::string agv_id = manufacturer + "/" + serial_number;
   return get_agv_by_id(agv_id);
 }
 
@@ -182,11 +185,10 @@ std::shared_ptr<AGV> VDA5050Master::get_agv_by_id(
 
 //=============================================================================
 bool VDA5050Master::publish_order(
-  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number,
   const Order& order)
 {
-  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
+  std::string agv_id = manufacturer + "/" + serial_number;
 
   std::shared_ptr<AGV> agv;
   {
@@ -205,11 +207,10 @@ bool VDA5050Master::publish_order(
 
 //=============================================================================
 bool VDA5050Master::publish_instant_actions(
-  const std::string& interface_name,
   const std::string& manufacturer, const std::string& serial_number,
   const InstantActions& actions)
 {
-  std::string agv_id = interface_name + "/" + manufacturer + "/" + serial_number;
+  std::string agv_id = manufacturer + "/" + serial_number;
 
   std::shared_ptr<AGV> agv;
   {

--- a/vda5050_core/test/master/test_integration_master_logic.cpp
+++ b/vda5050_core/test/master/test_integration_master_logic.cpp
@@ -39,8 +39,8 @@
 using vda5050_core::types::InstantActions;
 using vda5050_core::types::Order;
 
-using vda5050_core::master::VDA5050Master;
 using vda5050_core::master::DefaultInterfaceName;
+using vda5050_core::master::VDA5050Master;
 
 class MasterLogicTestFixture : public ::testing::Test
 {

--- a/vda5050_core/test/master/test_integration_master_logic.cpp
+++ b/vda5050_core/test/master/test_integration_master_logic.cpp
@@ -46,9 +46,10 @@ class MasterLogicTestFixture : public ::testing::Test
 protected:
   void SetUp() override
   {
+    interface_name_ = "agv";
     manufacturer_ = "TestManufacturer";
     serial_number_ = "SN001";
-    agv_id_ = manufacturer_ + "/" + serial_number_;
+    agv_id_ = interface_name_ + "/" + manufacturer_ + "/" + serial_number_;
   }
 
   std::shared_ptr<VDA5050Master> create_master()
@@ -74,6 +75,7 @@ protected:
     return actions;
   }
 
+  std::string interface_name_;
   std::string manufacturer_;
   std::string serial_number_;
   std::string agv_id_;
@@ -84,11 +86,11 @@ TEST_F(MasterLogicTestFixture, OnboardAGVCreatesInstance)
   auto master = create_master();
   master->connect();
 
-  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
-  master->onboard_agv(manufacturer_, serial_number_);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
 
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
   master->disconnect();
 }
@@ -98,11 +100,11 @@ TEST_F(MasterLogicTestFixture, OffboardAGVRemovesInstance)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
-  master->offboard_agv(manufacturer_, serial_number_);
-  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
+  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
   master->disconnect();
 }
@@ -114,7 +116,7 @@ TEST_F(MasterLogicTestFixture, PublishOrderToNotOnboardedAGVThrows)
 
   EXPECT_THROW(
     master->publish_order(
-      manufacturer_, serial_number_, create_test_order("1")),
+      interface_name_, manufacturer_, serial_number_, create_test_order("1")),
     std::runtime_error);
 
   master->disconnect();
@@ -127,7 +129,7 @@ TEST_F(MasterLogicTestFixture, PublishInstantActionsToNotOnboardedAGVThrows)
 
   EXPECT_THROW(
     master->publish_instant_actions(
-      manufacturer_, serial_number_, create_test_instant_actions(1)),
+      interface_name_, manufacturer_, serial_number_, create_test_instant_actions(1)),
     std::runtime_error);
 
   master->disconnect();
@@ -138,13 +140,13 @@ TEST_F(MasterLogicTestFixture, MultipleAGVsCanBeOnboarded)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv("Manufacturer1", "SN001");
-  master->onboard_agv("Manufacturer1", "SN002");
-  master->onboard_agv("Manufacturer2", "SN001");
+  master->onboard_agv("agv", "Manufacturer1", "SN001");
+  master->onboard_agv("agv", "Manufacturer1", "SN002");
+  master->onboard_agv("agv", "Manufacturer2", "SN001");
 
-  EXPECT_TRUE(master->is_agv_onboarded("Manufacturer1", "SN001"));
-  EXPECT_TRUE(master->is_agv_onboarded("Manufacturer1", "SN002"));
-  EXPECT_TRUE(master->is_agv_onboarded("Manufacturer2", "SN001"));
+  EXPECT_TRUE(master->is_agv_onboarded("agv", "Manufacturer1", "SN001"));
+  EXPECT_TRUE(master->is_agv_onboarded("agv", "Manufacturer1", "SN002"));
+  EXPECT_TRUE(master->is_agv_onboarded("agv", "Manufacturer2", "SN001"));
 
   master->disconnect();
 }
@@ -154,12 +156,12 @@ TEST_F(MasterLogicTestFixture, DuplicateOnboardingIsIgnored)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
   // Second onboarding should be ignored (no crash, no duplicate)
-  master->onboard_agv(manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
   master->disconnect();
 }
@@ -170,7 +172,7 @@ TEST_F(MasterLogicTestFixture, OffboardNonExistentAGVIsIgnored)
   master->connect();
 
   // Should not throw or crash
-  EXPECT_NO_THROW(master->offboard_agv("NonExistent", "AGV"));
+  EXPECT_NO_THROW(master->offboard_agv("agv", "NonExistent", "AGV"));
 
   master->disconnect();
 }
@@ -180,7 +182,7 @@ TEST_F(MasterLogicTestFixture, GetAGVReturnsNullptrForNonOnboardedAGV)
   auto master = create_master();
   master->connect();
 
-  auto agv = master->get_agv(manufacturer_, serial_number_);
+  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
   EXPECT_EQ(agv, nullptr);
 
   master->disconnect();
@@ -191,10 +193,11 @@ TEST_F(MasterLogicTestFixture, GetAGVReturnsValidAGVAfterOnboarding)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(manufacturer_, serial_number_);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
 
-  auto agv = master->get_agv(manufacturer_, serial_number_);
+  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
+  EXPECT_EQ(agv->get_interface_name(), interface_name_);
   EXPECT_EQ(agv->get_manufacturer(), manufacturer_);
   EXPECT_EQ(agv->get_serial_number(), serial_number_);
   EXPECT_EQ(agv->get_agv_id(), agv_id_);
@@ -207,13 +210,13 @@ TEST_F(MasterLogicTestFixture, GetAGVReturnsNullptrAfterOffboarding)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(manufacturer_, serial_number_);
-  auto agv_before = master->get_agv(manufacturer_, serial_number_);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv_before = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv_before, nullptr);
 
-  master->offboard_agv(manufacturer_, serial_number_);
+  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
 
-  auto agv_after = master->get_agv(manufacturer_, serial_number_);
+  auto agv_after = master->get_agv(interface_name_, manufacturer_, serial_number_);
   EXPECT_EQ(agv_after, nullptr);
 
   master->disconnect();
@@ -225,21 +228,21 @@ TEST_F(MasterLogicTestFixture, ReOnboardingAfterOffboardingWorks)
   master->connect();
 
   // First onboarding
-  master->onboard_agv(manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
-  auto agv1 = master->get_agv(manufacturer_, serial_number_);
+  auto agv1 = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv1, nullptr);
 
   // Offboard
-  master->offboard_agv(manufacturer_, serial_number_);
-  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
+  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
   // Re-onboard
-  master->onboard_agv(manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
-  auto agv2 = master->get_agv(manufacturer_, serial_number_);
+  auto agv2 = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv2, nullptr);
 
   // Should be a new instance (different pointer)
@@ -252,9 +255,9 @@ TEST_F(MasterLogicTestFixture, AGVQueuesOrders)
 {
   auto master = create_master();
   master->connect();
-  master->onboard_agv(manufacturer_, serial_number_);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
 
-  auto agv = master->get_agv(manufacturer_, serial_number_);
+  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Queue should work
@@ -268,9 +271,9 @@ TEST_F(MasterLogicTestFixture, AGVQueuesInstantActions)
 {
   auto master = create_master();
   master->connect();
-  master->onboard_agv(manufacturer_, serial_number_);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
 
-  auto agv = master->get_agv(manufacturer_, serial_number_);
+  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Queue should work
@@ -287,9 +290,9 @@ TEST_F(MasterLogicTestFixture, AGVDropOldestPolicyWorks)
 
   // Onboard with small queue size and drop_oldest = true
   size_t queue_size = 2;
-  master->onboard_agv(manufacturer_, serial_number_, queue_size, true);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_, queue_size, true);
 
-  auto agv = master->get_agv(manufacturer_, serial_number_);
+  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Fill the queue
@@ -309,9 +312,9 @@ TEST_F(MasterLogicTestFixture, AGVDropNewestPolicyWorks)
 
   // Onboard with small queue size and drop_oldest = false (drop newest)
   size_t queue_size = 2;
-  master->onboard_agv(manufacturer_, serial_number_, queue_size, false);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_, queue_size, false);
 
-  auto agv = master->get_agv(manufacturer_, serial_number_);
+  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Fill the queue
@@ -333,9 +336,9 @@ TEST_F(MasterLogicTestFixture, OnboardingWithCustomQueueSettings)
   size_t custom_queue_size = 5;
   bool drop_oldest = false;
   master->onboard_agv(
-    manufacturer_, serial_number_, custom_queue_size, drop_oldest);
+    interface_name_, manufacturer_, serial_number_, custom_queue_size, drop_oldest);
 
-  auto agv = master->get_agv(manufacturer_, serial_number_);
+  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Queue should accept up to custom_queue_size orders
@@ -382,14 +385,14 @@ TEST_F(MasterLogicTestFixture, AGVsRemainsOnboardedAfterMasterDisconnect)
 {
   auto master = create_master();
   master->connect();
-  master->onboard_agv(manufacturer_, serial_number_);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
 
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
   master->disconnect();
 
   // AGV should still be onboarded even if master is disconnected
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 }
 
 TEST_F(MasterLogicTestFixture, DestructorCompletesWithPendingMessages)
@@ -399,9 +402,9 @@ TEST_F(MasterLogicTestFixture, DestructorCompletesWithPendingMessages)
   {
     auto master = create_master();
     master->connect();
-    master->onboard_agv(manufacturer_, serial_number_);
+    master->onboard_agv(interface_name_, manufacturer_, serial_number_);
 
-    auto agv = master->get_agv(manufacturer_, serial_number_);
+    auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
     ASSERT_NE(agv, nullptr);
 
     // Queue many messages
@@ -424,9 +427,9 @@ TEST_F(MasterLogicTestFixture, OffboardWithPendingMessages)
 {
   auto master = create_master();
   master->connect();
-  master->onboard_agv(manufacturer_, serial_number_);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
 
-  auto agv = master->get_agv(manufacturer_, serial_number_);
+  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Queue some messages
@@ -437,12 +440,12 @@ TEST_F(MasterLogicTestFixture, OffboardWithPendingMessages)
 
   // Offboard should complete gracefully
   auto start = std::chrono::steady_clock::now();
-  master->offboard_agv(manufacturer_, serial_number_);
+  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
   auto elapsed = std::chrono::steady_clock::now() - start;
 
   EXPECT_LT(elapsed, std::chrono::seconds(5)) << "Offboard took too long";
 
-  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
   master->disconnect();
 }

--- a/vda5050_core/test/master/test_integration_master_logic.cpp
+++ b/vda5050_core/test/master/test_integration_master_logic.cpp
@@ -40,13 +40,14 @@ using vda5050_core::types::InstantActions;
 using vda5050_core::types::Order;
 
 using vda5050_core::master::VDA5050Master;
+using vda5050_core::master::DefaultInterfaceName;
 
 class MasterLogicTestFixture : public ::testing::Test
 {
 protected:
   void SetUp() override
   {
-    interface_name_ = "uagv";
+    interface_name_ = DefaultInterfaceName;
     manufacturer_ = "TestManufacturer";
     serial_number_ = "SN001";
     agv_id_ = manufacturer_ + "/" + serial_number_;

--- a/vda5050_core/test/master/test_integration_master_logic.cpp
+++ b/vda5050_core/test/master/test_integration_master_logic.cpp
@@ -46,10 +46,10 @@ class MasterLogicTestFixture : public ::testing::Test
 protected:
   void SetUp() override
   {
-    interface_name_ = "agv";
+    interface_name_ = "uagv";
     manufacturer_ = "TestManufacturer";
     serial_number_ = "SN001";
-    agv_id_ = interface_name_ + "/" + manufacturer_ + "/" + serial_number_;
+    agv_id_ = manufacturer_ + "/" + serial_number_;
   }
 
   std::shared_ptr<VDA5050Master> create_master()
@@ -86,11 +86,26 @@ TEST_F(MasterLogicTestFixture, OnboardAGVCreatesInstance)
   auto master = create_master();
   master->connect();
 
-  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  master->onboard_agv(manufacturer_, serial_number_);
 
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+
+  master->disconnect();
+}
+
+TEST_F(MasterLogicTestFixture, OnboardAGVCreatesInstanceCustomInterfaceName)
+{
+  std::string custom_interface_name = "amr";
+  auto master = create_master();
+  master->connect();
+
+  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
+
+  master->onboard_agv(custom_interface_name, manufacturer_, serial_number_);
+
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
   master->disconnect();
 }
@@ -100,11 +115,11 @@ TEST_F(MasterLogicTestFixture, OffboardAGVRemovesInstance)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  master->onboard_agv(manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
-  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
-  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  master->offboard_agv(manufacturer_, serial_number_);
+  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
   master->disconnect();
 }
@@ -116,7 +131,7 @@ TEST_F(MasterLogicTestFixture, PublishOrderToNotOnboardedAGVThrows)
 
   EXPECT_THROW(
     master->publish_order(
-      interface_name_, manufacturer_, serial_number_, create_test_order("1")),
+      manufacturer_, serial_number_, create_test_order("1")),
     std::runtime_error);
 
   master->disconnect();
@@ -129,7 +144,7 @@ TEST_F(MasterLogicTestFixture, PublishInstantActionsToNotOnboardedAGVThrows)
 
   EXPECT_THROW(
     master->publish_instant_actions(
-      interface_name_, manufacturer_, serial_number_, create_test_instant_actions(1)),
+      manufacturer_, serial_number_, create_test_instant_actions(1)),
     std::runtime_error);
 
   master->disconnect();
@@ -140,13 +155,13 @@ TEST_F(MasterLogicTestFixture, MultipleAGVsCanBeOnboarded)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv("agv", "Manufacturer1", "SN001");
-  master->onboard_agv("agv", "Manufacturer1", "SN002");
-  master->onboard_agv("agv", "Manufacturer2", "SN001");
+  master->onboard_agv("Manufacturer1", "SN001");
+  master->onboard_agv("Manufacturer1", "SN002");
+  master->onboard_agv("Manufacturer2", "SN001");
 
-  EXPECT_TRUE(master->is_agv_onboarded("agv", "Manufacturer1", "SN001"));
-  EXPECT_TRUE(master->is_agv_onboarded("agv", "Manufacturer1", "SN002"));
-  EXPECT_TRUE(master->is_agv_onboarded("agv", "Manufacturer2", "SN001"));
+  EXPECT_TRUE(master->is_agv_onboarded("Manufacturer1", "SN001"));
+  EXPECT_TRUE(master->is_agv_onboarded("Manufacturer1", "SN002"));
+  EXPECT_TRUE(master->is_agv_onboarded("Manufacturer2", "SN001"));
 
   master->disconnect();
 }
@@ -156,12 +171,12 @@ TEST_F(MasterLogicTestFixture, DuplicateOnboardingIsIgnored)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  master->onboard_agv(manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
   // Second onboarding should be ignored (no crash, no duplicate)
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  master->onboard_agv(manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
   master->disconnect();
 }
@@ -172,7 +187,7 @@ TEST_F(MasterLogicTestFixture, OffboardNonExistentAGVIsIgnored)
   master->connect();
 
   // Should not throw or crash
-  EXPECT_NO_THROW(master->offboard_agv("agv", "NonExistent", "AGV"));
+  EXPECT_NO_THROW(master->offboard_agv("NonExistent", "AGV"));
 
   master->disconnect();
 }
@@ -182,7 +197,7 @@ TEST_F(MasterLogicTestFixture, GetAGVReturnsNullptrForNonOnboardedAGV)
   auto master = create_master();
   master->connect();
 
-  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv = master->get_agv(manufacturer_, serial_number_);
   EXPECT_EQ(agv, nullptr);
 
   master->disconnect();
@@ -193,9 +208,9 @@ TEST_F(MasterLogicTestFixture, GetAGVReturnsValidAGVAfterOnboarding)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  master->onboard_agv(manufacturer_, serial_number_);
 
-  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
   EXPECT_EQ(agv->get_interface_name(), interface_name_);
   EXPECT_EQ(agv->get_manufacturer(), manufacturer_);
@@ -210,13 +225,13 @@ TEST_F(MasterLogicTestFixture, GetAGVReturnsNullptrAfterOffboarding)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
-  auto agv_before = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  master->onboard_agv(manufacturer_, serial_number_);
+  auto agv_before = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv_before, nullptr);
 
-  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
+  master->offboard_agv(manufacturer_, serial_number_);
 
-  auto agv_after = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv_after = master->get_agv(manufacturer_, serial_number_);
   EXPECT_EQ(agv_after, nullptr);
 
   master->disconnect();
@@ -228,21 +243,21 @@ TEST_F(MasterLogicTestFixture, ReOnboardingAfterOffboardingWorks)
   master->connect();
 
   // First onboarding
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  master->onboard_agv(manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
-  auto agv1 = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv1 = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv1, nullptr);
 
   // Offboard
-  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
-  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  master->offboard_agv(manufacturer_, serial_number_);
+  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
   // Re-onboard
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  master->onboard_agv(manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
-  auto agv2 = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv2 = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv2, nullptr);
 
   // Should be a new instance (different pointer)
@@ -255,9 +270,9 @@ TEST_F(MasterLogicTestFixture, AGVQueuesOrders)
 {
   auto master = create_master();
   master->connect();
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  master->onboard_agv(manufacturer_, serial_number_);
 
-  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Queue should work
@@ -271,9 +286,9 @@ TEST_F(MasterLogicTestFixture, AGVQueuesInstantActions)
 {
   auto master = create_master();
   master->connect();
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  master->onboard_agv(manufacturer_, serial_number_);
 
-  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Queue should work
@@ -290,9 +305,9 @@ TEST_F(MasterLogicTestFixture, AGVDropOldestPolicyWorks)
 
   // Onboard with small queue size and drop_oldest = true
   size_t queue_size = 2;
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_, queue_size, true);
+  master->onboard_agv(manufacturer_, serial_number_, queue_size, true);
 
-  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Fill the queue
@@ -312,9 +327,9 @@ TEST_F(MasterLogicTestFixture, AGVDropNewestPolicyWorks)
 
   // Onboard with small queue size and drop_oldest = false (drop newest)
   size_t queue_size = 2;
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_, queue_size, false);
+  master->onboard_agv(manufacturer_, serial_number_, queue_size, false);
 
-  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Fill the queue
@@ -336,9 +351,9 @@ TEST_F(MasterLogicTestFixture, OnboardingWithCustomQueueSettings)
   size_t custom_queue_size = 5;
   bool drop_oldest = false;
   master->onboard_agv(
-    interface_name_, manufacturer_, serial_number_, custom_queue_size, drop_oldest);
+    manufacturer_, serial_number_, custom_queue_size, drop_oldest);
 
-  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Queue should accept up to custom_queue_size orders
@@ -385,14 +400,14 @@ TEST_F(MasterLogicTestFixture, AGVsRemainsOnboardedAfterMasterDisconnect)
 {
   auto master = create_master();
   master->connect();
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  master->onboard_agv(manufacturer_, serial_number_);
 
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
   master->disconnect();
 
   // AGV should still be onboarded even if master is disconnected
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 }
 
 TEST_F(MasterLogicTestFixture, DestructorCompletesWithPendingMessages)
@@ -402,9 +417,9 @@ TEST_F(MasterLogicTestFixture, DestructorCompletesWithPendingMessages)
   {
     auto master = create_master();
     master->connect();
-    master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+    master->onboard_agv(manufacturer_, serial_number_);
 
-    auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+    auto agv = master->get_agv(manufacturer_, serial_number_);
     ASSERT_NE(agv, nullptr);
 
     // Queue many messages
@@ -427,9 +442,9 @@ TEST_F(MasterLogicTestFixture, OffboardWithPendingMessages)
 {
   auto master = create_master();
   master->connect();
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  master->onboard_agv(manufacturer_, serial_number_);
 
-  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
 
   // Queue some messages
@@ -440,12 +455,12 @@ TEST_F(MasterLogicTestFixture, OffboardWithPendingMessages)
 
   // Offboard should complete gracefully
   auto start = std::chrono::steady_clock::now();
-  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
+  master->offboard_agv(manufacturer_, serial_number_);
   auto elapsed = std::chrono::steady_clock::now() - start;
 
   EXPECT_LT(elapsed, std::chrono::seconds(5)) << "Offboard took too long";
 
-  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
   master->disconnect();
 }

--- a/vda5050_core/test/master/test_integration_master_mqtt.cpp
+++ b/vda5050_core/test/master/test_integration_master_mqtt.cpp
@@ -40,9 +40,9 @@ class MasterMqttTestFixture : public ::testing::Test
 protected:
   void SetUp() override
   {
-    interface_name_ = "agv";
     manufacturer_ = "TestManufacturer";
     serial_number_ = "SN001";
+    interface_name_ = "uagv";
   }
 
   void TearDown() override
@@ -100,15 +100,36 @@ TEST_F(MasterMqttTestFixture, OnboardAGVWhileConnected)
   auto master = create_master();
   master->connect();
 
-  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  master->onboard_agv(manufacturer_, serial_number_);
 
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
-  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
   EXPECT_EQ(agv->get_interface_name(), interface_name_);
+  EXPECT_EQ(agv->get_manufacturer(), manufacturer_);
+  EXPECT_EQ(agv->get_serial_number(), serial_number_);
+
+  master->disconnect();
+}
+
+TEST_F(MasterMqttTestFixture, OnboardAGVWCustomInterfaceNameWhileConnected)
+{
+  std::string custom_interface_name = "amr";
+  auto master = create_master();
+  master->connect();
+
+  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
+
+  master->onboard_agv(custom_interface_name, manufacturer_, serial_number_);
+
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+
+  auto agv = master->get_agv(manufacturer_, serial_number_);
+  ASSERT_NE(agv, nullptr);
+  EXPECT_EQ(agv->get_interface_name(), custom_interface_name);
   EXPECT_EQ(agv->get_manufacturer(), manufacturer_);
   EXPECT_EQ(agv->get_serial_number(), serial_number_);
 
@@ -120,11 +141,11 @@ TEST_F(MasterMqttTestFixture, OffboardAGVWhileConnected)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  master->onboard_agv(manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
-  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
-  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  master->offboard_agv(manufacturer_, serial_number_);
+  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
   master->disconnect();
 }
@@ -134,17 +155,17 @@ TEST_F(MasterMqttTestFixture, MultipleAGVsWhileConnected)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv("agv", "Mfg1", "AGV1");
-  master->onboard_agv("agv", "Mfg1", "AGV2");
-  master->onboard_agv("agv", "Mfg2", "AGV1");
+  master->onboard_agv("Mfg1", "AGV1");
+  master->onboard_agv("Mfg1", "AGV2");
+  master->onboard_agv("Mfg2", "AGV1");
 
-  EXPECT_TRUE(master->is_agv_onboarded("agv", "Mfg1", "AGV1"));
-  EXPECT_TRUE(master->is_agv_onboarded("agv", "Mfg1", "AGV2"));
-  EXPECT_TRUE(master->is_agv_onboarded("agv", "Mfg2", "AGV1"));
+  EXPECT_TRUE(master->is_agv_onboarded("Mfg1", "AGV1"));
+  EXPECT_TRUE(master->is_agv_onboarded("Mfg1", "AGV2"));
+  EXPECT_TRUE(master->is_agv_onboarded("Mfg2", "AGV1"));
 
-  auto agv1 = master->get_agv("agv", "Mfg1", "AGV1");
-  auto agv2 = master->get_agv("agv", "Mfg1", "AGV2");
-  auto agv3 = master->get_agv("agv", "Mfg2", "AGV1");
+  auto agv1 = master->get_agv("Mfg1", "AGV1");
+  auto agv2 = master->get_agv("Mfg1", "AGV2");
+  auto agv3 = master->get_agv("Mfg2", "AGV1");
 
   ASSERT_NE(agv1, nullptr);
   ASSERT_NE(agv2, nullptr);
@@ -158,17 +179,17 @@ TEST_F(MasterMqttTestFixture, AGVsPersistedAcrossReconnect)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
-  auto agv_before = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  master->onboard_agv(manufacturer_, serial_number_);
+  auto agv_before = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv_before, nullptr);
 
   master->disconnect();
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
   master->connect();
-  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
 
-  auto agv_after = master->get_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv_after = master->get_agv(manufacturer_, serial_number_);
   ASSERT_NE(agv_after, nullptr);
 
   // Same AGV instance should be preserved

--- a/vda5050_core/test/master/test_integration_master_mqtt.cpp
+++ b/vda5050_core/test/master/test_integration_master_mqtt.cpp
@@ -34,8 +34,8 @@
 #include "vda5050_core/master/standard_names.hpp"
 #include "vda5050_core/transport/mqtt_client_interface.hpp"
 
-using vda5050_core::master::VDA5050Master;
 using vda5050_core::master::DefaultInterfaceName;
+using vda5050_core::master::VDA5050Master;
 
 class MasterMqttTestFixture : public ::testing::Test
 {

--- a/vda5050_core/test/master/test_integration_master_mqtt.cpp
+++ b/vda5050_core/test/master/test_integration_master_mqtt.cpp
@@ -40,6 +40,7 @@ class MasterMqttTestFixture : public ::testing::Test
 protected:
   void SetUp() override
   {
+    interface_name_ = "agv";
     manufacturer_ = "TestManufacturer";
     serial_number_ = "SN001";
   }
@@ -58,6 +59,7 @@ protected:
     return std::make_shared<VDA5050Master>(client);
   }
 
+  std::string interface_name_;
   std::string manufacturer_;
   std::string serial_number_;
 };
@@ -98,14 +100,15 @@ TEST_F(MasterMqttTestFixture, OnboardAGVWhileConnected)
   auto master = create_master();
   master->connect();
 
-  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
-  master->onboard_agv(manufacturer_, serial_number_);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
 
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
-  auto agv = master->get_agv(manufacturer_, serial_number_);
+  auto agv = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv, nullptr);
+  EXPECT_EQ(agv->get_interface_name(), interface_name_);
   EXPECT_EQ(agv->get_manufacturer(), manufacturer_);
   EXPECT_EQ(agv->get_serial_number(), serial_number_);
 
@@ -117,11 +120,11 @@ TEST_F(MasterMqttTestFixture, OffboardAGVWhileConnected)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(manufacturer_, serial_number_);
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
-  master->offboard_agv(manufacturer_, serial_number_);
-  EXPECT_FALSE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  master->offboard_agv(interface_name_, manufacturer_, serial_number_);
+  EXPECT_FALSE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
   master->disconnect();
 }
@@ -131,17 +134,17 @@ TEST_F(MasterMqttTestFixture, MultipleAGVsWhileConnected)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv("Mfg1", "AGV1");
-  master->onboard_agv("Mfg1", "AGV2");
-  master->onboard_agv("Mfg2", "AGV1");
+  master->onboard_agv("agv", "Mfg1", "AGV1");
+  master->onboard_agv("agv", "Mfg1", "AGV2");
+  master->onboard_agv("agv", "Mfg2", "AGV1");
 
-  EXPECT_TRUE(master->is_agv_onboarded("Mfg1", "AGV1"));
-  EXPECT_TRUE(master->is_agv_onboarded("Mfg1", "AGV2"));
-  EXPECT_TRUE(master->is_agv_onboarded("Mfg2", "AGV1"));
+  EXPECT_TRUE(master->is_agv_onboarded("agv", "Mfg1", "AGV1"));
+  EXPECT_TRUE(master->is_agv_onboarded("agv", "Mfg1", "AGV2"));
+  EXPECT_TRUE(master->is_agv_onboarded("agv", "Mfg2", "AGV1"));
 
-  auto agv1 = master->get_agv("Mfg1", "AGV1");
-  auto agv2 = master->get_agv("Mfg1", "AGV2");
-  auto agv3 = master->get_agv("Mfg2", "AGV1");
+  auto agv1 = master->get_agv("agv", "Mfg1", "AGV1");
+  auto agv2 = master->get_agv("agv", "Mfg1", "AGV2");
+  auto agv3 = master->get_agv("agv", "Mfg2", "AGV1");
 
   ASSERT_NE(agv1, nullptr);
   ASSERT_NE(agv2, nullptr);
@@ -155,17 +158,17 @@ TEST_F(MasterMqttTestFixture, AGVsPersistedAcrossReconnect)
   auto master = create_master();
   master->connect();
 
-  master->onboard_agv(manufacturer_, serial_number_);
-  auto agv_before = master->get_agv(manufacturer_, serial_number_);
+  master->onboard_agv(interface_name_, manufacturer_, serial_number_);
+  auto agv_before = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv_before, nullptr);
 
   master->disconnect();
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
   master->connect();
-  EXPECT_TRUE(master->is_agv_onboarded(manufacturer_, serial_number_));
+  EXPECT_TRUE(master->is_agv_onboarded(interface_name_, manufacturer_, serial_number_));
 
-  auto agv_after = master->get_agv(manufacturer_, serial_number_);
+  auto agv_after = master->get_agv(interface_name_, manufacturer_, serial_number_);
   ASSERT_NE(agv_after, nullptr);
 
   // Same AGV instance should be preserved

--- a/vda5050_core/test/master/test_integration_master_mqtt.cpp
+++ b/vda5050_core/test/master/test_integration_master_mqtt.cpp
@@ -31,9 +31,11 @@
 #include <thread>
 
 #include "vda5050_core/master/master.hpp"
+#include "vda5050_core/master/standard_names.hpp"
 #include "vda5050_core/transport/mqtt_client_interface.hpp"
 
 using vda5050_core::master::VDA5050Master;
+using vda5050_core::master::DefaultInterfaceName;
 
 class MasterMqttTestFixture : public ::testing::Test
 {
@@ -42,7 +44,7 @@ protected:
   {
     manufacturer_ = "TestManufacturer";
     serial_number_ = "SN001";
-    interface_name_ = "uagv";
+    interface_name_ = DefaultInterfaceName;
   }
 
   void TearDown() override

--- a/vda5050_core/test/master/test_integration_master_mqtt.cpp
+++ b/vda5050_core/test/master/test_integration_master_mqtt.cpp
@@ -117,7 +117,7 @@ TEST_F(MasterMqttTestFixture, OnboardAGVWhileConnected)
   master->disconnect();
 }
 
-TEST_F(MasterMqttTestFixture, OnboardAGVWCustomInterfaceNameWhileConnected)
+TEST_F(MasterMqttTestFixture, OnboardAGVWithCustomInterfaceNameWhileConnected)
 {
   std::string custom_interface_name = "amr";
   auto master = create_master();

--- a/vda5050_core/test/master/test_integration_master_teardown.cpp
+++ b/vda5050_core/test/master/test_integration_master_teardown.cpp
@@ -138,6 +138,7 @@ TEST_F(MasterTeardownTest, OffboardAgvUnsubscribesAllPerAgvTopicsInterfaceName)
     master->offboard_agv("acme", "agv-001");
   }
 }
+
 TEST_F(MasterTeardownTest, MasterDestructionUnsubscribesAllPerAgvTopics)
 {
   EXPECT_CALL(

--- a/vda5050_core/test/master/test_integration_master_teardown.cpp
+++ b/vda5050_core/test/master/test_integration_master_teardown.cpp
@@ -72,41 +72,90 @@ TEST_F(MasterTeardownTest, OffboardAgvUnsubscribesAllPerAgvTopics)
 {
   auto master = std::make_shared<VDA5050Master>(mock_);
   master->connect();
-  master->onboard_agv("agv", "acme", "agv-001");
+  master->onboard_agv("acme", "agv-001");
 
   EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/connection")))
+    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/connection")))
     .Times(1);
-  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/state")))
-    .Times(1);
-  EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/factsheet")))
+  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/state")))
     .Times(1);
   EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/visualization")))
+    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/factsheet")))
+    .Times(1);
+  EXPECT_CALL(
+    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/visualization")))
     .Times(1);
 
-  master->offboard_agv("agv", "acme", "agv-001");
+  master->offboard_agv("acme", "agv-001");
 }
 
+TEST_F(MasterTeardownTest, OffboardAgvUnsubscribesAllPerAgvTopicsInterfaceName)
+{
+  auto master = std::make_shared<VDA5050Master>(mock_);
+  master->connect();
+  {  // default interface name
+    master->onboard_agv("acme", "agv-001");
+
+    EXPECT_CALL(
+      *mock_,
+      unsubscribe(::testing::HasSubstr("uagv/v2/acme/agv-001/connection")))
+      .Times(1);
+    EXPECT_CALL(
+      *mock_, unsubscribe(::testing::HasSubstr("uagv/v2/acme/agv-001/state")))
+      .Times(1);
+    EXPECT_CALL(
+      *mock_,
+      unsubscribe(::testing::HasSubstr("uagv/v2/acme/agv-001/factsheet")))
+      .Times(1);
+    EXPECT_CALL(
+      *mock_,
+      unsubscribe(::testing::HasSubstr("uagv/v2/acme/agv-001/visualization")))
+      .Times(1);
+
+    master->offboard_agv("acme", "agv-001");
+  }
+
+  {  // custom interface name
+    std::string custom_interface_name = "amr";
+    master->onboard_agv(custom_interface_name, "acme", "agv-001");
+
+    EXPECT_CALL(
+      *mock_,
+      unsubscribe(::testing::HasSubstr("amr/v2/acme/agv-001/connection")))
+      .Times(1);
+    EXPECT_CALL(
+      *mock_, unsubscribe(::testing::HasSubstr("amr/v2/acme/agv-001/state")))
+      .Times(1);
+    EXPECT_CALL(
+      *mock_,
+      unsubscribe(::testing::HasSubstr("amr/v2/acme/agv-001/factsheet")))
+      .Times(1);
+    EXPECT_CALL(
+      *mock_,
+      unsubscribe(::testing::HasSubstr("amr/v2/acme/agv-001/visualization")))
+      .Times(1);
+
+    master->offboard_agv("acme", "agv-001");
+  }
+}
 TEST_F(MasterTeardownTest, MasterDestructionUnsubscribesAllPerAgvTopics)
 {
   EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/connection")))
+    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/connection")))
     .Times(1);
-  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/state")))
-    .Times(1);
-  EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/factsheet")))
+  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/state")))
     .Times(1);
   EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/visualization")))
+    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/factsheet")))
+    .Times(1);
+  EXPECT_CALL(
+    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/visualization")))
     .Times(1);
 
   {
     auto master = std::make_shared<VDA5050Master>(mock_);
     master->connect();
-    master->onboard_agv("agv", "acme", "agv-001");
+    master->onboard_agv("acme", "agv-001");
     // master leaves scope → AGV destructor runs → unsubscribe chain
   }
 }
@@ -115,12 +164,12 @@ TEST_F(MasterTeardownTest, MultipleAgvsAllUnsubscribeOnOffboard)
 {
   auto master = std::make_shared<VDA5050Master>(mock_);
   master->connect();
-  master->onboard_agv("agv", "mfg1", "001");
-  master->onboard_agv("agv", "mfg2", "002");
+  master->onboard_agv("mfg1", "001");
+  master->onboard_agv("mfg2", "002");
 
-  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("agv/v2/mfg1/001/"))).Times(4);
-  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("agv/v2/mfg2/002/"))).Times(4);
+  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("mfg1/001/"))).Times(4);
+  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("mfg2/002/"))).Times(4);
 
-  master->offboard_agv("agv", "mfg1", "001");
-  master->offboard_agv("agv", "mfg2", "002");
+  master->offboard_agv("mfg1", "001");
+  master->offboard_agv("mfg2", "002");
 }

--- a/vda5050_core/test/master/test_integration_master_teardown.cpp
+++ b/vda5050_core/test/master/test_integration_master_teardown.cpp
@@ -72,41 +72,41 @@ TEST_F(MasterTeardownTest, OffboardAgvUnsubscribesAllPerAgvTopics)
 {
   auto master = std::make_shared<VDA5050Master>(mock_);
   master->connect();
-  master->onboard_agv("acme", "agv-001");
+  master->onboard_agv("agv", "acme", "agv-001");
 
   EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/connection")))
+    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/connection")))
     .Times(1);
-  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/state")))
-    .Times(1);
-  EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/factsheet")))
+  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/state")))
     .Times(1);
   EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/visualization")))
+    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/factsheet")))
+    .Times(1);
+  EXPECT_CALL(
+    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/visualization")))
     .Times(1);
 
-  master->offboard_agv("acme", "agv-001");
+  master->offboard_agv("agv", "acme", "agv-001");
 }
 
 TEST_F(MasterTeardownTest, MasterDestructionUnsubscribesAllPerAgvTopics)
 {
   EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/connection")))
+    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/connection")))
     .Times(1);
-  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/state")))
-    .Times(1);
-  EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/factsheet")))
+  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/state")))
     .Times(1);
   EXPECT_CALL(
-    *mock_, unsubscribe(::testing::HasSubstr("acme/agv-001/visualization")))
+    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/factsheet")))
+    .Times(1);
+  EXPECT_CALL(
+    *mock_, unsubscribe(::testing::HasSubstr("agv/v2/acme/agv-001/visualization")))
     .Times(1);
 
   {
     auto master = std::make_shared<VDA5050Master>(mock_);
     master->connect();
-    master->onboard_agv("acme", "agv-001");
+    master->onboard_agv("agv", "acme", "agv-001");
     // master leaves scope → AGV destructor runs → unsubscribe chain
   }
 }
@@ -115,12 +115,12 @@ TEST_F(MasterTeardownTest, MultipleAgvsAllUnsubscribeOnOffboard)
 {
   auto master = std::make_shared<VDA5050Master>(mock_);
   master->connect();
-  master->onboard_agv("mfg1", "001");
-  master->onboard_agv("mfg2", "002");
+  master->onboard_agv("agv", "mfg1", "001");
+  master->onboard_agv("agv", "mfg2", "002");
 
-  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("mfg1/001/"))).Times(4);
-  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("mfg2/002/"))).Times(4);
+  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("agv/v2/mfg1/001/"))).Times(4);
+  EXPECT_CALL(*mock_, unsubscribe(::testing::HasSubstr("agv/v2/mfg2/002/"))).Times(4);
 
-  master->offboard_agv("mfg1", "001");
-  master->offboard_agv("mfg2", "002");
+  master->offboard_agv("agv", "mfg1", "001");
+  master->offboard_agv("agv", "mfg2", "002");
 }

--- a/vda5050_core/test/master/test_unit_agv.cpp
+++ b/vda5050_core/test/master/test_unit_agv.cpp
@@ -32,7 +32,7 @@ class AGVTestFixture : public ::testing::Test
 protected:
   void SetUp() override
   {
-    interface_name_ = "uagv";
+    interface_name_ = DefaultInterfaceName;
     manufacturer_ = "TestManufacturer";
     serial_number_ = "SN001";
     agv_id_ = manufacturer_ + "/" + serial_number_;

--- a/vda5050_core/test/master/test_unit_agv.cpp
+++ b/vda5050_core/test/master/test_unit_agv.cpp
@@ -32,9 +32,10 @@ class AGVTestFixture : public ::testing::Test
 protected:
   void SetUp() override
   {
+    interface_name_ = "agv";
     manufacturer_ = "TestManufacturer";
     serial_number_ = "SN001";
-    agv_id_ = manufacturer_ + "/" + serial_number_;
+    agv_id_ = interface_name_ + "/" + manufacturer_ + "/" + serial_number_;
   }
 
   void TearDown() override
@@ -45,7 +46,7 @@ protected:
   std::unique_ptr<AGV>& create_agv()
   {
     // Use nullptr for ProtocolAdapter in unit tests
-    agv_ = std::make_unique<AGV>(nullptr, manufacturer_, serial_number_);
+    agv_ = std::make_unique<AGV>(nullptr, interface_name_, manufacturer_, serial_number_);
     return agv_;
   }
 
@@ -54,7 +55,7 @@ protected:
   {
     // Use nullptr for ProtocolAdapter in unit tests
     agv_ = std::make_unique<AGV>(
-      nullptr, manufacturer_, serial_number_, 10, true,
+      nullptr, interface_name_, manufacturer_, serial_number_, 10, true,
       state_heartbeat_interval);
     return agv_;
   }
@@ -117,6 +118,7 @@ protected:
   }
 
   std::unique_ptr<AGV> agv_;
+  std::string interface_name_;
   std::string manufacturer_;
   std::string serial_number_;
   std::string agv_id_;
@@ -413,6 +415,7 @@ TEST_F(AGVTestFixture, RestartPreservesIdentity)
 
   agv->restart();
 
+  EXPECT_EQ(agv->get_interface_name(), interface_name_);
   EXPECT_EQ(agv->get_manufacturer(), manufacturer_);
   EXPECT_EQ(agv->get_serial_number(), serial_number_);
   EXPECT_EQ(agv->get_agv_id(), agv_id_);

--- a/vda5050_core/test/master/test_unit_agv.cpp
+++ b/vda5050_core/test/master/test_unit_agv.cpp
@@ -32,10 +32,10 @@ class AGVTestFixture : public ::testing::Test
 protected:
   void SetUp() override
   {
-    interface_name_ = "agv";
+    interface_name_ = "uagv";
     manufacturer_ = "TestManufacturer";
     serial_number_ = "SN001";
-    agv_id_ = interface_name_ + "/" + manufacturer_ + "/" + serial_number_;
+    agv_id_ = manufacturer_ + "/" + serial_number_;
   }
 
   void TearDown() override
@@ -46,7 +46,8 @@ protected:
   std::unique_ptr<AGV>& create_agv()
   {
     // Use nullptr for ProtocolAdapter in unit tests
-    agv_ = std::make_unique<AGV>(nullptr, interface_name_, manufacturer_, serial_number_);
+    agv_ = std::make_unique<AGV>(
+      nullptr, interface_name_, manufacturer_, serial_number_);
     return agv_;
   }
 


### PR DESCRIPTION
Currently the `InterfaceName` is hard set to [`rmf2` in master](https://github.com/ros-industrial/vda5050_core/blob/develop/vda5050_core/include/vda5050_core/master/standard_names.hpp#L40). However, this should either be `uagv`, which is the only example interface name [mentioned in the VDA5050 docs](https://github.com/VDA5050/VDA5050/blob/release/2.0.0/VDA5050_EN_V1.md#-63-mqtt-topic-levels) or configurable from the master.

This Pull Request implements the latter. 