### PR TITLE
feat(client): add order validator and acceptance strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ compile_commands.json
 .cache/
 build/
 install/
+log/
+out/
 tags/

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -296,6 +296,8 @@ if(BUILD_TESTING)
     test/client/test_order_types.cpp
     test/client/test_order_execution_resource.cpp
     test/client/test_agv_context.cpp
+    test/client/test_order_validator.cpp
+    test/client/test_order_acceptance.cpp
   )
 
   target_link_libraries(test_client

--- a/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
@@ -47,8 +47,7 @@ class OrderAcceptance : public execution::StrategyInterface
 public:
   OrderAcceptance();
 
-  /// \brief Construct with a pre-configured validator (e.g. with real
-  /// reachability/capability hooks injected by the robot config layer).
+  /// \brief Construct with a pre-configured validator
   explicit OrderAcceptance(OrderValidator validator)
   : validator_(std::move(validator))
   {

--- a/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
@@ -56,9 +56,6 @@ public:
 private:
   OrderValidator validator_;
 
-  // Last (orderId, orderUpdateId) processed. The inbound OrderUpdate stays
-  // cached and step() runs every handler tick, so this lets an unchanged order
-  // be processed once instead of re-validated (and re-logged) on every tick.
   std::string last_order_id_;
   uint32_t last_order_update_id_ = 0;
 };

--- a/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
@@ -22,7 +22,6 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <utility>
 
 #include "vda5050_core/client/strategies/order_validator.hpp"
 #include "vda5050_core/execution/context_interface.hpp"
@@ -48,10 +47,7 @@ public:
   OrderAcceptance();
 
   /// \brief Construct with a pre-configured validator
-  explicit OrderAcceptance(OrderValidator validator)
-  : validator_(std::move(validator))
-  {
-  }
+  explicit OrderAcceptance(OrderValidator validator);
 
   void init(std::shared_ptr<execution::ContextInterface> context) override;
 

--- a/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
@@ -19,7 +19,9 @@
 #ifndef VDA5050_CORE__CLIENT__STRATEGIES__ORDER_ACCEPTANCE_HPP_
 #define VDA5050_CORE__CLIENT__STRATEGIES__ORDER_ACCEPTANCE_HPP_
 
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "vda5050_core/client/strategies/order_validator.hpp"
@@ -57,6 +59,12 @@ public:
 
 private:
   OrderValidator validator_;
+
+  // Last (orderId, orderUpdateId) processed. The inbound OrderUpdate stays
+  // cached and step() runs every handler tick, so this lets an unchanged order
+  // be processed once instead of re-validated (and re-logged) on every tick.
+  std::string last_order_id_;
+  uint32_t last_order_update_id_ = 0;
 };
 
 }  // namespace client

--- a/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__CLIENT__STRATEGIES__ORDER_ACCEPTANCE_HPP_
+#define VDA5050_CORE__CLIENT__STRATEGIES__ORDER_ACCEPTANCE_HPP_
+
+#include <memory>
+#include <utility>
+
+#include "vda5050_core/client/strategies/order_validator.hpp"
+#include "vda5050_core/execution/context_interface.hpp"
+#include "vda5050_core/execution/strategy_interface.hpp"
+
+namespace vda5050_core {
+
+namespace client {
+
+/// \brief Strategy that runs the VDA5050 order-acceptance flow.
+///
+/// On each step it reads the latest inbound `OrderUpdate` from the context,
+/// runs the `OrderValidator` decision, and acts on the outcome against the
+/// `OrderExecutionResource`:
+///   - Accepted -> populate (new) or append (update) the execution state and
+///                 mark the vehicle as executing.
+///   - Rejected -> record the VDA5050 errors (kept until a new order is taken).
+///   - Ignored  -> no-op (duplicate resend).
+///
+/// The validator owns the decision; this strategy owns the side effects, so the
+/// pure decision logic stays independently testable.
+class OrderAcceptance : public execution::StrategyInterface
+{
+public:
+  OrderAcceptance();
+
+  /// \brief Construct with a pre-configured validator (e.g. with real
+  /// reachability/capability hooks injected by the robot config layer).
+  explicit OrderAcceptance(OrderValidator validator)
+  : validator_(std::move(validator))
+  {
+  }
+
+  void init(std::shared_ptr<execution::ContextInterface> context) override;
+
+  void step(std::shared_ptr<execution::ContextInterface> context) override;
+
+private:
+  OrderValidator validator_;
+};
+
+}  // namespace client
+}  // namespace vda5050_core
+
+#endif  // VDA5050_CORE__CLIENT__STRATEGIES__ORDER_ACCEPTANCE_HPP_

--- a/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_acceptance.hpp
@@ -33,15 +33,13 @@ namespace client {
 /// \brief Strategy that runs the VDA5050 order-acceptance flow.
 ///
 /// On each step it reads the latest inbound `OrderUpdate` from the context,
-/// runs the `OrderValidator` decision, and acts on the outcome against the
-/// `OrderExecutionResource`:
-///   - Accepted -> populate (new) or append (update) the execution state and
-///                 mark the vehicle as executing.
-///   - Rejected -> record the VDA5050 errors (kept until a new order is taken).
-///   - Ignored  -> no-op (duplicate resend).
+/// runs the `OrderValidator` decision, and applies the corresponding side effects:
+///   - Accepted -> applies the order to the execution state.
+///   - Rejected -> records the validation errors.
+///   - Ignored  -> leaves the current execution state unchanged.
 ///
-/// The validator owns the decision; this strategy owns the side effects, so the
-/// pure decision logic stays independently testable.
+/// The validator owns the decision; this strategy owns the side effects,
+/// so the decision logic stays independently testable.
 class OrderAcceptance : public execution::StrategyInterface
 {
 public:

--- a/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
@@ -23,7 +23,7 @@
 #include <memory>
 #include <vector>
 
-#include "vda5050_core/client/updates/order_context.hpp"
+#include "vda5050_core/client/contexts/agv_context.hpp"
 #include "vda5050_core/types/error.hpp"
 #include "vda5050_core/types/order.hpp"
 
@@ -101,7 +101,7 @@ public:
   /// \return Acceptance decision; on rejection `errors` holds the VDA5050 errors.
   AcceptanceResult validate_order(
     const types::Order& incoming_order,
-    const std::shared_ptr<OrderContext>& context) const;
+    const std::shared_ptr<AGVContext>& context) const;
 
 private:
   ReachabilityCheck reachable_;

--- a/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
@@ -22,7 +22,7 @@
 #include <memory>
 #include <vector>
 
-#include "vda5050_core/client/contexts/agv_context.hpp"
+#include "vda5050_core/execution/context_interface.hpp"
 #include "vda5050_core/types/error.hpp"
 #include "vda5050_core/types/order.hpp"
 
@@ -75,13 +75,13 @@ public:
   /// \brief Evaluate an incoming order against graph validity and execution state.
   ///
   /// \param incoming_order Order payload received from master control.
-  /// \param context Thread-safe order context with execution tracking state.
+  /// \param context Execution context exposing the order-execution resource.
   /// \return Acceptance decision; on rejection `errors` holds the VDA5050 errors.
   // TODO(eileentyz): Add protocol limit validation once factsheet/config data
   // is available.
   AcceptanceResult validate_order(
     const types::Order& incoming_order,
-    const std::shared_ptr<AGVContext>& context) const;
+    const std::shared_ptr<execution::ContextInterface>& context) const;
 };
 
 }  // namespace client

--- a/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
@@ -68,16 +68,18 @@ struct AcceptanceResult
 /// before an order enters the execution plane.
 ///
 /// Structural validity reuses `order_utils::is_valid_graph`.
-/// TODO: Add position- and capability-dependent checks once AGV position and
-/// factsheet/capability data are available.
+/// TODO(eileentyz): Add position- and capability-dependent checks once AGV
+/// position and factsheet/capability data are available.
 class OrderValidator
 {
 public:
-  /// \brief Evaluate an incoming order against context state and protocol limits.
+  /// \brief Evaluate an incoming order against graph validity and execution state.
   ///
   /// \param incoming_order Order payload received from master control.
   /// \param context Thread-safe order context with execution tracking state.
   /// \return Acceptance decision; on rejection `errors` holds the VDA5050 errors.
+  // TODO(eileentyz): Add protocol limit validation once factsheet/config data
+  // is available.
   AcceptanceResult validate_order(
     const types::Order& incoming_order,
     const std::shared_ptr<AGVContext>& context) const;

--- a/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
@@ -34,32 +34,32 @@ namespace client {
 enum class AcceptanceOutcome
 {
   /// \brief Order is valid and should be applied to the execution state.
-  Accepted,
+  ACCEPTED,
   /// \brief Order is invalid; report `errors` and keep the previous order.
-  Rejected,
+  REJECTED,
   /// \brief Duplicate resend (same orderId + orderUpdateId); leave state unchanged.
-  Ignored
+  IGNORED
 };
 
 /// \brief Result of order-acceptance validation.
 struct AcceptanceResult
 {
-  AcceptanceOutcome outcome = AcceptanceOutcome::Rejected;
+  AcceptanceOutcome outcome = AcceptanceOutcome::REJECTED;
 
-  /// \brief Errors to report when `outcome == Rejected`.
+  /// \brief Errors to report when `outcome == REJECTED`.
   std::vector<types::Error> errors;
 
   bool accepted() const
   {
-    return outcome == AcceptanceOutcome::Accepted;
+    return outcome == AcceptanceOutcome::ACCEPTED;
   }
   bool rejected() const
   {
-    return outcome == AcceptanceOutcome::Rejected;
+    return outcome == AcceptanceOutcome::REJECTED;
   }
   bool ignored() const
   {
-    return outcome == AcceptanceOutcome::Ignored;
+    return outcome == AcceptanceOutcome::IGNORED;
   }
 };
 

--- a/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
@@ -37,7 +37,7 @@ enum class AcceptanceOutcome
   Accepted,
   /// \brief Order is invalid; report `errors` and keep the previous order.
   Rejected,
-  /// \brief Duplicate resend (same orderId + orderUpdateId); discard silently.
+  /// \brief Duplicate resend (same orderId + orderUpdateId); leave state unchanged.
   Ignored
 };
 
@@ -46,8 +46,7 @@ struct AcceptanceResult
 {
   AcceptanceOutcome outcome = AcceptanceOutcome::Rejected;
 
-  /// \brief VDA5050 errors to report when `outcome == Rejected`. Each carries
-  /// the error_type, errorReferences and warning level required by the spec.
+  /// \brief Errors to report when `outcome == Rejected`.
   std::vector<types::Error> errors;
 
   bool accepted() const

--- a/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
@@ -19,7 +19,6 @@
 #ifndef VDA5050_CORE__CLIENT__STRATEGIES__ORDER_VALIDATOR_HPP_
 #define VDA5050_CORE__CLIENT__STRATEGIES__ORDER_VALIDATOR_HPP_
 
-#include <functional>
 #include <memory>
 #include <vector>
 
@@ -68,32 +67,12 @@ struct AcceptanceResult
 /// \brief Gatekeeper that runs the VDA5050 order-acceptance decision flow
 /// before an order enters the execution plane.
 ///
-/// Structural validity reuses `order_utils::is_valid_graph`. Position- and
-/// capability-dependent checks (reachable start node, supported fields/actions)
-/// are injectable hooks that default to permissive, so the robot configuration
-/// layer can supply concrete checks without changing the decision flow.
+/// Structural validity reuses `order_utils::is_valid_graph`.
+/// TODO: Add position- and capability-dependent checks once AGV position and
+/// factsheet/capability data are available.
 class OrderValidator
 {
 public:
-  /// \brief Hook: can the AGV begin the order at this start node (standing on
-  /// it or within its deviation range)? Defaults to always-accept; inject a
-  /// position-aware check via set_reachability_check().
-  using ReachabilityCheck = std::function<bool(const types::Node&)>;
-
-  /// \brief Hook: returns references to any order fields/actions/maps the AGV
-  /// cannot process; an empty result means fully supported. Defaults to
-  /// accept-all; inject a factsheet-aware check via set_capability_check().
-  using CapabilityCheck =
-    std::function<std::vector<types::ErrorReference>(const types::Order&)>;
-
-  OrderValidator();
-
-  /// \brief Override the start-node reachability hook (no-op if `check` empty).
-  void set_reachability_check(ReachabilityCheck check);
-
-  /// \brief Override the capability/field-support hook (no-op if `check` empty).
-  void set_capability_check(CapabilityCheck check);
-
   /// \brief Evaluate an incoming order against context state and protocol limits.
   ///
   /// \param incoming_order Order payload received from master control.
@@ -102,10 +81,6 @@ public:
   AcceptanceResult validate_order(
     const types::Order& incoming_order,
     const std::shared_ptr<AGVContext>& context) const;
-
-private:
-  ReachabilityCheck reachable_;
-  CapabilityCheck capable_;
 };
 
 }  // namespace client

--- a/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
+++ b/vda5050_core/include/vda5050_core/client/strategies/order_validator.hpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__CLIENT__STRATEGIES__ORDER_VALIDATOR_HPP_
+#define VDA5050_CORE__CLIENT__STRATEGIES__ORDER_VALIDATOR_HPP_
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "vda5050_core/client/updates/order_context.hpp"
+#include "vda5050_core/types/error.hpp"
+#include "vda5050_core/types/order.hpp"
+
+namespace vda5050_core {
+
+namespace client {
+
+/// \brief Outcome of the VDA5050 order-acceptance decision.
+enum class AcceptanceOutcome
+{
+  /// \brief Order is valid and should be applied to the execution state.
+  Accepted,
+  /// \brief Order is invalid; report `errors` and keep the previous order.
+  Rejected,
+  /// \brief Duplicate resend (same orderId + orderUpdateId); discard silently.
+  Ignored
+};
+
+/// \brief Result of order-acceptance validation.
+struct AcceptanceResult
+{
+  AcceptanceOutcome outcome = AcceptanceOutcome::Rejected;
+
+  /// \brief VDA5050 errors to report when `outcome == Rejected`. Each carries
+  /// the error_type, errorReferences and warning level required by the spec.
+  std::vector<types::Error> errors;
+
+  bool accepted() const
+  {
+    return outcome == AcceptanceOutcome::Accepted;
+  }
+  bool rejected() const
+  {
+    return outcome == AcceptanceOutcome::Rejected;
+  }
+  bool ignored() const
+  {
+    return outcome == AcceptanceOutcome::Ignored;
+  }
+};
+
+/// \brief Gatekeeper that runs the VDA5050 order-acceptance decision flow
+/// before an order enters the execution plane.
+///
+/// Structural validity reuses `order_utils::is_valid_graph`. Position- and
+/// capability-dependent checks (reachable start node, supported fields/actions)
+/// are injectable hooks that default to permissive, so the robot configuration
+/// layer can supply concrete checks without changing the decision flow.
+class OrderValidator
+{
+public:
+  /// \brief Hook: can the AGV begin the order at this start node (standing on
+  /// it or within its deviation range)? Defaults to always-accept; inject a
+  /// position-aware check via set_reachability_check().
+  using ReachabilityCheck = std::function<bool(const types::Node&)>;
+
+  /// \brief Hook: returns references to any order fields/actions/maps the AGV
+  /// cannot process; an empty result means fully supported. Defaults to
+  /// accept-all; inject a factsheet-aware check via set_capability_check().
+  using CapabilityCheck =
+    std::function<std::vector<types::ErrorReference>(const types::Order&)>;
+
+  OrderValidator();
+
+  /// \brief Override the start-node reachability hook (no-op if `check` empty).
+  void set_reachability_check(ReachabilityCheck check);
+
+  /// \brief Override the capability/field-support hook (no-op if `check` empty).
+  void set_capability_check(CapabilityCheck check);
+
+  /// \brief Evaluate an incoming order against context state and protocol limits.
+  ///
+  /// \param incoming_order Order payload received from master control.
+  /// \param context Thread-safe order context with execution tracking state.
+  /// \return Acceptance decision; on rejection `errors` holds the VDA5050 errors.
+  AcceptanceResult validate_order(
+    const types::Order& incoming_order,
+    const std::shared_ptr<OrderContext>& context) const;
+
+private:
+  ReachabilityCheck reachable_;
+  CapabilityCheck capable_;
+};
+
+}  // namespace client
+}  // namespace vda5050_core
+
+#endif  // VDA5050_CORE__CLIENT__STRATEGIES__ORDER_VALIDATOR_HPP_

--- a/vda5050_core/include/vda5050_core/errors/error_codes.hpp
+++ b/vda5050_core/include/vda5050_core/errors/error_codes.hpp
@@ -29,7 +29,6 @@ namespace errors {
 inline const std::string GraphValidationError = "graphValidationError";
 inline const std::string OrderUpdateError = "orderUpdateError";
 inline const std::string ValidationError = "validationError";
-inline const std::string OrderError = "orderError";
 
 // Reference key string for vda5050_types::ErrorReference::key
 inline const std::string RefOrderId = "orderId";

--- a/vda5050_core/include/vda5050_core/errors/error_codes.hpp
+++ b/vda5050_core/include/vda5050_core/errors/error_codes.hpp
@@ -28,6 +28,8 @@ namespace errors {
 // Error Codes for vda5050_types::Error::error_type field
 inline const std::string GraphValidationError = "graphValidationError";
 inline const std::string OrderUpdateError = "orderUpdateError";
+inline const std::string ValidationError = "validationError";
+inline const std::string OrderError = "orderError";
 
 // Reference key string for vda5050_types::ErrorReference::key
 inline const std::string RefOrderId = "orderId";

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -95,6 +96,13 @@ void apply_new_order(types::State& state, const types::Order& order)
   state.order_id = order.order_id;
   state.order_update_id = order.order_update_id;
 
+  // A new order starts a fresh traversal, so clear any progress carried over
+  // from a previous order. Otherwise the stale last-reached node could be
+  // mistaken for this order's decision point when a later update is stitched.
+  state.last_node_id.clear();
+  state.last_node_sequence_id = 0;
+  state.new_base_request = std::nullopt;
+
   for (const auto& node : order.nodes) append_node(state, node);
   for (const auto& edge : order.edges) append_edge(state, edge);
 }
@@ -147,7 +155,8 @@ OrderAcceptance::OrderAcceptance() = default;
 void OrderAcceptance::init(
   std::shared_ptr<execution::ContextInterface> /*context*/)
 {
-  // Nothing to initialise; the validator carries its own (permissive) hooks.
+  // Nothing to initialise; the validator is stateless and reads everything it
+  // needs from the context on each step().
 }
 
 void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/client/strategies/order_acceptance.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+
+#include "vda5050_core/client/resources/order_execution.hpp"
+#include "vda5050_core/client/updates/order.hpp"
+#include "vda5050_core/client/updates/order_context.hpp"
+#include "vda5050_core/logger/logger.hpp"
+#include "vda5050_core/types/action_status.hpp"
+
+namespace vda5050_core {
+
+namespace client {
+
+namespace {
+
+types::NodeState to_node_state(const types::Node& node)
+{
+  types::NodeState state;
+  state.node_id = node.node_id;
+  state.sequence_id = node.sequence_id;
+  state.node_description = node.node_description;
+  state.node_position = node.node_position;
+  state.released = node.released;
+  return state;
+}
+
+types::EdgeState to_edge_state(const types::Edge& edge)
+{
+  types::EdgeState state;
+  state.edge_id = edge.edge_id;
+  state.sequence_id = edge.sequence_id;
+  state.edge_description = edge.edge_description;
+  state.released = edge.released;
+  state.trajectory = edge.trajectory;
+  return state;
+}
+
+types::ActionState to_action_state(const types::Action& action)
+{
+  types::ActionState state;
+  state.action_id = action.action_id;
+  state.action_type = action.action_type;
+  state.action_description = action.action_description;
+  state.action_status = types::ActionStatus::WAITING;
+  return state;
+}
+
+void append_node(types::State& state, const types::Node& node)
+{
+  state.node_states.push_back(to_node_state(node));
+  for (const auto& action : node.actions)
+  {
+    state.action_states.push_back(to_action_state(action));
+  }
+}
+
+void append_edge(types::State& state, const types::Edge& edge)
+{
+  state.edge_states.push_back(to_edge_state(edge));
+  for (const auto& action : edge.actions)
+  {
+    state.action_states.push_back(to_action_state(action));
+  }
+}
+
+// New order: reset the execution snapshot and populate it from the order.
+void apply_new_order(types::State& state, const types::Order& order)
+{
+  state.node_states.clear();
+  state.edge_states.clear();
+  state.action_states.clear();
+  state.order_id = order.order_id;
+  state.order_update_id = order.order_update_id;
+
+  for (const auto& node : order.nodes) append_node(state, node);
+  for (const auto& edge : order.edges) append_edge(state, edge);
+}
+
+// Order update: keep the running base, drop the old horizon, append new states.
+void apply_order_update(types::State& state, const types::Order& order)
+{
+  state.order_update_id = order.order_update_id;
+
+  // Drop the previous horizon (unreleased) node/edge states; the update
+  // re-supplies them. The first node of the update is the re-sent stitch node
+  // (already present in the base), so it is skipped when appending.
+  state.node_states.erase(
+    std::remove_if(
+      state.node_states.begin(), state.node_states.end(),
+      [](const types::NodeState& n) { return !n.released; }),
+    state.node_states.end());
+  state.edge_states.erase(
+    std::remove_if(
+      state.edge_states.begin(), state.edge_states.end(),
+      [](const types::EdgeState& e) { return !e.released; }),
+    state.edge_states.end());
+
+  for (size_t i = 1; i < order.nodes.size(); ++i)
+  {
+    append_node(state, order.nodes[i]);
+  }
+  for (const auto& edge : order.edges) append_edge(state, edge);
+}
+
+}  // namespace
+
+OrderAcceptance::OrderAcceptance() = default;
+
+void OrderAcceptance::init(
+  std::shared_ptr<execution::ContextInterface> /*context*/)
+{
+  // Nothing to initialise; the validator carries its own (permissive) hooks.
+}
+
+void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
+{
+  auto order_context = std::dynamic_pointer_cast<OrderContext>(context);
+  if (!order_context)
+  {
+    VDA5050_WARN_STREAM("OrderAcceptance: context is not an OrderContext");
+    return;
+  }
+
+  // The inbound order is whatever the protocol adapter (or a test) last pushed.
+  auto update = order_context->get_update<OrderUpdate>();
+  if (!update) return;  // nothing to process yet
+
+  const types::Order& order = update->order;
+  const AcceptanceResult result =
+    validator_.validate_order(order, order_context);
+
+  auto execution = order_context->get_resource<OrderExecutionResource>();
+  if (!execution) return;
+
+  std::lock_guard<std::mutex> lock(execution->mutex_);
+  switch (result.outcome)
+  {
+    case AcceptanceOutcome::Accepted: {
+      const bool is_update = (order.order_id == execution->state.order_id);
+      if (is_update)
+      {
+        apply_order_update(execution->state, order);
+      }
+      else
+      {
+        apply_new_order(execution->state, order);
+      }
+      execution->executing_order = true;
+      break;
+    }
+    case AcceptanceOutcome::Rejected: {
+      // Errors are kept in state until a new order is accepted.
+      for (const auto& error : result.errors)
+      {
+        execution->state.errors.push_back(error);
+      }
+      break;
+    }
+    case AcceptanceOutcome::Ignored:
+      break;  // duplicate resend; leave the execution state untouched
+  }
+}
+
+}  // namespace client
+}  // namespace vda5050_core

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -20,7 +20,7 @@
 
 #include <algorithm>
 #include <memory>
-#include <mutex>
+#include <utility>
 
 #include "vda5050_core/client/contexts/agv_context.hpp"
 #include "vda5050_core/client/resources/order_execution.hpp"
@@ -153,33 +153,34 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
   auto execution = order_context->get_resource<OrderExecutionResource>();
   if (!execution) return;
 
-  // All state mutation goes through update_state(), which holds the resource's
-  // internal mutex for us.
+  // State is mutated via a read-modify-write on the resource's snapshot
+  // (get_state -> mutate -> set_state). OrderAcceptance is the sole writer of
+  // order/node state, so the read-write window carries no lost-update risk.
   switch (result.outcome)
   {
     case AcceptanceOutcome::Accepted: {
-      execution->update_state([&order](types::State& state) {
-        const bool is_update = (order.order_id == state.order_id);
-        if (is_update)
-        {
-          apply_order_update(state, order);
-        }
-        else
-        {
-          apply_new_order(state, order);
-        }
-      });
+      types::State state = execution->get_state();
+      const bool is_update = (order.order_id == state.order_id);
+      if (is_update)
+      {
+        apply_order_update(state, order);
+      }
+      else
+      {
+        apply_new_order(state, order);
+      }
+      execution->set_state(std::move(state));
       execution->set_executing_order(true);
       break;
     }
     case AcceptanceOutcome::Rejected: {
       // Errors are kept in state until a new order is accepted.
-      execution->update_state([&result](types::State& state) {
-        for (const auto& error : result.errors)
-        {
-          state.errors.push_back(error);
-        }
-      });
+      types::State state = execution->get_state();
+      for (const auto& error : result.errors)
+      {
+        state.errors.push_back(error);
+      }
+      execution->set_state(std::move(state));
       break;
     }
     case AcceptanceOutcome::Ignored:

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -20,6 +20,8 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
+#include <unordered_set>
 #include <utility>
 
 #include "vda5050_core/client/contexts/agv_context.hpp"
@@ -121,6 +123,21 @@ void apply_order_update(types::State& state, const types::Order& order)
     append_node(state, order.nodes[i]);
   }
   for (const auto& edge : order.edges) append_edge(state, edge);
+
+  // Deduplicate action states after replacing the horizon. This prevents
+  // re-sent horizon actions from accumulating while preserving first-seen
+  // action status.
+  // TODO(eileentyz): reconcile action_states fully (also drop actions for
+  // horizon nodes/edges that an update removes) once node->action tracking
+  // exists.
+  std::unordered_set<std::string> seen_action_ids;
+  state.action_states.erase(
+    std::remove_if(
+      state.action_states.begin(), state.action_states.end(),
+      [&seen_action_ids](const types::ActionState& a) {
+        return !seen_action_ids.insert(a.action_id).second;
+      }),
+    state.action_states.end());
 }
 
 }  // namespace
@@ -153,13 +170,16 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
   auto execution = order_context->get_resource<OrderExecutionResource>();
   if (!execution) return;
 
-  // State is mutated via a read-modify-write on the resource's snapshot
-  // (get_state -> mutate -> set_state). OrderAcceptance is the sole writer of
-  // order/node state, so the read-write window carries no lost-update risk.
+  // NOTE: get_state()/set_state() is a non-atomic read-modify-write.
+  // This is safe while the handler runs state-writing strategies sequentially
+  // and OrderAcceptance is the only writer of this state.
   switch (result.outcome)
   {
     case AcceptanceOutcome::Accepted: {
       types::State state = execution->get_state();
+      // A successful acceptance supersedes any prior rejection, so clear stale
+      // errors before applying the new order or update.
+      state.errors.clear();
       const bool is_update = (order.order_id == state.order_id);
       if (is_update)
       {
@@ -174,12 +194,10 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
       break;
     }
     case AcceptanceOutcome::Rejected: {
-      // Errors are kept in state until a new order is accepted.
+      // Replace errors instead of appending, since step() may re-process the
+      // same cached rejected order.
       types::State state = execution->get_state();
-      for (const auto& error : result.errors)
-      {
-        state.errors.push_back(error);
-      }
+      state.errors = result.errors;
       execution->set_state(std::move(state));
       break;
     }

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -184,7 +184,7 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
   // and OrderAcceptance is the only writer of this state.
   switch (result.outcome)
   {
-    case AcceptanceOutcome::Accepted: {
+    case AcceptanceOutcome::ACCEPTED: {
       last_order_id_ = order.order_id;
       last_order_update_id_ = order.order_update_id;
       types::State state = execution->get_state();
@@ -204,7 +204,7 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
       execution->set_executing_order(true);
       break;
     }
-    case AcceptanceOutcome::Rejected: {
+    case AcceptanceOutcome::REJECTED: {
       // Replace errors instead of appending, since step() may re-process the
       // same cached rejected order.
       types::State state = execution->get_state();
@@ -212,7 +212,7 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
       execution->set_state(std::move(state));
       break;
     }
-    case AcceptanceOutcome::Ignored:
+    case AcceptanceOutcome::IGNORED:
       break;  // duplicate resend; leave the execution state untouched
   }
 }

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -85,7 +85,6 @@ void append_edge(types::State& state, const types::Edge& edge)
   }
 }
 
-// New order: reset the execution snapshot and populate it from the order.
 void apply_new_order(types::State& state, const types::Order& order)
 {
   state.node_states.clear();
@@ -105,7 +104,6 @@ void apply_new_order(types::State& state, const types::Order& order)
   for (const auto& edge : order.edges) append_edge(state, edge);
 }
 
-// Order update: keep the running base, drop the old horizon, append new states.
 void apply_order_update(types::State& state, const types::Order& order)
 {
   state.order_update_id = order.order_update_id;
@@ -184,9 +182,6 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
   auto execution = context->get_resource<OrderExecutionResource>();
   if (!execution) return;
 
-  // NOTE: get_state()/set_state() is a non-atomic read-modify-write.
-  // This is safe while the handler runs state-writing strategies sequentially
-  // and OrderAcceptance is the only writer of this state.
   switch (result.outcome)
   {
     case AcceptanceOutcome::ACCEPTED: {

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -22,9 +22,9 @@
 #include <memory>
 #include <mutex>
 
+#include "vda5050_core/client/contexts/agv_context.hpp"
 #include "vda5050_core/client/resources/order_execution.hpp"
 #include "vda5050_core/client/updates/order.hpp"
-#include "vda5050_core/client/updates/order_context.hpp"
 #include "vda5050_core/logger/logger.hpp"
 #include "vda5050_core/types/action_status.hpp"
 
@@ -135,10 +135,10 @@ void OrderAcceptance::init(
 
 void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
 {
-  auto order_context = std::dynamic_pointer_cast<OrderContext>(context);
+  auto order_context = std::dynamic_pointer_cast<AGVContext>(context);
   if (!order_context)
   {
-    VDA5050_WARN_STREAM("OrderAcceptance: context is not an OrderContext");
+    VDA5050_WARN_STREAM("OrderAcceptance: context is not an AGVContext");
     return;
   }
 
@@ -153,28 +153,33 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
   auto execution = order_context->get_resource<OrderExecutionResource>();
   if (!execution) return;
 
-  std::lock_guard<std::mutex> lock(execution->mutex_);
+  // All state mutation goes through update_state(), which holds the resource's
+  // internal mutex for us.
   switch (result.outcome)
   {
     case AcceptanceOutcome::Accepted: {
-      const bool is_update = (order.order_id == execution->state.order_id);
-      if (is_update)
-      {
-        apply_order_update(execution->state, order);
-      }
-      else
-      {
-        apply_new_order(execution->state, order);
-      }
-      execution->executing_order = true;
+      execution->update_state([&order](types::State& state) {
+        const bool is_update = (order.order_id == state.order_id);
+        if (is_update)
+        {
+          apply_order_update(state, order);
+        }
+        else
+        {
+          apply_new_order(state, order);
+        }
+      });
+      execution->set_executing_order(true);
       break;
     }
     case AcceptanceOutcome::Rejected: {
       // Errors are kept in state until a new order is accepted.
-      for (const auto& error : result.errors)
-      {
-        execution->state.errors.push_back(error);
-      }
+      execution->update_state([&result](types::State& state) {
+        for (const auto& error : result.errors)
+        {
+          state.errors.push_back(error);
+        }
+      });
       break;
     }
     case AcceptanceOutcome::Ignored:

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -126,7 +126,11 @@ void apply_order_update(types::State& state, const types::Order& order)
   {
     append_node(state, order.nodes[i]);
   }
-  for (const auto& edge : order.edges) append_edge(state, edge);
+
+  for (size_t i = 0; i < order.edges.size(); ++i)
+  {
+    append_edge(state, order.edges[i]);
+  }
 
   // Deduplicate action states after replacing the horizon. This prevents
   // re-sent horizon actions from accumulating while preserving first-seen

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -25,10 +25,8 @@
 #include <unordered_set>
 #include <utility>
 
-#include "vda5050_core/client/contexts/agv_context.hpp"
 #include "vda5050_core/client/resources/order_execution.hpp"
 #include "vda5050_core/client/updates/order.hpp"
-#include "vda5050_core/logger/logger.hpp"
 #include "vda5050_core/types/action_status.hpp"
 
 namespace vda5050_core {
@@ -161,15 +159,10 @@ void OrderAcceptance::init(
 
 void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
 {
-  auto order_context = std::dynamic_pointer_cast<AGVContext>(context);
-  if (!order_context)
-  {
-    VDA5050_WARN_STREAM("OrderAcceptance: context is not an AGVContext");
-    return;
-  }
+  if (!context) return;
 
   // The inbound order is whatever the protocol adapter (or a test) last pushed.
-  auto update = order_context->get_update<OrderUpdate>();
+  auto update = context->get_update<OrderUpdate>();
   if (!update) return;  // nothing to process yet
 
   const types::Order& order = update->order;
@@ -181,10 +174,9 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
     return;
   }
 
-  const AcceptanceResult result =
-    validator_.validate_order(order, order_context);
+  const AcceptanceResult result = validator_.validate_order(order, context);
 
-  auto execution = order_context->get_resource<OrderExecutionResource>();
+  auto execution = context->get_resource<OrderExecutionResource>();
   if (!execution) return;
 
   // NOTE: get_state()/set_state() is a non-atomic read-modify-write.

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -173,6 +173,20 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
   if (!update) return;  // nothing to process yet
 
   const types::Order& order = update->order;
+
+  // Edge-trigger: the cached OrderUpdate is not cleared and step() runs on every
+  // handler tick, so skip an order already processed at this (orderId,
+  // orderUpdateId). Without this the validator re-evaluates and logs the same
+  // order ~10x/second for as long as it stays cached.
+  if (
+    order.order_id == last_order_id_ &&
+    order.order_update_id == last_order_update_id_)
+  {
+    return;
+  }
+  last_order_id_ = order.order_id;
+  last_order_update_id_ = order.order_update_id;
+
   const AcceptanceResult result =
     validator_.validate_order(order, order_context);
 

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -150,6 +150,11 @@ void apply_order_update(types::State& state, const types::Order& order)
 
 OrderAcceptance::OrderAcceptance() = default;
 
+OrderAcceptance::OrderAcceptance(OrderValidator validator)
+: validator_(std::move(validator))
+{
+}
+
 void OrderAcceptance::init(
   std::shared_ptr<execution::ContextInterface> /*context*/)
 {

--- a/vda5050_core/src/client/strategies/order_acceptance.cpp
+++ b/vda5050_core/src/client/strategies/order_acceptance.cpp
@@ -174,18 +174,12 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
 
   const types::Order& order = update->order;
 
-  // Edge-trigger: the cached OrderUpdate is not cleared and step() runs on every
-  // handler tick, so skip an order already processed at this (orderId,
-  // orderUpdateId). Without this the validator re-evaluates and logs the same
-  // order ~10x/second for as long as it stays cached.
   if (
     order.order_id == last_order_id_ &&
     order.order_update_id == last_order_update_id_)
   {
     return;
   }
-  last_order_id_ = order.order_id;
-  last_order_update_id_ = order.order_update_id;
 
   const AcceptanceResult result =
     validator_.validate_order(order, order_context);
@@ -199,6 +193,8 @@ void OrderAcceptance::step(std::shared_ptr<execution::ContextInterface> context)
   switch (result.outcome)
   {
     case AcceptanceOutcome::Accepted: {
+      last_order_id_ = order.order_id;
+      last_order_update_id_ = order.order_update_id;
       types::State state = execution->get_state();
       // A successful acceptance supersedes any prior rejection, so clear stale
       // errors before applying the new order or update.

--- a/vda5050_core/src/client/strategies/order_validator.cpp
+++ b/vda5050_core/src/client/strategies/order_validator.cpp
@@ -35,8 +35,6 @@ namespace client {
 
 namespace {
 
-// Appends the orderId / orderUpdateId references to an existing error so every
-// rejection carries the same order context, no matter where it originated.
 void attach_order_refs(types::Error& error, const types::Order& order)
 {
   if (!error.error_references) error.error_references.emplace();
@@ -45,7 +43,6 @@ void attach_order_refs(types::Error& error, const types::Order& order)
     {errors::RefOrderUpdateId, std::to_string(order.order_update_id)});
 }
 
-// Builds a VDA5050 Error, always appending the orderId / orderUpdateId refs.
 types::Error make_error(
   const std::string& type, const std::string& description,
   const types::Order& order, std::vector<types::ErrorReference> refs = {})
@@ -120,15 +117,12 @@ AcceptanceResult OrderValidator::validate_order(
   const types::Order& incoming_order,
   const std::shared_ptr<execution::ContextInterface>& context) const
 {
-  // If context is null, return a validation error.
   if (!context)
   {
     return rejected(
       errors::create_error(errors::ValidationError, "context is null", {}));
   }
 
-  // Execution state (order/node tracking) lives in the resource, not the
-  // context itself; the context only routes us to it.
   auto execution = context->get_resource<OrderExecutionResource>();
   if (!execution)
   {
@@ -136,7 +130,6 @@ AcceptanceResult OrderValidator::validate_order(
       errors::ValidationError, "OrderExecutionResource is null", {}));
   }
 
-  // Structural / format validity of the order graph.
   if (auto graph = order_utils::is_valid_graph(incoming_order); !graph)
   {
     for (auto& error : graph.errors) attach_order_refs(error, incoming_order);
@@ -156,8 +149,6 @@ AcceptanceResult OrderValidator::validate_order(
   // Brand new order, or an update of the active one?
   if (incoming_order.order_id != current_id)
   {
-    // New order
-    // Reject if the vehicle is still executing or holding a horizon.
     if (is_busy(current_state))
     {
       return rejected(make_error(
@@ -173,16 +164,11 @@ AcceptanceResult OrderValidator::validate_order(
     return accepted();
   }
 
-  // Update of the active order (same orderId)
-  // Identical orderUpdateId => duplicate resend; discard silently.
   if (incoming_order.order_update_id == current_update_id)
   {
     return ignored();
   }
 
-  // Lower orderUpdateId => deprecated update. Report it
-  // and keep executing the previous order. Any strictly greater id is a valid
-  // newer update -- there is no requirement that it increment by exactly one.
   if (incoming_order.order_update_id < current_update_id)
   {
     return rejected(make_error(

--- a/vda5050_core/src/client/strategies/order_validator.cpp
+++ b/vda5050_core/src/client/strategies/order_validator.cpp
@@ -101,23 +101,6 @@ bool is_busy(const std::shared_ptr<OrderExecutionResource>& execution)
 
 }  // namespace
 
-OrderValidator::OrderValidator()
-: reachable_([](const types::Node&) { return true; }),
-  capable_(
-    [](const types::Order&) { return std::vector<types::ErrorReference>{}; })
-{
-}
-
-void OrderValidator::set_reachability_check(ReachabilityCheck check)
-{
-  if (check) reachable_ = std::move(check);
-}
-
-void OrderValidator::set_capability_check(CapabilityCheck check)
-{
-  if (check) capable_ = std::move(check);
-}
-
 AcceptanceResult OrderValidator::validate_order(
   const types::Order& incoming_order,
   const std::shared_ptr<AGVContext>& context) const
@@ -144,15 +127,7 @@ AcceptanceResult OrderValidator::validate_order(
     return rejected(std::move(graph.errors));
   }
 
-  // Capability / map / optional-field support. The AGV must
-  // reject (not silently ignore) fields or actions it cannot process.
-  if (auto unsupported = capable_(incoming_order); !unsupported.empty())
-  {
-    return rejected(make_error(
-      errors::OrderError,
-      "Order references fields or actions the AGV cannot process",
-      incoming_order, std::move(unsupported)));
-  }
+  // TODO(eileentyz): Add AGV capability/factsheet validation once capability data is available.
 
   // Read one consistent snapshot of the execution state; reused below for the
   // update-stitching check so both decisions see the same values.
@@ -174,17 +149,8 @@ AcceptanceResult OrderValidator::validate_order(
         incoming_order));
     }
 
-    // Step 4: the start node must be reachable from the current position.
-    if (
-      !incoming_order.nodes.empty() &&
-      !reachable_(incoming_order.nodes.front()))
-    {
-      return rejected(make_error(
-        errors::ValidationError,
-        "Start node of the new order is not reachable from current position",
-        incoming_order,
-        {{errors::RefNodeId, incoming_order.nodes.front().node_id}}));
-    }
+    // TODO(eileentyz): Add start-node reachability validation once AGV position tracking
+    // is available.
 
     return accepted();
   }

--- a/vda5050_core/src/client/strategies/order_validator.cpp
+++ b/vda5050_core/src/client/strategies/order_validator.cpp
@@ -93,8 +93,11 @@ AcceptanceResult accepted()
 // The vehicle is "busy" if it still has nodes left
 // to traverse (base or horizon) or any action that is not yet FINISHED/FAILED.
 // Edges never outlive their nodes, so checking node_states is sufficient.
-// Operates on a caller-supplied snapshot so the whole acceptance decision is
-// made from one consistent view of the state.
+//
+// LIMITATION: this PR does not yet remove nodes as the AGV reaches them, so
+// node_states stays populated for the lifetime of an accepted order. Until
+// traversal/state-update handling lands, an accepted order keeps the vehicle
+// "busy" and new orders are rejected until its state is cleared.
 bool is_busy(const types::State& state)
 {
   if (!state.node_states.empty()) return true;
@@ -115,13 +118,13 @@ bool is_busy(const types::State& state)
 
 AcceptanceResult OrderValidator::validate_order(
   const types::Order& incoming_order,
-  const std::shared_ptr<AGVContext>& context) const
+  const std::shared_ptr<execution::ContextInterface>& context) const
 {
   // If context is null, return a validation error.
   if (!context)
   {
     return rejected(
-      errors::create_error(errors::ValidationError, "AGVContext is null", {}));
+      errors::create_error(errors::ValidationError, "context is null", {}));
   }
 
   // Execution state (order/node tracking) lives in the resource, not the

--- a/vda5050_core/src/client/strategies/order_validator.cpp
+++ b/vda5050_core/src/client/strategies/order_validator.cpp
@@ -121,13 +121,14 @@ AcceptanceResult OrderValidator::validate_order(
       errors::ValidationError, "OrderExecutionResource is null", {}));
   }
 
-  // Step 1: structural / format validity of the order graph.
+  // Structural / format validity of the order graph.
   if (auto graph = order_utils::is_valid_graph(incoming_order); !graph)
   {
     return rejected(std::move(graph.errors));
   }
 
-  // TODO(eileentyz): Add AGV capability/factsheet validation once capability data is available.
+  // TODO(eileentyz): Add AGV capability/factsheet validation once capability
+  // data is available.
 
   // Read one consistent snapshot of the execution state; reused below for the
   // update-stitching check so both decisions see the same values.
@@ -135,11 +136,11 @@ AcceptanceResult OrderValidator::validate_order(
   const std::string current_id = current_state.order_id;
   const uint32_t current_update_id = current_state.order_update_id;
 
-  // Step 2: brand new order, or an update of the active one?
+  // Brand new order, or an update of the active one?
   if (incoming_order.order_id != current_id)
   {
     // New order
-    // Step 3: reject if the vehicle is still executing or holding a horizon.
+    // Reject if the vehicle is still executing or holding a horizon.
     if (is_busy(execution))
     {
       return rejected(make_error(
@@ -149,20 +150,20 @@ AcceptanceResult OrderValidator::validate_order(
         incoming_order));
     }
 
-    // TODO(eileentyz): Add start-node reachability validation once AGV position tracking
-    // is available.
+    // TODO(eileentyz): Add start-node reachability validation once AGV position
+    // tracking is available.
 
     return accepted();
   }
 
   // Update of the active order (same orderId)
-  // Step 6: identical orderUpdateId => duplicate resend; discard silently.
+  // Identical orderUpdateId => duplicate resend; discard silently.
   if (incoming_order.order_update_id == current_update_id)
   {
     return ignored();
   }
 
-  // Step 5: lower orderUpdateId => deprecated update. Report it
+  // Lower orderUpdateId => deprecated update. Report it
   // and keep executing the previous order. Any strictly greater id is a valid
   // newer update -- there is no requirement that it increment by exactly one.
   if (incoming_order.order_update_id < current_update_id)
@@ -173,7 +174,7 @@ AcceptanceResult OrderValidator::validate_order(
       incoming_order));
   }
 
-  // Steps 7/8: the update must continue from the decision point. We anchor on
+  // The update must continue from the decision point. We anchor on
   // the last reached node tracked in OrderExecutionResource (nodeId + sequenceId).
   if (incoming_order.nodes.empty())
   {

--- a/vda5050_core/src/client/strategies/order_validator.cpp
+++ b/vda5050_core/src/client/strategies/order_validator.cpp
@@ -84,9 +84,10 @@ AcceptanceResult accepted()
 // to traverse (base or horizon) or any action that is not yet FINISHED/FAILED.
 bool is_busy(const std::shared_ptr<OrderExecutionResource>& execution)
 {
-  if (!execution->get_node_states().empty()) return true;
+  const types::State state = execution->get_state();
+  if (!state.node_states.empty()) return true;
 
-  for (const auto& action : execution->get_action_states())
+  for (const auto& action : state.action_states)
   {
     if (
       action.action_status != types::ActionStatus::FINISHED &&
@@ -153,8 +154,11 @@ AcceptanceResult OrderValidator::validate_order(
       incoming_order, std::move(unsupported)));
   }
 
-  const std::string current_id = execution->get_active_order_id();
-  const uint32_t current_update_id = execution->get_active_order_update_id();
+  // Read one consistent snapshot of the execution state; reused below for the
+  // update-stitching check so both decisions see the same values.
+  const types::State current_state = execution->get_state();
+  const std::string current_id = current_state.order_id;
+  const uint32_t current_update_id = current_state.order_update_id;
 
   // Step 2: brand new order, or an update of the active one?
   if (incoming_order.order_id != current_id)
@@ -215,8 +219,8 @@ AcceptanceResult OrderValidator::validate_order(
 
   const auto& stitch_node = incoming_order.nodes.front();
   if (
-    stitch_node.node_id != execution->get_last_node_id() ||
-    stitch_node.sequence_id != execution->get_last_node_sequence_id())
+    stitch_node.node_id != current_state.last_node_id ||
+    stitch_node.sequence_id != current_state.last_node_sequence_id)
   {
     return rejected(make_error(
       errors::OrderUpdateError,

--- a/vda5050_core/src/client/strategies/order_validator.cpp
+++ b/vda5050_core/src/client/strategies/order_validator.cpp
@@ -35,6 +35,16 @@ namespace client {
 
 namespace {
 
+// Appends the orderId / orderUpdateId references to an existing error so every
+// rejection carries the same order context, no matter where it originated.
+void attach_order_refs(types::Error& error, const types::Order& order)
+{
+  if (!error.error_references) error.error_references.emplace();
+  error.error_references->push_back({errors::RefOrderId, order.order_id});
+  error.error_references->push_back(
+    {errors::RefOrderUpdateId, std::to_string(order.order_update_id)});
+}
+
 // Builds a VDA5050 Error, always appending the orderId / orderUpdateId refs.
 types::Error make_error(
   const std::string& type, const std::string& description,
@@ -82,9 +92,11 @@ AcceptanceResult accepted()
 
 // The vehicle is "busy" if it still has nodes left
 // to traverse (base or horizon) or any action that is not yet FINISHED/FAILED.
-bool is_busy(const std::shared_ptr<OrderExecutionResource>& execution)
+// Edges never outlive their nodes, so checking node_states is sufficient.
+// Operates on a caller-supplied snapshot so the whole acceptance decision is
+// made from one consistent view of the state.
+bool is_busy(const types::State& state)
 {
-  const types::State state = execution->get_state();
   if (!state.node_states.empty()) return true;
 
   for (const auto& action : state.action_states)
@@ -124,14 +136,16 @@ AcceptanceResult OrderValidator::validate_order(
   // Structural / format validity of the order graph.
   if (auto graph = order_utils::is_valid_graph(incoming_order); !graph)
   {
+    for (auto& error : graph.errors) attach_order_refs(error, incoming_order);
     return rejected(std::move(graph.errors));
   }
 
   // TODO(eileentyz): Add AGV capability/factsheet validation once capability
   // data is available.
 
-  // Read one consistent snapshot of the execution state; reused below for the
-  // update-stitching check so both decisions see the same values.
+  // Read one consistent snapshot of the execution state; every decision below
+  // (busy check, duplicate/deprecated update, stitch match) reads from this
+  // same snapshot so they cannot disagree about the moment they observed.
   const types::State current_state = execution->get_state();
   const std::string current_id = current_state.order_id;
   const uint32_t current_update_id = current_state.order_update_id;
@@ -141,7 +155,7 @@ AcceptanceResult OrderValidator::validate_order(
   {
     // New order
     // Reject if the vehicle is still executing or holding a horizon.
-    if (is_busy(execution))
+    if (is_busy(current_state))
     {
       return rejected(make_error(
         errors::ValidationError,
@@ -174,8 +188,6 @@ AcceptanceResult OrderValidator::validate_order(
       incoming_order));
   }
 
-  // The update must continue from the decision point. We anchor on
-  // the last reached node tracked in OrderExecutionResource (nodeId + sequenceId).
   if (incoming_order.nodes.empty())
   {
     return rejected(make_error(
@@ -184,14 +196,26 @@ AcceptanceResult OrderValidator::validate_order(
       incoming_order));
   }
 
+  std::string base_end_id = current_state.last_node_id;
+  uint32_t base_end_sequence_id = current_state.last_node_sequence_id;
+  for (const auto& node : current_state.node_states)
+  {
+    if (node.released && node.sequence_id > base_end_sequence_id)
+    {
+      base_end_id = node.node_id;
+      base_end_sequence_id = node.sequence_id;
+    }
+  }
+
   const auto& stitch_node = incoming_order.nodes.front();
   if (
-    stitch_node.node_id != current_state.last_node_id ||
-    stitch_node.sequence_id != current_state.last_node_sequence_id)
+    stitch_node.node_id != base_end_id ||
+    stitch_node.sequence_id != base_end_sequence_id)
   {
     return rejected(make_error(
       errors::OrderUpdateError,
-      "Order update stitch node does not match the last known base node",
+      "Order update stitch node does not match the last node of the current "
+      "base (the decision point)",
       incoming_order,
       {{errors::RefNodeId, stitch_node.node_id},
        {errors::RefSequenceId, std::to_string(stitch_node.sequence_id)}}));

--- a/vda5050_core/src/client/strategies/order_validator.cpp
+++ b/vda5050_core/src/client/strategies/order_validator.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "vda5050_core/client/resources/order_execution.hpp"
 #include "vda5050_core/errors/error_codes.hpp"
 #include "vda5050_core/errors/error_factory.hpp"
 #include "vda5050_core/logger/logger.hpp"
@@ -81,11 +82,11 @@ AcceptanceResult accepted()
 
 // The vehicle is "busy" if it still has nodes left
 // to traverse (base or horizon) or any action that is not yet FINISHED/FAILED.
-bool is_busy(const std::shared_ptr<OrderContext>& context)
+bool is_busy(const std::shared_ptr<OrderExecutionResource>& execution)
 {
-  if (!context->get_node_states().empty()) return true;
+  if (!execution->get_node_states().empty()) return true;
 
-  for (const auto& action : context->get_action_states())
+  for (const auto& action : execution->get_action_states())
   {
     if (
       action.action_status != types::ActionStatus::FINISHED &&
@@ -118,13 +119,22 @@ void OrderValidator::set_capability_check(CapabilityCheck check)
 
 AcceptanceResult OrderValidator::validate_order(
   const types::Order& incoming_order,
-  const std::shared_ptr<OrderContext>& context) const
+  const std::shared_ptr<AGVContext>& context) const
 {
   // If context is null, return a validation error.
   if (!context)
   {
+    return rejected(
+      errors::create_error(errors::ValidationError, "AGVContext is null", {}));
+  }
+
+  // Execution state (order/node tracking) lives in the resource, not the
+  // context itself; the context only routes us to it.
+  auto execution = context->get_resource<OrderExecutionResource>();
+  if (!execution)
+  {
     return rejected(errors::create_error(
-      errors::ValidationError, "OrderContext is null", {}));
+      errors::ValidationError, "OrderExecutionResource is null", {}));
   }
 
   // Step 1: structural / format validity of the order graph.
@@ -143,15 +153,15 @@ AcceptanceResult OrderValidator::validate_order(
       incoming_order, std::move(unsupported)));
   }
 
-  const std::string current_id = context->get_active_order_id();
-  const uint32_t current_update_id = context->get_active_order_update_id();
+  const std::string current_id = execution->get_active_order_id();
+  const uint32_t current_update_id = execution->get_active_order_update_id();
 
   // Step 2: brand new order, or an update of the active one?
   if (incoming_order.order_id != current_id)
   {
     // New order
     // Step 3: reject if the vehicle is still executing or holding a horizon.
-    if (is_busy(context))
+    if (is_busy(execution))
     {
       return rejected(make_error(
         errors::ValidationError,
@@ -194,7 +204,7 @@ AcceptanceResult OrderValidator::validate_order(
   }
 
   // Steps 7/8: the update must continue from the decision point. We anchor on
-  // the last reached node tracked in OrderContext (nodeId + sequenceId).
+  // the last reached node tracked in OrderExecutionResource (nodeId + sequenceId).
   if (incoming_order.nodes.empty())
   {
     return rejected(make_error(
@@ -205,8 +215,8 @@ AcceptanceResult OrderValidator::validate_order(
 
   const auto& stitch_node = incoming_order.nodes.front();
   if (
-    stitch_node.node_id != context->get_last_node_id() ||
-    stitch_node.sequence_id != context->get_last_node_sequence_id())
+    stitch_node.node_id != execution->get_last_node_id() ||
+    stitch_node.sequence_id != execution->get_last_node_sequence_id())
   {
     return rejected(make_error(
       errors::OrderUpdateError,

--- a/vda5050_core/src/client/strategies/order_validator.cpp
+++ b/vda5050_core/src/client/strategies/order_validator.cpp
@@ -62,7 +62,7 @@ AcceptanceResult rejected(types::Error error)
     "OrderValidator rejected order: " << error.error_type << " - "
                                       << error.error_description.value_or(""));
   AcceptanceResult res;
-  res.outcome = AcceptanceOutcome::Rejected;
+  res.outcome = AcceptanceOutcome::REJECTED;
   res.errors.push_back(std::move(error));
   return res;
 }
@@ -70,7 +70,7 @@ AcceptanceResult rejected(types::Error error)
 AcceptanceResult rejected(std::vector<types::Error> errors)
 {
   AcceptanceResult res;
-  res.outcome = AcceptanceOutcome::Rejected;
+  res.outcome = AcceptanceOutcome::REJECTED;
   res.errors = std::move(errors);
   return res;
 }
@@ -79,14 +79,14 @@ AcceptanceResult ignored()
 {
   VDA5050_INFO_STREAM("OrderValidator ignored duplicate order update");
   AcceptanceResult res;
-  res.outcome = AcceptanceOutcome::Ignored;
+  res.outcome = AcceptanceOutcome::IGNORED;
   return res;
 }
 
 AcceptanceResult accepted()
 {
   AcceptanceResult res;
-  res.outcome = AcceptanceOutcome::Accepted;
+  res.outcome = AcceptanceOutcome::ACCEPTED;
   return res;
 }
 

--- a/vda5050_core/src/client/strategies/order_validator.cpp
+++ b/vda5050_core/src/client/strategies/order_validator.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/client/strategies/order_validator.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/errors/error_factory.hpp"
+#include "vda5050_core/logger/logger.hpp"
+#include "vda5050_core/order_utils/order_graph_validator.hpp"
+#include "vda5050_core/types/action_status.hpp"
+
+namespace vda5050_core {
+
+namespace client {
+
+namespace {
+
+// Builds a VDA5050 Error, always appending the orderId / orderUpdateId refs.
+types::Error make_error(
+  const std::string& type, const std::string& description,
+  const types::Order& order, std::vector<types::ErrorReference> refs = {})
+{
+  refs.push_back({errors::RefOrderId, order.order_id});
+  refs.push_back(
+    {errors::RefOrderUpdateId, std::to_string(order.order_update_id)});
+  return errors::create_error(type, description, refs);
+}
+
+AcceptanceResult rejected(types::Error error)
+{
+  VDA5050_WARN_STREAM(
+    "OrderValidator rejected order: " << error.error_type << " - "
+                                      << error.error_description.value_or(""));
+  AcceptanceResult res;
+  res.outcome = AcceptanceOutcome::Rejected;
+  res.errors.push_back(std::move(error));
+  return res;
+}
+
+AcceptanceResult rejected(std::vector<types::Error> errors)
+{
+  AcceptanceResult res;
+  res.outcome = AcceptanceOutcome::Rejected;
+  res.errors = std::move(errors);
+  return res;
+}
+
+AcceptanceResult ignored()
+{
+  VDA5050_INFO_STREAM("OrderValidator ignored duplicate order update");
+  AcceptanceResult res;
+  res.outcome = AcceptanceOutcome::Ignored;
+  return res;
+}
+
+AcceptanceResult accepted()
+{
+  AcceptanceResult res;
+  res.outcome = AcceptanceOutcome::Accepted;
+  return res;
+}
+
+// The vehicle is "busy" if it still has nodes left
+// to traverse (base or horizon) or any action that is not yet FINISHED/FAILED.
+bool is_busy(const std::shared_ptr<OrderContext>& context)
+{
+  if (!context->get_node_states().empty()) return true;
+
+  for (const auto& action : context->get_action_states())
+  {
+    if (
+      action.action_status != types::ActionStatus::FINISHED &&
+      action.action_status != types::ActionStatus::FAILED)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+OrderValidator::OrderValidator()
+: reachable_([](const types::Node&) { return true; }),
+  capable_(
+    [](const types::Order&) { return std::vector<types::ErrorReference>{}; })
+{
+}
+
+void OrderValidator::set_reachability_check(ReachabilityCheck check)
+{
+  if (check) reachable_ = std::move(check);
+}
+
+void OrderValidator::set_capability_check(CapabilityCheck check)
+{
+  if (check) capable_ = std::move(check);
+}
+
+AcceptanceResult OrderValidator::validate_order(
+  const types::Order& incoming_order,
+  const std::shared_ptr<OrderContext>& context) const
+{
+  // If context is null, return a validation error.
+  if (!context)
+  {
+    return rejected(errors::create_error(
+      errors::ValidationError, "OrderContext is null", {}));
+  }
+
+  // Step 1: structural / format validity of the order graph.
+  if (auto graph = order_utils::is_valid_graph(incoming_order); !graph)
+  {
+    return rejected(std::move(graph.errors));
+  }
+
+  // Capability / map / optional-field support. The AGV must
+  // reject (not silently ignore) fields or actions it cannot process.
+  if (auto unsupported = capable_(incoming_order); !unsupported.empty())
+  {
+    return rejected(make_error(
+      errors::OrderError,
+      "Order references fields or actions the AGV cannot process",
+      incoming_order, std::move(unsupported)));
+  }
+
+  const std::string current_id = context->get_active_order_id();
+  const uint32_t current_update_id = context->get_active_order_update_id();
+
+  // Step 2: brand new order, or an update of the active one?
+  if (incoming_order.order_id != current_id)
+  {
+    // New order
+    // Step 3: reject if the vehicle is still executing or holding a horizon.
+    if (is_busy(context))
+    {
+      return rejected(make_error(
+        errors::ValidationError,
+        "Cannot accept a new order while the vehicle is still executing or "
+        "holding a horizon",
+        incoming_order));
+    }
+
+    // Step 4: the start node must be reachable from the current position.
+    if (
+      !incoming_order.nodes.empty() &&
+      !reachable_(incoming_order.nodes.front()))
+    {
+      return rejected(make_error(
+        errors::ValidationError,
+        "Start node of the new order is not reachable from current position",
+        incoming_order,
+        {{errors::RefNodeId, incoming_order.nodes.front().node_id}}));
+    }
+
+    return accepted();
+  }
+
+  // Update of the active order (same orderId)
+  // Step 6: identical orderUpdateId => duplicate resend; discard silently.
+  if (incoming_order.order_update_id == current_update_id)
+  {
+    return ignored();
+  }
+
+  // Step 5: lower orderUpdateId => deprecated update. Report it
+  // and keep executing the previous order. Any strictly greater id is a valid
+  // newer update -- there is no requirement that it increment by exactly one.
+  if (incoming_order.order_update_id < current_update_id)
+  {
+    return rejected(make_error(
+      errors::OrderUpdateError,
+      "Order update is deprecated (older than the active orderUpdateId)",
+      incoming_order));
+  }
+
+  // Steps 7/8: the update must continue from the decision point. We anchor on
+  // the last reached node tracked in OrderContext (nodeId + sequenceId).
+  if (incoming_order.nodes.empty())
+  {
+    return rejected(make_error(
+      errors::ValidationError,
+      "Order update must contain at least one node for stitching",
+      incoming_order));
+  }
+
+  const auto& stitch_node = incoming_order.nodes.front();
+  if (
+    stitch_node.node_id != context->get_last_node_id() ||
+    stitch_node.sequence_id != context->get_last_node_sequence_id())
+  {
+    return rejected(make_error(
+      errors::OrderUpdateError,
+      "Order update stitch node does not match the last known base node",
+      incoming_order,
+      {{errors::RefNodeId, stitch_node.node_id},
+       {errors::RefSequenceId, std::to_string(stitch_node.sequence_id)}}));
+  }
+
+  return accepted();
+}
+
+}  // namespace client
+}  // namespace vda5050_core

--- a/vda5050_core/test/client/test_order_acceptance.cpp
+++ b/vda5050_core/test/client/test_order_acceptance.cpp
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "vda5050_core/client/contexts/agv_context.hpp"
 #include "vda5050_core/client/resources/config.hpp"
@@ -41,7 +42,7 @@ std::shared_ptr<AGVContext> make_context()
 {
   auto config = std::make_shared<vda5050_core::client::HeaderConfigResource>(
     "uagv", "2.0.0", "ROS-I", "S001");
-  auto context = std::make_shared<AGVContext>(config);
+  auto context = AGVContext::make(config);
   context->init();
   return context;
 }
@@ -139,19 +140,19 @@ TEST(OrderAcceptanceTest, AppliesUpdateByAppending)
   {
     auto execution = context->get_resource<OrderExecutionResource>();
     execution->set_executing_order(true);
-    execution->update_state([](types::State& state) {
-      state.order_id = "o1";
-      state.order_update_id = 1;
-      state.last_node_id = "node_a";
-      state.last_node_sequence_id = 10;
-      state.node_states.push_back([] {
-        types::NodeState n;
-        n.node_id = "node_a";
-        n.sequence_id = 10;
-        n.released = true;
-        return n;
-      }());
-    });
+    types::State state = execution->get_state();
+    state.order_id = "o1";
+    state.order_update_id = 1;
+    state.last_node_id = "node_a";
+    state.last_node_sequence_id = 10;
+    state.node_states.push_back([] {
+      types::NodeState n;
+      n.node_id = "node_a";
+      n.sequence_id = 10;
+      n.released = true;
+      return n;
+    }());
+    execution->set_state(std::move(state));
   }
 
   types::Order update;
@@ -181,12 +182,12 @@ TEST(OrderAcceptanceTest, IgnoresDuplicateUpdate)
 
   {
     auto execution = context->get_resource<OrderExecutionResource>();
-    execution->update_state([](types::State& state) {
-      state.order_id = "o1";
-      state.order_update_id = 3;
-      state.last_node_id = "node_a";
-      state.last_node_sequence_id = 10;
-    });
+    types::State state = execution->get_state();
+    state.order_id = "o1";
+    state.order_update_id = 3;
+    state.last_node_id = "node_a";
+    state.last_node_sequence_id = 10;
+    execution->set_state(std::move(state));
   }
 
   types::Order duplicate;

--- a/vda5050_core/test/client/test_order_acceptance.cpp
+++ b/vda5050_core/test/client/test_order_acceptance.cpp
@@ -21,27 +21,27 @@
 #include <memory>
 #include <string>
 
+#include "vda5050_core/client/contexts/agv_context.hpp"
 #include "vda5050_core/client/resources/config.hpp"
 #include "vda5050_core/client/resources/order_execution.hpp"
 #include "vda5050_core/client/strategies/order_acceptance.hpp"
 #include "vda5050_core/client/updates/order.hpp"
-#include "vda5050_core/client/updates/order_context.hpp"
 #include "vda5050_core/types/order.hpp"
 
 namespace {
 
 using OrderAcceptance = vda5050_core::client::OrderAcceptance;
-using OrderContext = vda5050_core::client::OrderContext;
+using AGVContext = vda5050_core::client::AGVContext;
 using OrderExecutionResource = vda5050_core::client::OrderExecutionResource;
 using OrderUpdate = vda5050_core::client::OrderUpdate;
 namespace execution = vda5050_core::execution;
 namespace types = vda5050_core::types;
 
-std::shared_ptr<OrderContext> make_context()
+std::shared_ptr<AGVContext> make_context()
 {
   auto config = std::make_shared<vda5050_core::client::HeaderConfigResource>(
     "uagv", "2.0.0", "ROS-I", "S001");
-  auto context = std::make_shared<OrderContext>(config);
+  auto context = std::make_shared<AGVContext>(config);
   context->init();
   return context;
 }
@@ -95,14 +95,14 @@ TEST(OrderAcceptanceTest, AcceptsAndPopulatesNewOrder)
   strategy.step(context);
 
   auto execution = context->get_resource<OrderExecutionResource>();
-  std::lock_guard<std::mutex> lock(execution->mutex_);
-  EXPECT_TRUE(execution->executing_order);
-  EXPECT_EQ(execution->state.order_id, "o1");
-  EXPECT_EQ(execution->state.order_update_id, 0u);
-  EXPECT_EQ(execution->state.node_states.size(), 2u);
-  EXPECT_EQ(execution->state.edge_states.size(), 1u);
-  EXPECT_EQ(execution->state.action_states.size(), 1u);
-  EXPECT_TRUE(execution->state.errors.empty());
+  EXPECT_TRUE(execution->is_executing_order());
+  const auto state = execution->get_state();
+  EXPECT_EQ(state.order_id, "o1");
+  EXPECT_EQ(state.order_update_id, 0u);
+  EXPECT_EQ(state.node_states.size(), 2u);
+  EXPECT_EQ(state.edge_states.size(), 1u);
+  EXPECT_EQ(state.action_states.size(), 1u);
+  EXPECT_TRUE(state.errors.empty());
 }
 
 // Test 2: A structurally invalid order is rejected; errors are recorded and the
@@ -122,11 +122,11 @@ TEST(OrderAcceptanceTest, RejectsInvalidOrderAndRecordsErrors)
   strategy.step(context);
 
   auto execution = context->get_resource<OrderExecutionResource>();
-  std::lock_guard<std::mutex> lock(execution->mutex_);
-  EXPECT_FALSE(execution->executing_order);
-  EXPECT_TRUE(execution->state.order_id.empty());
-  EXPECT_TRUE(execution->state.node_states.empty());
-  EXPECT_FALSE(execution->state.errors.empty());
+  EXPECT_FALSE(execution->is_executing_order());
+  const auto state = execution->get_state();
+  EXPECT_TRUE(state.order_id.empty());
+  EXPECT_TRUE(state.node_states.empty());
+  EXPECT_FALSE(state.errors.empty());
 }
 
 // Test 3: A valid update appends the new node onto the running base.
@@ -138,19 +138,20 @@ TEST(OrderAcceptanceTest, AppliesUpdateByAppending)
   // Seed a running base: order "o1" update 1, sitting at node_a (seq 10).
   {
     auto execution = context->get_resource<OrderExecutionResource>();
-    std::lock_guard<std::mutex> lock(execution->mutex_);
-    execution->executing_order = true;
-    execution->state.order_id = "o1";
-    execution->state.order_update_id = 1;
-    execution->state.last_node_id = "node_a";
-    execution->state.last_node_sequence_id = 10;
-    execution->state.node_states.push_back([] {
-      types::NodeState n;
-      n.node_id = "node_a";
-      n.sequence_id = 10;
-      n.released = true;
-      return n;
-    }());
+    execution->set_executing_order(true);
+    execution->update_state([](types::State& state) {
+      state.order_id = "o1";
+      state.order_update_id = 1;
+      state.last_node_id = "node_a";
+      state.last_node_sequence_id = 10;
+      state.node_states.push_back([] {
+        types::NodeState n;
+        n.node_id = "node_a";
+        n.sequence_id = 10;
+        n.released = true;
+        return n;
+      }());
+    });
   }
 
   types::Order update;
@@ -164,12 +165,12 @@ TEST(OrderAcceptanceTest, AppliesUpdateByAppending)
   strategy.step(context);
 
   auto execution = context->get_resource<OrderExecutionResource>();
-  std::lock_guard<std::mutex> lock(execution->mutex_);
-  EXPECT_EQ(execution->state.order_update_id, 2u);
-  ASSERT_EQ(execution->state.node_states.size(), 2u);
-  EXPECT_EQ(execution->state.node_states[0].node_id, "node_a");
-  EXPECT_EQ(execution->state.node_states[1].node_id, "node_b");
-  EXPECT_EQ(execution->state.edge_states.size(), 1u);
+  const auto state = execution->get_state();
+  EXPECT_EQ(state.order_update_id, 2u);
+  ASSERT_EQ(state.node_states.size(), 2u);
+  EXPECT_EQ(state.node_states[0].node_id, "node_a");
+  EXPECT_EQ(state.node_states[1].node_id, "node_b");
+  EXPECT_EQ(state.edge_states.size(), 1u);
 }
 
 // Test 4: A duplicate update (same orderUpdateId) leaves the state untouched.
@@ -180,11 +181,12 @@ TEST(OrderAcceptanceTest, IgnoresDuplicateUpdate)
 
   {
     auto execution = context->get_resource<OrderExecutionResource>();
-    std::lock_guard<std::mutex> lock(execution->mutex_);
-    execution->state.order_id = "o1";
-    execution->state.order_update_id = 3;
-    execution->state.last_node_id = "node_a";
-    execution->state.last_node_sequence_id = 10;
+    execution->update_state([](types::State& state) {
+      state.order_id = "o1";
+      state.order_update_id = 3;
+      state.last_node_id = "node_a";
+      state.last_node_sequence_id = 10;
+    });
   }
 
   types::Order duplicate;
@@ -196,10 +198,10 @@ TEST(OrderAcceptanceTest, IgnoresDuplicateUpdate)
   strategy.step(context);
 
   auto execution = context->get_resource<OrderExecutionResource>();
-  std::lock_guard<std::mutex> lock(execution->mutex_);
-  EXPECT_EQ(execution->state.order_update_id, 3u);
-  EXPECT_TRUE(execution->state.node_states.empty());
-  EXPECT_TRUE(execution->state.errors.empty());
+  const auto state = execution->get_state();
+  EXPECT_EQ(state.order_update_id, 3u);
+  EXPECT_TRUE(state.node_states.empty());
+  EXPECT_TRUE(state.errors.empty());
 }
 
 }  // namespace

--- a/vda5050_core/test/client/test_order_acceptance.cpp
+++ b/vda5050_core/test/client/test_order_acceptance.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+
+#include "vda5050_core/client/resources/config.hpp"
+#include "vda5050_core/client/resources/order_execution.hpp"
+#include "vda5050_core/client/strategies/order_acceptance.hpp"
+#include "vda5050_core/client/updates/order.hpp"
+#include "vda5050_core/client/updates/order_context.hpp"
+#include "vda5050_core/types/order.hpp"
+
+namespace {
+
+using OrderAcceptance = vda5050_core::client::OrderAcceptance;
+using OrderContext = vda5050_core::client::OrderContext;
+using OrderExecutionResource = vda5050_core::client::OrderExecutionResource;
+using OrderUpdate = vda5050_core::client::OrderUpdate;
+namespace execution = vda5050_core::execution;
+namespace types = vda5050_core::types;
+
+std::shared_ptr<OrderContext> make_context()
+{
+  auto config = std::make_shared<vda5050_core::client::HeaderConfigResource>(
+    "uagv", "2.0.0", "ROS-I", "S001");
+  auto context = std::make_shared<OrderContext>(config);
+  context->init();
+  return context;
+}
+
+types::Node make_node(const std::string& node_id, uint32_t sequence_id)
+{
+  types::Node node;
+  node.node_id = node_id;
+  node.sequence_id = sequence_id;
+  node.released = true;
+  return node;
+}
+
+types::Edge make_edge(
+  const std::string& edge_id, uint32_t sequence_id,
+  const std::string& start_node_id, const std::string& end_node_id)
+{
+  types::Edge edge;
+  edge.edge_id = edge_id;
+  edge.sequence_id = sequence_id;
+  edge.start_node_id = start_node_id;
+  edge.end_node_id = end_node_id;
+  edge.released = true;
+  return edge;
+}
+
+types::Action make_action(const std::string& action_id)
+{
+  types::Action action;
+  action.action_id = action_id;
+  action.action_type = "pick";
+  return action;
+}
+
+// Test 1: A valid new order populates the execution state and marks executing.
+TEST(OrderAcceptanceTest, AcceptsAndPopulatesNewOrder)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  types::Order order;
+  order.order_id = "o1";
+  order.order_update_id = 0;
+  auto node0 = make_node("node_0", 0);
+  node0.actions.push_back(make_action("act_0"));
+  order.nodes.push_back(node0);
+  order.nodes.push_back(make_node("node_2", 2));
+  order.edges.push_back(make_edge("edge_1", 1, "node_0", "node_2"));
+
+  context->provider()->push<OrderUpdate>(order);
+  strategy.step(context);
+
+  auto execution = context->get_resource<OrderExecutionResource>();
+  std::lock_guard<std::mutex> lock(execution->mutex_);
+  EXPECT_TRUE(execution->executing_order);
+  EXPECT_EQ(execution->state.order_id, "o1");
+  EXPECT_EQ(execution->state.order_update_id, 0u);
+  EXPECT_EQ(execution->state.node_states.size(), 2u);
+  EXPECT_EQ(execution->state.edge_states.size(), 1u);
+  EXPECT_EQ(execution->state.action_states.size(), 1u);
+  EXPECT_TRUE(execution->state.errors.empty());
+}
+
+// Test 2: A structurally invalid order is rejected; errors are recorded and the
+// execution state is left untouched.
+TEST(OrderAcceptanceTest, RejectsInvalidOrderAndRecordsErrors)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  types::Order order;
+  order.order_id = "bad";
+  order.order_update_id = 0;
+  order.nodes.push_back(make_node("node_0", 0));
+  order.nodes.push_back(make_node("node_2", 2));  // 2 nodes, 0 edges -> invalid
+
+  context->provider()->push<OrderUpdate>(order);
+  strategy.step(context);
+
+  auto execution = context->get_resource<OrderExecutionResource>();
+  std::lock_guard<std::mutex> lock(execution->mutex_);
+  EXPECT_FALSE(execution->executing_order);
+  EXPECT_TRUE(execution->state.order_id.empty());
+  EXPECT_TRUE(execution->state.node_states.empty());
+  EXPECT_FALSE(execution->state.errors.empty());
+}
+
+// Test 3: A valid update appends the new node onto the running base.
+TEST(OrderAcceptanceTest, AppliesUpdateByAppending)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  // Seed a running base: order "o1" update 1, sitting at node_a (seq 10).
+  {
+    auto execution = context->get_resource<OrderExecutionResource>();
+    std::lock_guard<std::mutex> lock(execution->mutex_);
+    execution->executing_order = true;
+    execution->state.order_id = "o1";
+    execution->state.order_update_id = 1;
+    execution->state.last_node_id = "node_a";
+    execution->state.last_node_sequence_id = 10;
+    execution->state.node_states.push_back([] {
+      types::NodeState n;
+      n.node_id = "node_a";
+      n.sequence_id = 10;
+      n.released = true;
+      return n;
+    }());
+  }
+
+  types::Order update;
+  update.order_id = "o1";
+  update.order_update_id = 2;
+  update.nodes.push_back(make_node("node_a", 10));  // re-sent stitch node
+  update.nodes.push_back(make_node("node_b", 12));
+  update.edges.push_back(make_edge("edge_ab", 11, "node_a", "node_b"));
+
+  context->provider()->push<OrderUpdate>(update);
+  strategy.step(context);
+
+  auto execution = context->get_resource<OrderExecutionResource>();
+  std::lock_guard<std::mutex> lock(execution->mutex_);
+  EXPECT_EQ(execution->state.order_update_id, 2u);
+  ASSERT_EQ(execution->state.node_states.size(), 2u);
+  EXPECT_EQ(execution->state.node_states[0].node_id, "node_a");
+  EXPECT_EQ(execution->state.node_states[1].node_id, "node_b");
+  EXPECT_EQ(execution->state.edge_states.size(), 1u);
+}
+
+// Test 4: A duplicate update (same orderUpdateId) leaves the state untouched.
+TEST(OrderAcceptanceTest, IgnoresDuplicateUpdate)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  {
+    auto execution = context->get_resource<OrderExecutionResource>();
+    std::lock_guard<std::mutex> lock(execution->mutex_);
+    execution->state.order_id = "o1";
+    execution->state.order_update_id = 3;
+    execution->state.last_node_id = "node_a";
+    execution->state.last_node_sequence_id = 10;
+  }
+
+  types::Order duplicate;
+  duplicate.order_id = "o1";
+  duplicate.order_update_id = 3;
+  duplicate.nodes.push_back(make_node("node_a", 10));
+
+  context->provider()->push<OrderUpdate>(duplicate);
+  strategy.step(context);
+
+  auto execution = context->get_resource<OrderExecutionResource>();
+  std::lock_guard<std::mutex> lock(execution->mutex_);
+  EXPECT_EQ(execution->state.order_update_id, 3u);
+  EXPECT_TRUE(execution->state.node_states.empty());
+  EXPECT_TRUE(execution->state.errors.empty());
+}
+
+}  // namespace

--- a/vda5050_core/test/client/test_order_acceptance.cpp
+++ b/vda5050_core/test/client/test_order_acceptance.cpp
@@ -402,4 +402,113 @@ TEST(OrderAcceptanceTest, RejectedUpdatePreservesRunningBase)
   EXPECT_FALSE(state.errors.empty());  // rejection error recorded
 }
 
+// Test 10: A new order rejected because the AGV is busy must not be remembered
+// as processed. If the master resends the same order after the AGV becomes idle,
+// it should be accepted.
+TEST(OrderAcceptanceTest, RejectedBusyOrderCanBeAcceptedWhenResentAfterIdle)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+  auto execution = context->get_resource<OrderExecutionResource>();
+
+  // Simulate that the AGV is currently busy executing another order.
+  execution->set_executing_order(true);
+  {
+    types::State state = execution->get_state();
+    state.order_id = "running";
+    state.order_update_id = 0;
+    state.node_states.push_back([] {
+      types::NodeState n;
+      n.node_id = "running_node";
+      n.sequence_id = 0;
+      n.released = true;
+      return n;
+    }());
+    execution->set_state(std::move(state));
+  }
+
+  // New order arrives while busy, so it should be rejected.
+  types::Order queued;
+  queued.order_id = "queued";
+  queued.order_update_id = 0;
+  queued.nodes.push_back(make_node("node_0", 0));
+
+  context->provider()->push<OrderUpdate>(queued);
+  strategy.step(context);
+
+  {
+    const auto state = execution->get_state();
+    EXPECT_EQ(state.order_id, "running");
+    EXPECT_FALSE(state.errors.empty());
+  }
+
+  // AGV becomes idle after finishing the running order.
+  execution->set_executing_order(false);
+  {
+    types::State state = execution->get_state();
+    state.order_id.clear();
+    state.order_update_id = 0;
+    state.node_states.clear();
+    state.edge_states.clear();
+    state.action_states.clear();
+    state.last_node_id.clear();
+    state.last_node_sequence_id = 0;
+    execution->set_state(std::move(state));
+  }
+
+  // Master resends the same order_id/order_update_id.
+  // This should NOT be skipped by last_order_id_/last_order_update_id_.
+  context->provider()->push<OrderUpdate>(queued);
+  strategy.step(context);
+
+  const auto state = execution->get_state();
+  EXPECT_TRUE(execution->is_executing_order());
+  EXPECT_EQ(state.order_id, "queued");
+  EXPECT_EQ(state.order_update_id, 0u);
+  EXPECT_TRUE(state.errors.empty());
+  ASSERT_EQ(state.node_states.size(), 1u);
+  EXPECT_EQ(state.node_states[0].node_id, "node_0");
+}
+
+// Test 11: An already accepted order should not be re-applied on later step()
+// ticks while the same cached OrderUpdate remains in the context.
+TEST(OrderAcceptanceTest, AcceptedOrderIsNotReprocessedOnLaterTicks)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  types::Order order;
+  order.order_id = "o1";
+  order.order_update_id = 0;
+  order.nodes.push_back(make_node("node_0", 0));
+
+  context->provider()->push<OrderUpdate>(order);
+  strategy.step(context);
+
+  auto execution = context->get_resource<OrderExecutionResource>();
+  const auto state_after_first = execution->get_state();
+  ASSERT_EQ(state_after_first.order_id, "o1");
+  ASSERT_EQ(state_after_first.node_states.size(), 1u);
+
+  // Mutate state so we can detect if apply_new_order() runs again.
+  {
+    types::State state = execution->get_state();
+    state.node_states.push_back([] {
+      types::NodeState n;
+      n.node_id = "should_not_be_cleared";
+      n.sequence_id = 99;
+      n.released = true;
+      return n;
+    }());
+    execution->set_state(std::move(state));
+  }
+
+  // Same cached update should be skipped because it was already accepted.
+  strategy.step(context);
+
+  const auto state_after_second = execution->get_state();
+  ASSERT_EQ(state_after_second.node_states.size(), 2u);
+  EXPECT_EQ(state_after_second.node_states[1].node_id, "should_not_be_cleared");
+}
+
 }  // namespace

--- a/vda5050_core/test/client/test_order_acceptance.cpp
+++ b/vda5050_core/test/client/test_order_acceptance.cpp
@@ -205,4 +205,122 @@ TEST(OrderAcceptanceTest, IgnoresDuplicateUpdate)
   EXPECT_TRUE(state.errors.empty());
 }
 
+// Test 5: Errors from a rejected order are cleared once a new order is accepted,
+// rather than leaking into the freshly accepted order's reported state.
+TEST(OrderAcceptanceTest, ClearsStaleErrorsOnAcceptedNewOrder)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  // First order is structurally invalid -> rejected, error recorded in state.
+  types::Order bad;
+  bad.order_id = "bad";
+  bad.order_update_id = 0;
+  bad.nodes.push_back(make_node("node_0", 0));
+  bad.nodes.push_back(make_node("node_2", 2));  // 2 nodes, 0 edges -> invalid
+
+  context->provider()->push<OrderUpdate>(bad);
+  strategy.step(context);
+
+  auto execution = context->get_resource<OrderExecutionResource>();
+  ASSERT_FALSE(execution->get_state().errors.empty());
+
+  // A subsequent valid new order is accepted and must clear the stale error.
+  types::Order good;
+  good.order_id = "o1";
+  good.order_update_id = 0;
+  good.nodes.push_back(make_node("node_0", 0));
+
+  context->provider()->push<OrderUpdate>(good);
+  strategy.step(context);
+
+  const auto state = execution->get_state();
+  EXPECT_EQ(state.order_id, "o1");
+  EXPECT_TRUE(state.errors.empty());
+}
+
+// Test 6: step() re-fires on every spin tick against the same cached order, so
+// re-processing a rejected order must not accumulate duplicate errors.
+TEST(OrderAcceptanceTest, ReprocessingRejectedOrderDoesNotDuplicateErrors)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  types::Order bad;
+  bad.order_id = "bad";
+  bad.order_update_id = 0;
+  bad.nodes.push_back(make_node("node_0", 0));
+  bad.nodes.push_back(make_node("node_2", 2));  // 2 nodes, 0 edges -> invalid
+
+  context->provider()->push<OrderUpdate>(bad);
+  auto execution = context->get_resource<OrderExecutionResource>();
+
+  strategy.step(context);
+  const size_t after_first = execution->get_state().errors.size();
+  ASSERT_GT(after_first, 0u);
+
+  // Same cached order re-processed on subsequent ticks; error count is stable.
+  strategy.step(context);
+  strategy.step(context);
+
+  EXPECT_EQ(execution->get_state().errors.size(), after_first);
+}
+
+// Test 7: An order update that re-supplies a horizon node's action must not
+// duplicate the corresponding action_state.
+TEST(OrderAcceptanceTest, UpdateDoesNotDuplicateReSuppliedActionStates)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  // Seed a base sitting at node_a (seq 10) with an unreleased horizon node_b
+  // whose action "act_b" is already tracked in action_states.
+  {
+    auto execution = context->get_resource<OrderExecutionResource>();
+    execution->set_executing_order(true);
+    types::State state = execution->get_state();
+    state.order_id = "o1";
+    state.order_update_id = 1;
+    state.last_node_id = "node_a";
+    state.last_node_sequence_id = 10;
+
+    types::NodeState a;
+    a.node_id = "node_a";
+    a.sequence_id = 10;
+    a.released = true;
+    types::NodeState b;
+    b.node_id = "node_b";
+    b.sequence_id = 12;
+    b.released = false;  // horizon
+    state.node_states = {a, b};
+
+    types::ActionState act;
+    act.action_id = "act_b";
+    state.action_states = {act};
+    execution->set_state(std::move(state));
+  }
+
+  // Update re-supplies node_b (now released) carrying the same action act_b.
+  types::Order update;
+  update.order_id = "o1";
+  update.order_update_id = 2;
+  update.nodes.push_back(make_node("node_a", 10));  // re-sent stitch node
+  auto node_b = make_node("node_b", 12);
+  node_b.actions.push_back(make_action("act_b"));
+  update.nodes.push_back(node_b);
+  update.edges.push_back(make_edge("edge_ab", 11, "node_a", "node_b"));
+
+  context->provider()->push<OrderUpdate>(update);
+  strategy.step(context);
+
+  const auto state =
+    context->get_resource<OrderExecutionResource>()->get_state();
+  size_t act_b_count = 0;
+  for (const auto& a : state.action_states)
+  {
+    if (a.action_id == "act_b") ++act_b_count;
+  }
+  EXPECT_EQ(act_b_count, 1u);
+}
+
 }  // namespace

--- a/vda5050_core/test/client/test_order_acceptance.cpp
+++ b/vda5050_core/test/client/test_order_acceptance.cpp
@@ -323,4 +323,83 @@ TEST(OrderAcceptanceTest, UpdateDoesNotDuplicateReSuppliedActionStates)
   EXPECT_EQ(act_b_count, 1u);
 }
 
+// Test 8: A new order must not inherit traversal progress from a previous order.
+// last_node_id / last_node_sequence_id / new_base_request are reset so a later
+// update cannot stitch against a stale anchor.
+TEST(OrderAcceptanceTest, NewOrderResetsCarriedOverTraversalProgress)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  // Seed leftover state from a completed previous order: idle (no nodes, no
+  // pending actions) but still carrying a last-reached node and a base request.
+  {
+    auto execution = context->get_resource<OrderExecutionResource>();
+    types::State state = execution->get_state();
+    state.order_id = "old";
+    state.order_update_id = 7;
+    state.last_node_id = "old_node";
+    state.last_node_sequence_id = 99;
+    state.new_base_request = true;
+    execution->set_state(std::move(state));
+  }
+
+  types::Order fresh;
+  fresh.order_id = "new";
+  fresh.order_update_id = 0;
+  fresh.nodes.push_back(make_node("node_0", 0));
+
+  context->provider()->push<OrderUpdate>(fresh);
+  strategy.step(context);
+
+  const auto state =
+    context->get_resource<OrderExecutionResource>()->get_state();
+  EXPECT_EQ(state.order_id, "new");
+  EXPECT_TRUE(state.last_node_id.empty());
+  EXPECT_EQ(state.last_node_sequence_id, 0u);
+  EXPECT_FALSE(state.new_base_request.has_value());
+}
+
+// Test 9: Rejecting an update while an order is executing must preserve the
+// running base (only errors are updated) and keep the vehicle executing.
+TEST(OrderAcceptanceTest, RejectedUpdatePreservesRunningBase)
+{
+  OrderAcceptance strategy;
+  auto context = make_context();
+
+  // Running order o1 @ update 2, sitting at node_a (seq 10) still in the base.
+  {
+    auto execution = context->get_resource<OrderExecutionResource>();
+    execution->set_executing_order(true);
+    types::State state = execution->get_state();
+    state.order_id = "o1";
+    state.order_update_id = 2;
+    state.last_node_id = "node_a";
+    state.last_node_sequence_id = 10;
+    types::NodeState a;
+    a.node_id = "node_a";
+    a.sequence_id = 10;
+    a.released = true;
+    state.node_states = {a};
+    execution->set_state(std::move(state));
+  }
+
+  // A deprecated update (lower orderUpdateId) is rejected.
+  types::Order stale;
+  stale.order_id = "o1";
+  stale.order_update_id = 1;
+  stale.nodes.push_back(make_node("node_a", 10));
+
+  context->provider()->push<OrderUpdate>(stale);
+  strategy.step(context);
+
+  auto execution = context->get_resource<OrderExecutionResource>();
+  const auto state = execution->get_state();
+  EXPECT_TRUE(execution->is_executing_order());  // still executing
+  EXPECT_EQ(state.order_update_id, 2u);          // base left untouched
+  ASSERT_EQ(state.node_states.size(), 1u);
+  EXPECT_EQ(state.node_states[0].node_id, "node_a");
+  EXPECT_FALSE(state.errors.empty());  // rejection error recorded
+}
+
 }  // namespace

--- a/vda5050_core/test/client/test_order_validator.cpp
+++ b/vda5050_core/test/client/test_order_validator.cpp
@@ -147,22 +147,7 @@ TEST(OrderValidatorTest, RejectsNewOrderWhileBusy)
   EXPECT_EQ(result.errors.front().error_type, "validationError");
 }
 
-// Test 4: Reject a new order whose start node is not reachable.
-TEST(OrderValidatorTest, RejectsUnreachableStartNode)
-{
-  OrderValidator validator;
-  validator.set_reachability_check([](const types::Node&) { return false; });
-  auto context = make_context();
-
-  const auto result =
-    validator.validate_order(single_node_order("new_4", 0), context);
-
-  EXPECT_TRUE(result.rejected());
-  ASSERT_FALSE(result.errors.empty());
-  EXPECT_EQ(result.errors.front().error_type, "validationError");
-}
-
-// Test 5: Accept a valid stitched update onto the active order.
+// Test 4: Accept a valid stitched update onto the active order.
 TEST(OrderValidatorTest, AcceptsValidStitchedUpdate)
 {
   OrderValidator validator;
@@ -181,7 +166,7 @@ TEST(OrderValidatorTest, AcceptsValidStitchedUpdate)
   EXPECT_TRUE(result.accepted());
 }
 
-// Test 6: A non-consecutive (but strictly greater) update id is still valid;
+// Test 5: A non-consecutive (but strictly greater) update id is still valid;
 // VDA5050 does not require updates to increment by exactly one.
 TEST(OrderValidatorTest, AcceptsNonConsecutiveUpdateId)
 {
@@ -199,7 +184,7 @@ TEST(OrderValidatorTest, AcceptsNonConsecutiveUpdateId)
   EXPECT_TRUE(result.accepted());
 }
 
-// Test 7: A duplicate update (same orderUpdateId) is ignored silently.
+// Test 6: A duplicate update (same orderUpdateId) is ignored silently.
 TEST(OrderValidatorTest, IgnoresDuplicateUpdate)
 {
   OrderValidator validator;
@@ -218,7 +203,7 @@ TEST(OrderValidatorTest, IgnoresDuplicateUpdate)
   EXPECT_TRUE(result.errors.empty());
 }
 
-// Test 8: A deprecated update (lower id) is rejected with orderUpdateError
+// Test 7: A deprecated update (lower id) is rejected with orderUpdateError
 // and the previous order is kept -- not silently dropped.
 TEST(OrderValidatorTest, RejectsDeprecatedUpdate)
 {
@@ -238,7 +223,7 @@ TEST(OrderValidatorTest, RejectsDeprecatedUpdate)
   EXPECT_EQ(result.errors.front().error_type, "orderUpdateError");
 }
 
-// Test 9: An update whose stitch node does not match the last base node fails.
+// Test 8: An update whose stitch node does not match the last base node fails.
 TEST(OrderValidatorTest, RejectsStitchNodeMismatch)
 {
   OrderValidator validator;
@@ -255,26 +240,6 @@ TEST(OrderValidatorTest, RejectsStitchNodeMismatch)
   EXPECT_TRUE(result.rejected());
   ASSERT_FALSE(result.errors.empty());
   EXPECT_EQ(result.errors.front().error_type, "orderUpdateError");
-}
-
-// Test 10: Reject fields/actions the AGV cannot process,
-// reporting an orderError carrying the offending errorReferences.
-TEST(OrderValidatorTest, RejectsUnsupportedCapability)
-{
-  OrderValidator validator;
-  validator.set_capability_check([](const types::Order&) {
-    return std::vector<types::ErrorReference>{{"actionType", "nurbs"}};
-  });
-  auto context = make_context();
-
-  const auto result =
-    validator.validate_order(single_node_order("new_11", 0), context);
-
-  EXPECT_TRUE(result.rejected());
-  ASSERT_FALSE(result.errors.empty());
-  EXPECT_EQ(result.errors.front().error_type, "orderError");
-  ASSERT_TRUE(result.errors.front().error_references.has_value());
-  EXPECT_FALSE(result.errors.front().error_references->empty());
 }
 
 }  // namespace

--- a/vda5050_core/test/client/test_order_validator.cpp
+++ b/vda5050_core/test/client/test_order_validator.cpp
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "vda5050_core/client/resources/config.hpp"
+#include "vda5050_core/client/resources/order_execution.hpp"
+#include "vda5050_core/client/strategies/order_validator.hpp"
+#include "vda5050_core/client/updates/order_context.hpp"
+#include "vda5050_core/types/order.hpp"
+
+namespace {
+
+using OrderContext = vda5050_core::client::OrderContext;
+using OrderExecutionResource = vda5050_core::client::OrderExecutionResource;
+using OrderValidator = vda5050_core::client::OrderValidator;
+namespace types = vda5050_core::types;
+
+std::shared_ptr<OrderContext> make_context()
+{
+  auto config = std::make_shared<vda5050_core::client::HeaderConfigResource>(
+    "uagv", "2.0.0", "ROS-I", "S001");
+  auto context = std::make_shared<OrderContext>(config);
+  context->init();
+  return context;
+}
+
+types::Node make_node(const std::string& node_id, uint32_t sequence_id)
+{
+  types::Node node;
+  node.node_id = node_id;
+  node.sequence_id = sequence_id;
+  node.released = true;
+  return node;
+}
+
+types::Edge make_edge(
+  const std::string& edge_id, uint32_t sequence_id,
+  const std::string& start_node_id, const std::string& end_node_id)
+{
+  types::Edge edge;
+  edge.edge_id = edge_id;
+  edge.sequence_id = sequence_id;
+  edge.start_node_id = start_node_id;
+  edge.end_node_id = end_node_id;
+  edge.released = true;
+  return edge;
+}
+
+// A minimal structurally-valid single-node order (node 0, no edges).
+types::Order single_node_order(
+  const std::string& order_id, uint32_t order_update_id)
+{
+  types::Order order;
+  order.order_id = order_id;
+  order.order_update_id = order_update_id;
+  order.nodes.push_back(make_node("node_0", 0));
+  return order;
+}
+
+void seed_execution_state(
+  const std::shared_ptr<OrderContext>& context, const std::string& order_id,
+  uint32_t order_update_id, const std::string& last_node_id,
+  uint32_t last_node_sequence_id,
+  const std::vector<types::NodeState>& node_states = {})
+{
+  auto execution = context->get_resource<OrderExecutionResource>();
+  ASSERT_NE(execution, nullptr);
+  std::lock_guard<std::mutex> lock(execution->mutex_);
+  execution->state.order_id = order_id;
+  execution->state.order_update_id = order_update_id;
+  execution->state.last_node_id = last_node_id;
+  execution->state.last_node_sequence_id = last_node_sequence_id;
+  execution->state.node_states = node_states;
+}
+
+// Test 1: Accept a valid, structurally sound new order.
+TEST(OrderValidatorTest, AcceptsValidNewOrder)
+{
+  OrderValidator validator;
+  auto context = make_context();
+
+  const auto result =
+    validator.validate_order(single_node_order("new_1", 0), context);
+
+  EXPECT_TRUE(result.accepted());
+  EXPECT_TRUE(result.errors.empty());
+}
+
+// Test 2: Reject a structurally invalid order (step 1, reuses is_valid_graph).
+TEST(OrderValidatorTest, RejectsStructurallyInvalidOrder)
+{
+  OrderValidator validator;
+  auto context = make_context();
+
+  // Two nodes but no connecting edge violates edges == nodes - 1.
+  types::Order order;
+  order.order_id = "bad";
+  order.order_update_id = 0;
+  order.nodes.push_back(make_node("node_0", 0));
+  order.nodes.push_back(make_node("node_2", 2));
+
+  const auto result = validator.validate_order(order, context);
+
+  EXPECT_TRUE(result.rejected());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_EQ(result.errors.front().error_type, "graphValidationError");
+}
+
+// Test 3: Reject a new order while the vehicle is still busy.
+TEST(OrderValidatorTest, RejectsNewOrderWhileBusy)
+{
+  OrderValidator validator;
+  auto context = make_context();
+
+  types::NodeState pending;
+  pending.node_id = "node_x";
+  pending.sequence_id = 4;
+  seed_execution_state(context, "active", 1, "node_x", 4, {pending});
+
+  const auto result =
+    validator.validate_order(single_node_order("new_3", 0), context);
+
+  EXPECT_TRUE(result.rejected());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_EQ(result.errors.front().error_type, "validationError");
+}
+
+// Test 4: Reject a new order whose start node is not reachable.
+TEST(OrderValidatorTest, RejectsUnreachableStartNode)
+{
+  OrderValidator validator;
+  validator.set_reachability_check([](const types::Node&) { return false; });
+  auto context = make_context();
+
+  const auto result =
+    validator.validate_order(single_node_order("new_4", 0), context);
+
+  EXPECT_TRUE(result.rejected());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_EQ(result.errors.front().error_type, "validationError");
+}
+
+// Test 5: Accept a valid stitched update onto the active order.
+TEST(OrderValidatorTest, AcceptsValidStitchedUpdate)
+{
+  OrderValidator validator;
+  auto context = make_context();
+  seed_execution_state(context, "active", 1, "node_a", 10);
+
+  types::Order order;
+  order.order_id = "active";
+  order.order_update_id = 2;
+  order.nodes.push_back(make_node("node_a", 10));
+  order.nodes.push_back(make_node("node_b", 12));
+  order.edges.push_back(make_edge("edge_ab", 11, "node_a", "node_b"));
+
+  const auto result = validator.validate_order(order, context);
+
+  EXPECT_TRUE(result.accepted());
+}
+
+// Test 6: A non-consecutive (but strictly greater) update id is still valid;
+// VDA5050 does not require updates to increment by exactly one.
+TEST(OrderValidatorTest, AcceptsNonConsecutiveUpdateId)
+{
+  OrderValidator validator;
+  auto context = make_context();
+  seed_execution_state(context, "active", 1, "node_a", 10);
+
+  types::Order order;
+  order.order_id = "active";
+  order.order_update_id = 4;  // jumps 1 -> 4, no edges needed (single node)
+  order.nodes.push_back(make_node("node_a", 10));
+
+  const auto result = validator.validate_order(order, context);
+
+  EXPECT_TRUE(result.accepted());
+}
+
+// Test 7: A duplicate update (same orderUpdateId) is ignored silently.
+TEST(OrderValidatorTest, IgnoresDuplicateUpdate)
+{
+  OrderValidator validator;
+  auto context = make_context();
+  seed_execution_state(context, "active", 3, "node_a", 10);
+
+  types::Order order;
+  order.order_id = "active";
+  order.order_update_id = 3;
+  order.nodes.push_back(make_node("node_a", 10));
+
+  const auto result = validator.validate_order(order, context);
+
+  EXPECT_TRUE(result.ignored());
+  EXPECT_FALSE(result.accepted());
+  EXPECT_TRUE(result.errors.empty());
+}
+
+// Test 8: A deprecated update (lower id) is rejected with orderUpdateError
+// and the previous order is kept -- not silently dropped.
+TEST(OrderValidatorTest, RejectsDeprecatedUpdate)
+{
+  OrderValidator validator;
+  auto context = make_context();
+  seed_execution_state(context, "active", 5, "node_a", 10);
+
+  types::Order order;
+  order.order_id = "active";
+  order.order_update_id = 2;
+  order.nodes.push_back(make_node("node_a", 10));
+
+  const auto result = validator.validate_order(order, context);
+
+  EXPECT_TRUE(result.rejected());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_EQ(result.errors.front().error_type, "orderUpdateError");
+}
+
+// Test 9: An update whose stitch node does not match the last base node fails.
+TEST(OrderValidatorTest, RejectsStitchNodeMismatch)
+{
+  OrderValidator validator;
+  auto context = make_context();
+  seed_execution_state(context, "active", 1, "node_a", 10);
+
+  types::Order order;
+  order.order_id = "active";
+  order.order_update_id = 2;
+  order.nodes.push_back(make_node("node_z", 10));  // wrong node id
+
+  const auto result = validator.validate_order(order, context);
+
+  EXPECT_TRUE(result.rejected());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_EQ(result.errors.front().error_type, "orderUpdateError");
+}
+
+// Test 10: Reject fields/actions the AGV cannot process,
+// reporting an orderError carrying the offending errorReferences.
+TEST(OrderValidatorTest, RejectsUnsupportedCapability)
+{
+  OrderValidator validator;
+  validator.set_capability_check([](const types::Order&) {
+    return std::vector<types::ErrorReference>{{"actionType", "nurbs"}};
+  });
+  auto context = make_context();
+
+  const auto result =
+    validator.validate_order(single_node_order("new_11", 0), context);
+
+  EXPECT_TRUE(result.rejected());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_EQ(result.errors.front().error_type, "orderError");
+  ASSERT_TRUE(result.errors.front().error_references.has_value());
+  EXPECT_FALSE(result.errors.front().error_references->empty());
+}
+
+}  // namespace

--- a/vda5050_core/test/client/test_order_validator.cpp
+++ b/vda5050_core/test/client/test_order_validator.cpp
@@ -22,24 +22,24 @@
 #include <string>
 #include <vector>
 
+#include "vda5050_core/client/contexts/agv_context.hpp"
 #include "vda5050_core/client/resources/config.hpp"
 #include "vda5050_core/client/resources/order_execution.hpp"
 #include "vda5050_core/client/strategies/order_validator.hpp"
-#include "vda5050_core/client/updates/order_context.hpp"
 #include "vda5050_core/types/order.hpp"
 
 namespace {
 
-using OrderContext = vda5050_core::client::OrderContext;
+using AGVContext = vda5050_core::client::AGVContext;
 using OrderExecutionResource = vda5050_core::client::OrderExecutionResource;
 using OrderValidator = vda5050_core::client::OrderValidator;
 namespace types = vda5050_core::types;
 
-std::shared_ptr<OrderContext> make_context()
+std::shared_ptr<AGVContext> make_context()
 {
   auto config = std::make_shared<vda5050_core::client::HeaderConfigResource>(
     "uagv", "2.0.0", "ROS-I", "S001");
-  auto context = std::make_shared<OrderContext>(config);
+  auto context = std::make_shared<AGVContext>(config);
   context->init();
   return context;
 }
@@ -78,19 +78,20 @@ types::Order single_node_order(
 }
 
 void seed_execution_state(
-  const std::shared_ptr<OrderContext>& context, const std::string& order_id,
+  const std::shared_ptr<AGVContext>& context, const std::string& order_id,
   uint32_t order_update_id, const std::string& last_node_id,
   uint32_t last_node_sequence_id,
   const std::vector<types::NodeState>& node_states = {})
 {
   auto execution = context->get_resource<OrderExecutionResource>();
   ASSERT_NE(execution, nullptr);
-  std::lock_guard<std::mutex> lock(execution->mutex_);
-  execution->state.order_id = order_id;
-  execution->state.order_update_id = order_update_id;
-  execution->state.last_node_id = last_node_id;
-  execution->state.last_node_sequence_id = last_node_sequence_id;
-  execution->state.node_states = node_states;
+  execution->update_state([&](types::State& state) {
+    state.order_id = order_id;
+    state.order_update_id = order_update_id;
+    state.last_node_id = last_node_id;
+    state.last_node_sequence_id = last_node_sequence_id;
+    state.node_states = node_states;
+  });
 }
 
 // Test 1: Accept a valid, structurally sound new order.

--- a/vda5050_core/test/client/test_order_validator.cpp
+++ b/vda5050_core/test/client/test_order_validator.cpp
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "vda5050_core/client/contexts/agv_context.hpp"
@@ -39,7 +40,7 @@ std::shared_ptr<AGVContext> make_context()
 {
   auto config = std::make_shared<vda5050_core::client::HeaderConfigResource>(
     "uagv", "2.0.0", "ROS-I", "S001");
-  auto context = std::make_shared<AGVContext>(config);
+  auto context = AGVContext::make(config);
   context->init();
   return context;
 }
@@ -85,13 +86,13 @@ void seed_execution_state(
 {
   auto execution = context->get_resource<OrderExecutionResource>();
   ASSERT_NE(execution, nullptr);
-  execution->update_state([&](types::State& state) {
-    state.order_id = order_id;
-    state.order_update_id = order_update_id;
-    state.last_node_id = last_node_id;
-    state.last_node_sequence_id = last_node_sequence_id;
-    state.node_states = node_states;
-  });
+  types::State state = execution->get_state();
+  state.order_id = order_id;
+  state.order_update_id = order_update_id;
+  state.last_node_id = last_node_id;
+  state.last_node_sequence_id = last_node_sequence_id;
+  state.node_states = node_states;
+  execution->set_state(std::move(state));
 }
 
 // Test 1: Accept a valid, structurally sound new order.

--- a/vda5050_core/test/client/test_order_validator.cpp
+++ b/vda5050_core/test/client/test_order_validator.cpp
@@ -223,7 +223,61 @@ TEST(OrderValidatorTest, RejectsDeprecatedUpdate)
   EXPECT_EQ(result.errors.front().error_type, "orderUpdateError");
 }
 
-// Test 8: An update whose stitch node does not match the last base node fails.
+// Test 8a: An update is accepted when it stitches at the decision point (the
+// last released base node) even though the AGV has not reached it yet. Here the
+// AGV last reached node_a (seq 10) but node_c (seq 14) is still pending in the
+// released base, so the update must stitch at node_c, not node_a.
+TEST(OrderValidatorTest, AcceptsUpdateStitchedAtBaseEndAheadOfLastReached)
+{
+  OrderValidator validator;
+  auto context = make_context();
+
+  types::NodeState pending_c;
+  pending_c.node_id = "node_c";
+  pending_c.sequence_id = 14;
+  pending_c.released = true;
+  seed_execution_state(context, "active", 1, "node_a", 10, {pending_c});
+
+  types::Order order;
+  order.order_id = "active";
+  order.order_update_id = 2;
+  order.nodes.push_back(
+    make_node("node_c", 14));  // stitch at the decision point
+  order.nodes.push_back(make_node("node_d", 16));
+  order.edges.push_back(make_edge("edge_cd", 15, "node_c", "node_d"));
+
+  const auto result = validator.validate_order(order, context);
+
+  EXPECT_TRUE(result.accepted());
+}
+
+// Test 8b: With a released base node still pending ahead of the last reached
+// node, stitching at the last reached node (instead of the decision point) is
+// rejected.
+TEST(OrderValidatorTest, RejectsUpdateStitchedAtLastReachedWhenBaseStillPending)
+{
+  OrderValidator validator;
+  auto context = make_context();
+
+  types::NodeState pending_c;
+  pending_c.node_id = "node_c";
+  pending_c.sequence_id = 14;
+  pending_c.released = true;
+  seed_execution_state(context, "active", 1, "node_a", 10, {pending_c});
+
+  types::Order order;
+  order.order_id = "active";
+  order.order_update_id = 2;
+  order.nodes.push_back(make_node("node_a", 10));  // stale anchor, not base end
+
+  const auto result = validator.validate_order(order, context);
+
+  EXPECT_TRUE(result.rejected());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_EQ(result.errors.front().error_type, "orderUpdateError");
+}
+
+// Test 9: An update whose stitch node does not match the last base node fails.
 TEST(OrderValidatorTest, RejectsStitchNodeMismatch)
 {
   OrderValidator validator;


### PR DESCRIPTION
> **Stacked PR** — depends on https://github.com/ros-industrial/vda5050_core/pull/62
Please review / merge in order: https://github.com/ros-industrial/vda5050_core/pull/62 → this PR.

## Summary
Implements the AGV-side order acceptance flow. Processes inbound orders from the `OrderContext`, runs the accept/reject/ignore decision and applies the result to the execution state.

## What's Included
### Strategies
* **OrderValidator** — Handles the validation decision and returns `AcceptanceResult {outcome, errors}` where outcome is one of the `{Accepted, Rejected, Ignored}`:
    - **Structural validity** — validates the order graph structure (Node -> Edge -> Node -> Edge)
    - **New vs Update order detection** — compares `orderId` against the active order
    - **Busy/horizon check** — rejects a new order while the vehicle is still executing or holding non-finished/failed actions
    - **Deprecated update** — lower `orderUpdateId` -> `orderUpdateError`, while keeping previous order
    - **Duplicate update** — equal orderUpdateId is ignored without changing execution state
    - **Stitch continuity** — update's first node must match the current decision point / end of the released base
    - **Future checks** — TODOs are left for AGV capability/factsheet validation and start-node reachability once the required data is available
              
* **OrderAcceptance** — Applies the validator decision. `step()` pulls the latest `OrderUpdate` from the context, runs the validator and updates the execution resource:
    - **Accepted (new order)** — populate `node_states`/ `edge_states` / `action_states`, set order ids and mark `executing_order`
    - **Accepted (old order -> update)** — drop the old horizon, append the new states, bump id
    - **Rejected** — record the errors in `state.errors`
    - **Ignored** — no-op for duplicate resend

### Errors
* **error_codes** — adds shared error/reference constants used by the order acceptance flow such as `validationError`, `orderError`

### Tests
* **OrderValidatorTest** — covers structural reject, busy reject, valid stitch update, duplicate update, deprecated update, empty update and stitch mismatch
* **OrderAcceptanceTest** — covers new order state population, invalid order error recording, order update appending, duplicate ignored behaviour

### Notes
- Reachability, capability hooks and protocol limit checks were not added in this PR to keep the scope focused on the core order acceptance flow.
- TODOs were left for future AGV-specific checks once map, position, factsheet and capability context are available.