### PR TITLE
refactor(client): move context and resource implementations to source file

### DIFF
--- a/vda5050_core/include/vda5050_core/client/contexts/agv_context.hpp
+++ b/vda5050_core/include/vda5050_core/client/contexts/agv_context.hpp
@@ -21,14 +21,11 @@
 
 #include <memory>
 #include <mutex>
-#include <stdexcept>
 #include <typeindex>
 #include <unordered_map>
 #include <utility>
 
 #include "vda5050_core/client/resources/config.hpp"
-#include "vda5050_core/client/resources/order_execution.hpp"
-#include "vda5050_core/client/updates/order.hpp"
 #include "vda5050_core/execution/context_interface.hpp"
 
 namespace vda5050_core {
@@ -80,15 +77,7 @@ protected:
 
 private:
   /// \brief Private constructor; use make() to obtain a shared_ptr instance.
-  explicit AGVContext(std::shared_ptr<HeaderConfigResource> config)
-  {
-    if (!config)
-    {
-      throw std::invalid_argument("AGVContext: config cannot be nullptr");
-    }
-    cache_resource(std::move(config));
-    cache_resource(std::make_shared<OrderExecutionResource>());
-  }
+  explicit AGVContext(std::shared_ptr<HeaderConfigResource> config);
 
   // Thread-safe internal layout caches
   void cache_update(std::shared_ptr<execution::UpdateBase> update);

--- a/vda5050_core/include/vda5050_core/client/resources/order_execution.hpp
+++ b/vda5050_core/include/vda5050_core/client/resources/order_execution.hpp
@@ -20,7 +20,6 @@
 #define VDA5050_CORE__CLIENT__RESOURCES__ORDER_EXECUTION_HPP_
 
 #include <mutex>
-#include <utility>
 
 #include "vda5050_core/execution/base.hpp"
 #include "vda5050_core/types/state.hpp"
@@ -35,46 +34,22 @@ class OrderExecutionResource
 {
 public:
   /// \brief Whether the AGV is actively executing an order.
-  bool is_executing_order() const
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return executing_order_;
-  }
+  bool is_executing_order() const;
 
   /// \brief Set whether the AGV is actively executing an order.
-  void set_executing_order(bool executing)
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    executing_order_ = executing;
-  }
+  void set_executing_order(bool executing);
 
   /// \brief Whether the AGV is waiting for a base extension from the master.
-  bool is_awaiting_order_update() const
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return awaiting_order_update_;
-  }
+  bool is_awaiting_order_update() const;
 
   /// \brief Set whether the AGV is waiting for a base extension.
-  void set_awaiting_order_update(bool awaiting)
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    awaiting_order_update_ = awaiting;
-  }
+  void set_awaiting_order_update(bool awaiting);
 
   /// \brief Return a copy of the full working state snapshot.
-  types::State get_state() const
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return state_;
-  }
+  types::State get_state() const;
 
   /// \brief Replace the full working state snapshot.
-  void set_state(types::State state)
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    state_ = std::move(state);
-  }
+  void set_state(types::State state);
 
 private:
   /// \brief Serialises concurrent reads and writes to the members below.

--- a/vda5050_core/src/client/contexts/agv_context.cpp
+++ b/vda5050_core/src/client/contexts/agv_context.cpp
@@ -19,13 +19,26 @@
 #include "vda5050_core/client/contexts/agv_context.hpp"
 
 #include <memory>
+#include <stdexcept>
 #include <typeindex>
+#include <utility>
 
+#include "vda5050_core/client/resources/order_execution.hpp"
 #include "vda5050_core/client/updates/order.hpp"
 
 namespace vda5050_core {
 
 namespace client {
+
+AGVContext::AGVContext(std::shared_ptr<HeaderConfigResource> config)
+{
+  if (!config)
+  {
+    throw std::invalid_argument("AGVContext: config cannot be nullptr");
+  }
+  cache_resource(std::move(config));
+  cache_resource(std::make_shared<OrderExecutionResource>());
+}
 
 void AGVContext::init()
 {

--- a/vda5050_core/src/client/resources/order_execution.cpp
+++ b/vda5050_core/src/client/resources/order_execution.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vda5050_core/client/resources/order_execution.hpp"
+
+#include <mutex>
+#include <utility>
+
+namespace vda5050_core {
+
+namespace client {
+
+bool OrderExecutionResource::is_executing_order() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return executing_order_;
+}
+
+void OrderExecutionResource::set_executing_order(bool executing)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  executing_order_ = executing;
+}
+
+bool OrderExecutionResource::is_awaiting_order_update() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return awaiting_order_update_;
+}
+
+void OrderExecutionResource::set_awaiting_order_update(bool awaiting)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  awaiting_order_update_ = awaiting;
+}
+
+types::State OrderExecutionResource::get_state() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return state_;
+}
+
+void OrderExecutionResource::set_state(types::State state)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  state_ = std::move(state);
+}
+
+}  // namespace client
+}  // namespace vda5050_core


### PR DESCRIPTION
## Summary
- Move `AGVContext` constructor/private helper implementations from header to source file
- Move `OrderExecutionResource` method implementations from header to source file
- Keep headers focused on declarations