### PR TITLE
feat(mqtt): bound MQTT operations with a timeout and harden pub/sub

### DIFF
--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -230,11 +230,18 @@ if(BUILD_EXAMPLES)
     ${PROJECT_NAME}::logger
   )
 
+  add_executable(mqtt_stay_connected examples/mqtt_stay_connected.cpp)
+  target_link_libraries(mqtt_stay_connected PUBLIC
+    ${PROJECT_NAME}::transport
+    ${PROJECT_NAME}::logger
+  )
+
   install(TARGETS
       custom_base
       provider_example
       engine_example
       handler_integration
+      mqtt_stay_connected
     DESTINATION lib/${PROJECT_NAME}
   )
 endif()

--- a/vda5050_core/examples/mqtt_stay_connected.cpp
+++ b/vda5050_core/examples/mqtt_stay_connected.cpp
@@ -25,6 +25,7 @@
 //
 // Example:
 //   mqtt_stay_connected tcp://localhost:1883 stay_connected 3000
+//   ros2 run vda5050_core mqtt_stay_connected tcp://localhost:1883 stay_connected 3000
 
 #include <atomic>
 #include <chrono>

--- a/vda5050_core/examples/mqtt_stay_connected.cpp
+++ b/vda5050_core/examples/mqtt_stay_connected.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Client that connects to an MQTT broker and holds the connection open
+// indefinitely, until the user presses Ctrl-C (SIGINT). On signal it
+// disconnects cleanly and exits.
+//
+// Usage:
+//   mqtt_stay_connected [broker_address] [client_id] [timeout_ms]
+//
+// Example:
+//   mqtt_stay_connected tcp://localhost:1883 stay_connected 3000
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+#include <vda5050_core/logger/logger.hpp>
+#include <vda5050_core/transport/paho_mqtt_client.hpp>
+
+using PahoMqttClient = vda5050_core::transport::PahoMqttClient;
+
+namespace {
+
+std::atomic<bool> g_running{true};
+
+void handle_signal(int /*signum*/)
+{
+  g_running = false;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+  const std::string broker =
+    (argc > 1) ? argv[1] : "tcp://localhost:1883";
+  const std::string client_id =
+    (argc > 2) ? argv[2] : "stay_connected";
+  const auto timeout_ms =
+    (argc > 3) ? std::chrono::milliseconds(std::atol(argv[3]))
+               : std::chrono::milliseconds(3000);
+
+  std::signal(SIGINT, handle_signal);
+  std::signal(SIGTERM, handle_signal);
+
+  VDA5050_INFO(
+    "Creating client id=[{}] broker=[{}] operation_timeout={} ms", client_id,
+    broker, timeout_ms.count());
+
+  auto client = PahoMqttClient::make_unique(broker, client_id);
+  client->set_operation_timeout(timeout_ms);
+
+  client->connect();
+  VDA5050_INFO("connected() == {}", client->connected());
+
+  if (client->connected())
+  {
+    const std::string topic = "vda5050/stay_connected";
+    client->subscribe(
+      topic,
+      [](const std::string& t, const std::string& payload) {
+        VDA5050_INFO("message on [{}]: {}", t, payload);
+      },
+      1);
+    VDA5050_INFO("subscribed to [{}]", topic);
+  }
+
+  VDA5050_INFO("Holding connection open. Press Ctrl-C to disconnect and exit.");
+  while (g_running)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+
+  VDA5050_INFO("Signal received, disconnecting ...");
+  client->disconnect();
+  VDA5050_INFO("connected() == {} (after disconnect)", client->connected());
+  VDA5050_INFO("done");
+  return 0;
+}

--- a/vda5050_core/examples/mqtt_stay_connected.cpp
+++ b/vda5050_core/examples/mqtt_stay_connected.cpp
@@ -53,13 +53,11 @@ void handle_signal(int signum)
 
 int main(int argc, char** argv)
 {
-  const std::string broker =
-    (argc > 1) ? argv[1] : "tcp://localhost:1883";
-  const std::string client_id =
-    (argc > 2) ? argv[2] : "stay_connected";
-  const auto timeout_ms =
-    (argc > 3) ? std::chrono::milliseconds(std::atol(argv[3]))
-               : std::chrono::milliseconds(3000);
+  const std::string broker = (argc > 1) ? argv[1] : "tcp://localhost:1883";
+  const std::string client_id = (argc > 2) ? argv[2] : "stay_connected";
+  const auto timeout_ms = (argc > 3)
+                            ? std::chrono::milliseconds(std::atol(argv[3]))
+                            : std::chrono::milliseconds(3000);
 
   std::signal(SIGINT, handle_signal);
   std::signal(SIGTERM, handle_signal);

--- a/vda5050_core/examples/mqtt_stay_connected.cpp
+++ b/vda5050_core/examples/mqtt_stay_connected.cpp
@@ -43,8 +43,9 @@ namespace {
 
 std::atomic<bool> g_running{true};
 
-void handle_signal(int /*signum*/)
+void handle_signal(int signum)
 {
+  (void)signum;
   g_running = false;
 }
 

--- a/vda5050_core/include/vda5050_core/transport/paho_mqtt_client.hpp
+++ b/vda5050_core/include/vda5050_core/transport/paho_mqtt_client.hpp
@@ -22,9 +22,11 @@
 #include <mqtt/async_client.h>
 #include <mqtt/callback.h>
 #include <mqtt/connect_options.h>
+#include <mqtt/disconnect_options.h>
 #include <mqtt/iaction_listener.h>
 #include <mqtt/will_options.h>
 
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -139,6 +141,9 @@ public:
   /// \return Mutable reference to Paho configuration options
   mqtt::connect_options& connect_options();
 
+  /// \brief Set the maximum time to wait for MQTT operations to complete
+  void set_operation_timeout(std::chrono::milliseconds timeout);
+
   friend class MqttCallback;
 
 private:
@@ -148,6 +153,13 @@ private:
   /// \param client_id ID of the MQTT client
   PahoMqttClient(
     const std::string& broker_address, const std::string& client_id);
+
+  /// Safer than token->wait(): bounds the block so a slow/unreachable broker
+  /// cannot hang the process indefinitely.
+  bool wait_for_token(mqtt::token_ptr token, const char* operation);
+
+  static constexpr std::chrono::milliseconds kDefaultOperationTimeout{
+    std::chrono::seconds(3)};
 
   /// \brief Unique pointer to Paho async client
   std::unique_ptr<mqtt::async_client> client_;
@@ -166,6 +178,9 @@ private:
 
   /// \brief MQTT connection options
   mqtt::connect_options conn_options_;
+
+  /// \brief Maximum time to wait for connect/publish/subscribe/disconnect
+  std::chrono::milliseconds operation_timeout_{kDefaultOperationTimeout};
 };
 
 }  // namespace transport

--- a/vda5050_core/src/transport/paho_mqtt_client.cpp
+++ b/vda5050_core/src/transport/paho_mqtt_client.cpp
@@ -127,7 +127,8 @@ void PahoMqttClient::set_operation_timeout(std::chrono::milliseconds timeout)
 }
 
 //=============================================================================
-bool PahoMqttClient::wait_for_token(mqtt::token_ptr token, const char* operation)
+bool PahoMqttClient::wait_for_token(
+  mqtt::token_ptr token, const char* operation)
 {
   if (!token) return true;
 
@@ -171,8 +172,7 @@ void PahoMqttClient::disconnect()
     const auto timeout_ms = static_cast<int>(operation_timeout_.count());
     mqtt::disconnect_options options(timeout_ms);
 
-    if (
-      wait_for_token(client_->disconnect(options), "disconnect"))
+    if (wait_for_token(client_->disconnect(options), "disconnect"))
     {
       VDA5050_INFO_STREAM(
         "MQTT client disconnected: " << client_->get_client_id());

--- a/vda5050_core/src/transport/paho_mqtt_client.cpp
+++ b/vda5050_core/src/transport/paho_mqtt_client.cpp
@@ -131,12 +131,11 @@ bool PahoMqttClient::wait_for_token(mqtt::token_ptr token, const char* operation
 {
   if (!token) return true;
 
-  const auto timeout_ms = static_cast<long>(operation_timeout_.count());
-  if (token->wait_for(timeout_ms)) return true;
+  if (token->wait_for(operation_timeout_)) return true;
 
   VDA5050_WARN(
-    "MQTT {} timed out after {} ms for client [{}]", operation, timeout_ms,
-    client_->get_client_id());
+    "MQTT {} timed out after {} ms for client [{}]", operation,
+    operation_timeout_.count(), client_->get_client_id());
   return false;
 }
 

--- a/vda5050_core/src/transport/paho_mqtt_client.cpp
+++ b/vda5050_core/src/transport/paho_mqtt_client.cpp
@@ -80,12 +80,17 @@ void MqttCallback::connection_lost(const std::string& /*cause*/)
 //=============================================================================
 void MqttCallback::message_arrived(mqtt::const_message_ptr msg)
 {
-  std::lock_guard<std::mutex> lock(parent_.handler_mutex_);
-  auto it = parent_.handlers_.find(msg->get_topic());
-  if (it != parent_.handlers_.end())
+  // Copy the handler out and release the lock before invoking it, so a handler
+  // that calls back into subscribe()/unsubscribe() cannot self-deadlock on
+  // handler_mutex_.
+  MqttClientInterface::MessageHandler handler;
   {
-    it->second(msg->get_topic(), msg->get_payload());
+    std::lock_guard<std::mutex> lock(parent_.handler_mutex_);
+    auto it = parent_.handlers_.find(msg->get_topic());
+    if (it == parent_.handlers_.end()) return;
+    handler = it->second;
   }
+  handler(msg->get_topic(), msg->get_payload());
 }
 
 //=============================================================================
@@ -159,7 +164,11 @@ void PahoMqttClient::disconnect()
 
   try
   {
-    conn_options_.set_automatic_reconnect(false);
+    // Note: do not mutate conn_options_ here. Disabling automatic reconnect on
+    // the persistent member has no effect on the already-established session
+    // (Paho captured the options at connect time and stops reconnecting on an
+    // explicit disconnect anyway), but it would corrupt the options reused by
+    // the next connect(), permanently disabling reconnection.
     const auto timeout_ms = static_cast<int>(operation_timeout_.count());
     mqtt::disconnect_options options(timeout_ms);
 
@@ -206,14 +215,27 @@ void PahoMqttClient::publish(
 void PahoMqttClient::subscribe(
   const std::string& topic, MessageHandler handler, int qos)
 {
-  try
+  // Register the handler before subscribing so a message arriving between the
+  // broker's SUBACK and handler registration is not dropped.
   {
-    wait_for_token(client_->subscribe(topic, qos), "subscribe");
     std::lock_guard<std::mutex> lock(handler_mutex_);
     handlers_[topic] = handler;
   }
+
+  try
+  {
+    if (!wait_for_token(client_->subscribe(topic, qos), "subscribe"))
+    {
+      // Subscription did not complete; roll back so local state stays
+      // consistent with the broker.
+      std::lock_guard<std::mutex> lock(handler_mutex_);
+      handlers_.erase(topic);
+    }
+  }
   catch (const mqtt::exception& e)
   {
+    std::lock_guard<std::mutex> lock(handler_mutex_);
+    handlers_.erase(topic);
     VDA5050_ERROR_STREAM("MQTT subscription failed: " << e.get_message());
   }
 }
@@ -223,9 +245,14 @@ void PahoMqttClient::unsubscribe(const std::string& topic)
 {
   try
   {
-    wait_for_token(client_->unsubscribe(topic), "unsubscribe");
-    std::lock_guard<std::mutex> lock(handler_mutex_);
-    handlers_.erase(topic);
+    // Only drop the local handler once the broker confirms the unsubscribe;
+    // otherwise the broker keeps delivering and we would have no handler for
+    // incoming messages.
+    if (wait_for_token(client_->unsubscribe(topic), "unsubscribe"))
+    {
+      std::lock_guard<std::mutex> lock(handler_mutex_);
+      handlers_.erase(topic);
+    }
   }
   catch (const mqtt::exception& e)
   {

--- a/vda5050_core/src/transport/paho_mqtt_client.cpp
+++ b/vda5050_core/src/transport/paho_mqtt_client.cpp
@@ -116,13 +116,34 @@ std::unique_ptr<PahoMqttClient> PahoMqttClient::make_unique(
 PahoMqttClient::~PahoMqttClient() = default;
 
 //=============================================================================
+void PahoMqttClient::set_operation_timeout(std::chrono::milliseconds timeout)
+{
+  operation_timeout_ = timeout;
+}
+
+//=============================================================================
+bool PahoMqttClient::wait_for_token(mqtt::token_ptr token, const char* operation)
+{
+  if (!token) return true;
+
+  const auto timeout_ms = static_cast<long>(operation_timeout_.count());
+  if (token->wait_for(timeout_ms)) return true;
+
+  VDA5050_WARN(
+    "MQTT {} timed out after {} ms for client [{}]", operation, timeout_ms,
+    client_->get_client_id());
+  return false;
+}
+
+//=============================================================================
 void PahoMqttClient::connect()
 {
   if (client_->is_connected()) return;
 
   try
   {
-    client_->connect(conn_options_, nullptr, action_listener_)->wait();
+    wait_for_token(
+      client_->connect(conn_options_, nullptr, action_listener_), "connect");
   }
   catch (const mqtt::exception& e)
   {
@@ -134,18 +155,24 @@ void PahoMqttClient::connect()
 //=============================================================================
 void PahoMqttClient::disconnect()
 {
-  if (client_->is_connected())
+  if (!client_->is_connected()) return;
+
+  try
   {
-    try
+    conn_options_.set_automatic_reconnect(false);
+    const auto timeout_ms = static_cast<int>(operation_timeout_.count());
+    mqtt::disconnect_options options(timeout_ms);
+
+    if (
+      wait_for_token(client_->disconnect(options), "disconnect"))
     {
-      client_->disconnect()->wait();
       VDA5050_INFO_STREAM(
         "MQTT client disconnected: " << client_->get_client_id());
     }
-    catch (const mqtt::exception& e)
-    {
-      VDA5050_ERROR_STREAM("MQTT disconnection failed: " << e.get_message());
-    }
+  }
+  catch (const mqtt::exception& e)
+  {
+    VDA5050_ERROR_STREAM("MQTT disconnection failed: " << e.get_message());
   }
 }
 
@@ -167,7 +194,7 @@ void PahoMqttClient::publish(
     msg->set_qos(qos);
     msg->set_retained(retain);
 
-    client_->publish(msg)->wait();
+    wait_for_token(client_->publish(msg), "publish");
   }
   catch (const mqtt::exception& e)
   {
@@ -181,7 +208,7 @@ void PahoMqttClient::subscribe(
 {
   try
   {
-    client_->subscribe(topic, qos)->wait();
+    wait_for_token(client_->subscribe(topic, qos), "subscribe");
     std::lock_guard<std::mutex> lock(handler_mutex_);
     handlers_[topic] = handler;
   }
@@ -196,7 +223,7 @@ void PahoMqttClient::unsubscribe(const std::string& topic)
 {
   try
   {
-    client_->unsubscribe(topic)->wait();
+    wait_for_token(client_->unsubscribe(topic), "unsubscribe");
     std::lock_guard<std::mutex> lock(handler_mutex_);
     handlers_.erase(topic);
   }

--- a/vda5050_core/test/transport/test_integration_paho_mqtt_client.cpp
+++ b/vda5050_core/test/transport/test_integration_paho_mqtt_client.cpp
@@ -139,3 +139,23 @@ TEST(PahoMqttClientTest, FailedConnectionRemainsDisconnected)
   // connected() should return false after failed connection
   ASSERT_FALSE(client->connected());
 }
+
+TEST(PahoMqttClientTest, DisconnectReturnsPromptlyWithoutConnection)
+{
+  const std::string invalid_broker = "tcp://127.0.0.1:19999";
+
+  auto client = vda5050_core::transport::PahoMqttClient::make_unique(
+    invalid_broker, "prompt_disconnect_client");
+  client->set_operation_timeout(std::chrono::milliseconds(500));
+
+  const auto start = std::chrono::steady_clock::now();
+  ASSERT_NO_THROW(client->connect());
+  ASSERT_FALSE(client->connected());
+  ASSERT_NO_THROW(client->disconnect());
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_LT(
+    std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(),
+    2000)
+    << "connect/disconnect to unreachable broker should be bounded by timeout";
+}


### PR DESCRIPTION
## Summary

Bounds all blocking MQTT operations with a configurable timeout so a slow or unreachable broker can no longer hang the process, and hardens `PahoMqttClient`'s subscribe/unsubscribe and handler dispatch. Adds an example client and an integration test covering the disconnect path.

The changes are confined to the transport layer (`PahoMqttClient`); the public `MqttClientInterface` is unchanged, so existing `agv` / `master` callers are unaffected.

## Why?
Before client using this mqtt wouldn't be able to `KeyboardInterupt` and need to SIGKILL. This is cause problem when not handle properly.

## What's Included

### Operation Timeout (`transport/paho_mqtt_client`)

- Replaces unbounded `token->wait()` calls with `wait_for_token()`, which blocks for at most `operation_timeout_` (default 3s) across connect, disconnect, publish, subscribe, and unsubscribe.
- Adds `set_operation_timeout()` to configure the bound at runtime.
- `disconnect()` returns promptly: it short-circuits when not connected and passes the timeout through to Paho's `disconnect_options`.

### Subscribe / Unsubscribe & Dispatch Hardening (`transport/paho_mqtt_client`)

- `message_arrived` copies the handler out and releases `handler_mutex_` before invoking it, so a handler that calls back into `subscribe()` / `unsubscribe()` cannot self-deadlock.
- `subscribe()` registers the handler *before* the broker SUBACK and rolls back on failure, so messages arriving between SUBACK and registration are not dropped.
- `unsubscribe()` drops the local handler only once the broker confirms, keeping local state consistent with the broker.
- `disconnect()` no longer mutates `conn_options_`, so reconnect options reused by the next `connect()` are not corrupted.

### Example Client (`examples/mqtt_stay_connected`)

- Connects, subscribes, and holds the connection open until `SIGINT` / `SIGTERM`, then disconnects cleanly — for manually verifying connect/disconnect behaviour against a live broker.

### Tests (`test/transport/test_integration_paho_mqtt_client`)

- Asserts connect/disconnect to an unreachable broker completes within the configured timeout rather than hanging.
