### PR TITLE
feat(windows): add initial Windows support

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,11 +48,17 @@ jobs:
       - name: Start MQTT broker (mosquitto)
         shell: pwsh
         run: |
-          choco install mosquitto --no-progress -y
+          # The Chocolatey 'mosquitto' package was delisted, so install from the
+          # official mosquitto.org installer (silent /S, default install dir).
+          $ver = "2.0.20"
+          $url = "https://mosquitto.org/files/binary/win64/mosquitto-$ver-install-windows-x64.exe"
+          $installer = "$env:RUNNER_TEMP\mosquitto-install.exe"
+          Invoke-WebRequest -Uri $url -OutFile $installer
+          Start-Process -FilePath $installer -ArgumentList "/S" -Wait
+          $dir = "C:\Program Files\mosquitto"
           # mosquitto 2.x denies anonymous access and needs an explicit listener.
-          "listener 1883`nallow_anonymous true" | Out-File -Encoding ascii mosquitto.conf
-          $exe = "C:\Program Files\mosquitto\mosquitto.exe"
-          Start-Process -FilePath $exe -ArgumentList "-c", "$PWD\mosquitto.conf"
+          "listener 1883`nallow_anonymous true" | Out-File -Encoding ascii "$dir\mosquitto.conf"
+          Start-Process -FilePath "$dir\mosquitto.exe" -ArgumentList "-c", "$dir\mosquitto.conf"
           Start-Sleep -Seconds 2
 
       - name: Test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,42 @@
+name: Build and test on native Windows
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  windows:
+    name: Windows (MSVC + vcpkg)
+    runs-on: windows-latest
+    env:
+      # The library lives in the vda5050_core/ subdirectory of the repository.
+      SOURCE_DIR: vda5050_core
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure (CMake + vcpkg manifest)
+        shell: pwsh
+        run: |
+          cmake -S "$env:SOURCE_DIR" -B build `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Start MQTT broker (mosquitto)
+        shell: pwsh
+        run: |
+          choco install mosquitto --no-progress -y
+          # mosquitto 2.x denies anonymous access and needs an explicit listener.
+          "listener 1883`nallow_anonymous true" | Out-File -Encoding ascii mosquitto.conf
+          $exe = "C:\Program Files\mosquitto\mosquitto.exe"
+          Start-Process -FilePath $exe -ArgumentList "-c", "$PWD\mosquitto.conf"
+          Start-Sleep -Seconds 2
+
+      - name: Test
+        run: ctest --test-dir build -C Release --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,8 +15,25 @@ jobs:
     env:
       # The library lives in the vda5050_core/ subdirectory of the repository.
       SOURCE_DIR: vda5050_core
+      # vcpkg stores built packages here; actions/cache persists it across runs
+      # so paho/fmt/nlohmann-json/gtest are restored instead of recompiled.
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg-bincache
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache vcpkg binary packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          # Invalidate when the manifest changes; fall back to the latest cache.
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('vda5050_core/vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-
+
+      # vcpkg requires VCPKG_DEFAULT_BINARY_CACHE to be an existing directory.
+      - name: Create binary cache directory
+        shell: pwsh
+        run: New-Item -ItemType Directory -Force -Path "$env:VCPKG_DEFAULT_BINARY_CACHE" | Out-Null
 
       - name: Configure (CMake + vcpkg manifest)
         shell: pwsh

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -1,15 +1,34 @@
 cmake_minimum_required(VERSION 3.8)
-project(vda5050_core)
+project(vda5050_core VERSION 0.0.0)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
+elseif(MSVC)
+  # /bigobj: template-heavy deps (nlohmann_json, fmt, gmock) exceed MSVC's 64k
+  #          section limit per object (fatal C1128).
+  # /utf-8:  treat source/exec charset as UTF-8 instead of the system code page.
+  add_compile_options(/bigobj /utf-8)
+  # NOMINMAX: stop <windows.h> defining min/max macros that clash with
+  #           std::min/max and std::numeric_limits<>::max().
+  # _CRT_SECURE_NO_WARNINGS: silence C4996 "insecure" CRT deprecation warnings.
+  add_compile_definitions(NOMINMAX _CRT_SECURE_NO_WARNINGS)
 endif()
 
-find_package(ament_cmake REQUIRED)
+# Export all symbols from the shared libraries on Windows so consumers can link
+# against the DLLs without per-symbol __declspec annotations. No-op elsewhere.
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+# Windows has no RPATH: co-locate the DLLs with the executables that load them
+# (examples and tests) so they resolve at run time. Harmless on other platforms.
+if(WIN32)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+endif()
+
 find_package(PahoMqttCpp REQUIRED)
 find_package(fmt REQUIRED)
 find_package(nlohmann_json REQUIRED)
@@ -235,15 +254,31 @@ install(
   RUNTIME DESTINATION bin
 )
 
-ament_export_targets(export_${PROJECT_NAME}
-  HAS_LIBRARY_TARGET
+# Export the targets and generate a plain CMake package config so consumers can
+# `find_package(vda5050_core)` and link `vda5050_core::<component>`.
+install(EXPORT export_${PROJECT_NAME}
   NAMESPACE ${PROJECT_NAME}::
+  DESTINATION lib/cmake/${PROJECT_NAME}
+  FILE ${PROJECT_NAME}Targets.cmake
 )
-ament_export_dependencies(PahoMqttCpp fmt nlohmann_json)
 
-if(ENABLE_ROS2)
-  ament_export_dependencies(vda5050_interfaces)
-endif()
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  cmake/vda5050_ament_lint_common.cmake
+  DESTINATION lib/cmake/${PROJECT_NAME}
+)
 
 option(BUILD_EXAMPLES "Build examples" ON)
 
@@ -284,47 +319,54 @@ endif()
 option(BUILD_TESTING "Build tests" ON)
 
 if(BUILD_TESTING)
-  include(cmake/vda5050_ament_lint_common.cmake)
-  vda5050_ament_lint_common()
+  enable_testing()
 
-  find_package(ament_cmake_gmock REQUIRED)
+  # In a ROS 2 dev environment, keep the ament linters and register tests with
+  # the ament backends (selected inside vda5050_add_gtest/gmock by the
+  # ament_cmake_g{test,mock}_FOUND variables set here).
+  find_package(ament_cmake_gtest QUIET)
+  find_package(ament_cmake_gmock QUIET)
+  if(ament_cmake_gmock_FOUND)
+    include(cmake/vda5050_ament_lint_common.cmake)
+    vda5050_ament_lint_common()
+  endif()
+
+  include(cmake/vda5050_add_gtest.cmake)
+  include(cmake/vda5050_add_gmock.cmake)
 
   set(json_tests test/json_utils/test_json_utils.cpp)
   if(ENABLE_ROS2)
     list(APPEND json_tests test/json_utils/test_json_utils_ros2.cpp)
   endif()
-  ament_add_gmock(test_json_utils ${json_tests})
+  vda5050_add_gtest(test_json_utils ${json_tests})
   target_link_libraries(test_json_utils vda5050_core::json_utils)
 
-  ament_add_gmock(test_order_utils
+  vda5050_add_gtest(test_order_utils
     test/order_utils/test_unit_order_graph_validator.cpp)
   target_link_libraries(test_order_utils vda5050_core::order_utils)
 
-  ament_add_gmock(test_logger
+  vda5050_add_gtest(test_logger
     test/logger/test_unit_default_logger.cpp
     test/logger/test_unit_logger.cpp
   )
   target_link_libraries(test_logger vda5050_core::logger)
 
-  ament_add_gmock(test_transport
+  vda5050_add_gmock(test_transport
     test/transport/test_unit_mqtt_client_interface.cpp
     test/transport/test_integration_paho_mqtt_client.cpp
   )
   target_link_libraries(test_transport vda5050_core::transport)
 
-  ament_add_gmock(test_client
+  vda5050_add_gmock(test_client
     test/client/test_order_types.cpp
     test/client/test_order_execution_resource.cpp
     test/client/test_agv_context.cpp
     test/client/test_order_validator.cpp
     test/client/test_order_acceptance.cpp
   )
+  target_link_libraries(test_client vda5050_core::client)
 
-  target_link_libraries(test_client
-    vda5050_core::client
-  )
-
-  ament_add_gmock(test_execution
+  vda5050_add_gmock(test_execution
     test/execution/test_engine.cpp
     test/execution/test_event_queue.cpp
     test/execution/test_handler.cpp
@@ -333,7 +375,7 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_execution vda5050_core::execution)
 
-  ament_add_gmock(test_master
+  vda5050_add_gmock(test_master
     test/master/test_integration_heartbeat.cpp
     test/master/test_integration_master_logic.cpp
     test/master/test_integration_master_mqtt.cpp
@@ -342,28 +384,17 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_master vda5050_core::master)
 
-  ament_add_gmock(test_layout_loader
+  vda5050_add_gtest(test_layout_loader
     test/layout/test_unit_loader.cpp
   )
   target_link_libraries(test_layout_loader vda5050_core::layout)
   target_compile_definitions(test_layout_loader PRIVATE
     VDA5050_CORE__SAMPLE_LAYOUT_PATH="${CMAKE_CURRENT_SOURCE_DIR}/test/layout/data/sample_layout.json")
 
-  ament_add_gmock(test_layout_graph
+  vda5050_add_gtest(test_layout_graph
     test/layout/test_unit_graph.cpp
   )
   target_link_libraries(test_layout_graph vda5050_core::layout)
   target_compile_definitions(test_layout_graph PRIVATE
     VDA5050_CORE__SAMPLE_LAYOUT_PATH="${CMAKE_CURRENT_SOURCE_DIR}/test/layout/data/sample_layout.json")
 endif()
-
-# Install linter macro
-install(
-  FILES
-    cmake/vda5050_ament_lint_common.cmake
-  DESTINATION share/${PROJECT_NAME}/cmake
-)
-
-ament_package(
-  CONFIG_EXTRAS "vda5050_core-extras.cmake"
-)

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -148,6 +148,12 @@ target_include_directories(vda5050_transport
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+# The shared paho-mqttpp3 DLL on Windows needs PAHO_MQTTPP_IMPORTS so its headers
+# declare symbols as dllimport; the vcpkg target does not propagate it
+# (microsoft/vcpkg#52261). PUBLIC because paho_mqtt_client.hpp exposes mqtt types.
+if(WIN32)
+  target_compile_definitions(vda5050_transport PUBLIC PAHO_MQTTPP_IMPORTS)
+endif()
 
 # Execution
 file(GLOB_RECURSE execution_srcs "src/execution/*.cpp")

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -255,16 +255,16 @@ install(
     vda5050_layout
     vda5050_master
   EXPORT export_${PROJECT_NAME}
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 # Export the targets and generate a plain CMake package config so consumers can
 # `find_package(vda5050_core)` and link `vda5050_core::<component>`.
 install(EXPORT export_${PROJECT_NAME}
   NAMESPACE ${PROJECT_NAME}::
-  DESTINATION lib/cmake/${PROJECT_NAME}
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
   FILE ${PROJECT_NAME}Targets.cmake
 )
 
@@ -272,7 +272,7 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-  INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
@@ -283,7 +283,7 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
   cmake/vda5050_ament_lint_common.cmake
-  DESTINATION lib/cmake/${PROJECT_NAME}
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
 option(BUILD_EXAMPLES "Build examples" ON)
@@ -318,7 +318,7 @@ if(BUILD_EXAMPLES)
       provider_example
       engine_example
       handler_integration
-    DESTINATION lib/${PROJECT_NAME}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}
   )
 endif()
 

--- a/vda5050_core/CMakePresets.json
+++ b/vda5050_core/CMakePresets.json
@@ -1,0 +1,58 @@
+﻿{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "windows-base",
+      "description": "Target Windows with the Visual Studio development environment.",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl.exe",
+        "CMAKE_CXX_COMPILER": "cl.exe",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "x64-debug",
+      "displayName": "x64 Debug",
+      "description": "Target Windows (64-bit) with the Visual Studio development environment. (Debug)",
+      "inherits": "windows-base",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    },
+    {
+      "name": "x64-release",
+      "displayName": "x64 Release",
+      "description": "Target Windows (64-bit) with the Visual Studio development environment. (RelWithDebInfo)",
+      "inherits": "x64-debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "x86-debug",
+      "displayName": "x86 Debug",
+      "description": "Target Windows (32-bit) with the Visual Studio development environment. (Debug)",
+      "inherits": "windows-base",
+      "architecture": {
+        "value": "x86",
+        "strategy": "external"
+      },
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    },
+    {
+      "name": "x86-release",
+      "displayName": "x86 Release",
+      "description": "Target Windows (32-bit) with the Visual Studio development environment. (RelWithDebInfo)",
+      "inherits": "x86-debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
+    }
+  ]
+}

--- a/vda5050_core/cmake/vda5050_add_gmock.cmake
+++ b/vda5050_core/cmake/vda5050_add_gmock.cmake
@@ -1,0 +1,46 @@
+# Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+# Advanced Remanufacturing and Technology Centre
+# A*STAR Research Entities (Co. Registration No. 199702110H)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Dual-mode gmock test registration for VDA5050.
+#
+# Drop-in replacement for ament_add_gmock(<target> <sources...>): link the test
+# against its libraries with a normal target_link_libraries() call afterwards.
+#
+# When ament_cmake_gmock is available (the caller is expected to have run
+# find_package(ament_cmake_gmock) so ament_cmake_gmock_FOUND is set), tests
+# register via ament_add_gmock for `colcon test`. Otherwise they fall back to
+# upstream GoogleTest (gmock + gtest + main via GTest::gmock_main).
+#
+# Each executable is registered as a single ctest entry (matching the ament
+# behaviour), so the gtest cases within it run serially -- important for the
+# integration tests that share a single MQTT broker.
+#
+# vda5050_add_gmock(<target> <source> [<source> ...])
+#
+function(vda5050_add_gmock target)
+  if(ament_cmake_gmock_FOUND)
+    ament_add_gmock(${target} ${ARGN})
+  else()
+    # Find GoogleTest on first use.
+    if(NOT GTest_FOUND)
+      find_package(GTest REQUIRED)
+    endif()
+    add_executable(${target} ${ARGN})
+    target_link_libraries(${target} GTest::gmock_main)
+    add_test(NAME ${target} COMMAND ${target})
+  endif()
+endfunction()

--- a/vda5050_core/cmake/vda5050_add_gtest.cmake
+++ b/vda5050_core/cmake/vda5050_add_gtest.cmake
@@ -1,0 +1,46 @@
+# Copyright (C) 2026 ROS-Industrial Consortium Asia Pacific
+# Advanced Remanufacturing and Technology Centre
+# A*STAR Research Entities (Co. Registration No. 199702110H)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Dual-mode gtest test registration for VDA5050.
+#
+# Drop-in replacement for ament_add_gtest(<target> <sources...>): link the test
+# against its libraries with a normal target_link_libraries() call afterwards.
+#
+# When ament_cmake_gtest is available (the caller is expected to have run
+# find_package(ament_cmake_gtest) so ament_cmake_gtest_FOUND is set), tests
+# register via ament_add_gtest for `colcon test`. Otherwise they fall back to
+# upstream GoogleTest (gtest + main via GTest::gtest_main).
+#
+# Each executable is registered as a single ctest entry (matching the ament
+# behaviour), so the gtest cases within it run serially -- important for the
+# integration tests that share a single MQTT broker.
+#
+# vda5050_add_gtest(<target> <source> [<source> ...])
+#
+function(vda5050_add_gtest target)
+  if(ament_cmake_gtest_FOUND)
+    ament_add_gtest(${target} ${ARGN})
+  else()
+    # Find GoogleTest on first use.
+    if(NOT GTest_FOUND)
+      find_package(GTest REQUIRED)
+    endif()
+    add_executable(${target} ${ARGN})
+    target_link_libraries(${target} GTest::gtest_main)
+    add_test(NAME ${target} COMMAND ${target})
+  endif()
+endfunction()

--- a/vda5050_core/cmake/vda5050_coreConfig.cmake.in
+++ b/vda5050_core/cmake/vda5050_coreConfig.cmake.in
@@ -1,0 +1,14 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(PahoMqttCpp)
+find_dependency(fmt)
+find_dependency(nlohmann_json)
+
+include("${CMAKE_CURRENT_LIST_DIR}/vda5050_coreTargets.cmake")
+
+# Expose the vda5050_ament_lint_common() command to consumers (when shipped).
+include("${CMAKE_CURRENT_LIST_DIR}/vda5050_ament_lint_common.cmake" OPTIONAL)
+
+check_required_components(vda5050_core)

--- a/vda5050_core/include/vda5050_core/compat/time_utils.hpp
+++ b/vda5050_core/include/vda5050_core/compat/time_utils.hpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2025 ROS-Industrial Consortium Asia Pacific
+ * Advanced Remanufacturing and Technology Centre
+ * A*STAR Research Entities (Co. Registration No. 199702110H)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VDA5050_CORE__COMPAT__TIME_UTILS_HPP_
+#define VDA5050_CORE__COMPAT__TIME_UTILS_HPP_
+
+#include <ctime>
+
+namespace vda5050_core {
+
+namespace compat {
+
+/// \brief Portable wrapper around the POSIX `gmtime_r` / Windows `gmtime_s`.
+///
+/// Converts a `std::time_t` to a broken-down UTC `std::tm` using the
+/// thread-safe variant available on the current platform.
+///
+/// \param time Seconds since the Unix epoch
+/// \return Broken-down time in UTC
+inline std::tm to_gmtime(std::time_t time)
+{
+  std::tm result{};
+#if defined(_WIN32)
+  gmtime_s(&result, &time);
+#else
+  gmtime_r(&time, &result);
+#endif
+  return result;
+}
+
+/// \brief Portable wrapper around the POSIX `localtime_r` / Windows
+/// `localtime_s`.
+///
+/// Converts a `std::time_t` to a broken-down local `std::tm` using the
+/// thread-safe variant available on the current platform.
+///
+/// \param time Seconds since the Unix epoch
+/// \return Broken-down time in local time
+inline std::tm to_localtime(std::time_t time)
+{
+  std::tm result{};
+#if defined(_WIN32)
+  localtime_s(&result, &time);
+#else
+  localtime_r(&time, &result);
+#endif
+  return result;
+}
+
+/// \brief Portable wrapper around the POSIX `timegm` / Windows `_mkgmtime`.
+///
+/// Converts a broken-down UTC `std::tm` back to a `std::time_t`, interpreting
+/// the fields as UTC (unlike `std::mktime`, which uses local time).
+///
+/// \param tm Broken-down time in UTC; may be normalised in place
+/// \return Seconds since the Unix epoch
+inline std::time_t timegm_utc(std::tm* tm)
+{
+#if defined(_WIN32)
+  return _mkgmtime(tm);
+#else
+  return timegm(tm);
+#endif
+}
+
+}  // namespace compat
+}  // namespace vda5050_core
+
+#endif  // VDA5050_CORE__COMPAT__TIME_UTILS_HPP_

--- a/vda5050_core/include/vda5050_core/execution/base.hpp
+++ b/vda5050_core/include/vda5050_core/execution/base.hpp
@@ -43,9 +43,13 @@ struct ResourceBase : public Base
 template <typename DerivedT, typename BaseT>
 struct Initialize : public BaseT
 {
-  static inline const std::type_index type = std::type_index(typeid(DerivedT));
   std::type_index get_type() const override
   {
+    // Computed once and cached (as before), but as a function-local static so
+    // typeid(DerivedT) lives in a deferred function body. A static *member*
+    // initializer is instantiated eagerly by MSVC while DerivedT is still an
+    // incomplete CRTP base, which fails with error C2027.
+    static const std::type_index type = std::type_index(typeid(DerivedT));
     return type;
   }
 };

--- a/vda5050_core/include/vda5050_core/json_utils/traits.hpp
+++ b/vda5050_core/include/vda5050_core/json_utils/traits.hpp
@@ -30,6 +30,7 @@
 #include <utility>
 #include <vector>
 
+#include "vda5050_core/compat/time_utils.hpp"
 #include "vda5050_core/types/action_scope.hpp"
 #include "vda5050_core/types/action_status.hpp"
 #include "vda5050_core/types/agv_class.hpp"
@@ -185,8 +186,7 @@ inline std::string to_iso8601(TimePoint time_point)
   auto duration = time_point.time_since_epoch();
   auto millisec = duration_cast<milliseconds>(duration).count() % 1000;
 
-  std::tm tm_buf;
-  gmtime_r(&time_sec, &tm_buf);
+  std::tm tm_buf = compat::to_gmtime(time_sec);
 
   std::ostringstream oss;
   oss << std::put_time(&tm_buf, types::ISO8601_FORMAT);
@@ -241,8 +241,7 @@ inline TimePoint from_iso8601(const std::string& time_string)
     }
   }
 
-  // TODO(sauk): Add a check to see if the platform supports timegm
-  auto tp = system_clock::from_time_t(timegm(&t));
+  auto tp = system_clock::from_time_t(compat::timegm_utc(&t));
 
   return tp + milliseconds(millisec);
 }

--- a/vda5050_core/include/vda5050_core/logger/logger.hpp
+++ b/vda5050_core/include/vda5050_core/logger/logger.hpp
@@ -19,7 +19,7 @@
 #ifndef VDA5050_CORE__LOGGER__LOGGER_HPP_
 #define VDA5050_CORE__LOGGER__LOGGER_HPP_
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/vda5050_core/src/logger/logger.cpp
+++ b/vda5050_core/src/logger/logger.cpp
@@ -23,6 +23,8 @@
 #include <iostream>
 #include <mutex>
 
+#include "vda5050_core/compat/time_utils.hpp"
+
 namespace vda5050_core {
 
 namespace logger {
@@ -40,8 +42,7 @@ public:
   {
     auto now = std::chrono::system_clock::now();
     std::time_t now_t = std::chrono::system_clock::to_time_t(now);
-    std::tm localtime;
-    localtime_r(&now_t, &localtime);
+    std::tm localtime = compat::to_localtime(now_t);
 
     std::cout << "[" << fmt::format("{:%Y-%m-%d %H:%M:%S}", localtime) << "]"
               << to_log_level_string(level) << ": " << message << std::endl;

--- a/vda5050_core/test/json_utils/generator/generator.hpp
+++ b/vda5050_core/test/json_utils/generator/generator.hpp
@@ -202,7 +202,9 @@ public:
   /// \brief Generate a random index for enum selection
   uint8_t generate_random_index(size_t size)
   {
-    std::uniform_int_distribution<uint8_t> index_dist(0, size - 1);
+    // uniform_int_distribution does not permit char-sized types (MSVC enforces
+    // this); use int and narrow on return.
+    std::uniform_int_distribution<int> index_dist(0, static_cast<int>(size) - 1);
     return index_dist(rng_);
   }
 
@@ -864,8 +866,9 @@ private:
   /// \brief Distribution for unsigned 32-bit integers
   std::uniform_int_distribution<uint32_t> uint_dist_;
 
-  /// \brief Distribution for signed 8-bit integers
-  std::uniform_int_distribution<int8_t> int_dist_;
+  /// \brief Distribution for signed 8-bit integers (int-typed; char-sized
+  /// distribution types are not permitted by the standard / MSVC)
+  std::uniform_int_distribution<int> int_dist_;
 
   /// \brief Distribution for 64-bit floating-point numbers
   std::uniform_real_distribution<double> float_dist_;
@@ -876,8 +879,9 @@ private:
   /// \brief Distribution for random string lengths
   std::uniform_int_distribution<int> string_length_dist_;
 
-  /// \brief Distribution for random vector size
-  std::uniform_int_distribution<uint8_t> size_dist_;
+  /// \brief Distribution for random vector size (int-typed; char-sized
+  /// distribution types are not permitted by the standard / MSVC)
+  std::uniform_int_distribution<int> size_dist_;
 
   /// \brief Distribution for random percentage values
   std::uniform_real_distribution<double> percentage_dist_;

--- a/vda5050_core/test/json_utils/generator/generator.hpp
+++ b/vda5050_core/test/json_utils/generator/generator.hpp
@@ -204,7 +204,8 @@ public:
   {
     // uniform_int_distribution does not permit char-sized types (MSVC enforces
     // this); use int and narrow on return.
-    std::uniform_int_distribution<int> index_dist(0, static_cast<int>(size) - 1);
+    std::uniform_int_distribution<int> index_dist(
+      0, static_cast<int>(size) - 1);
     return index_dist(rng_);
   }
 

--- a/vda5050_core/test/json_utils/generator/generator_ros2.hpp
+++ b/vda5050_core/test/json_utils/generator/generator_ros2.hpp
@@ -183,7 +183,9 @@ public:
   /// \brief Generate a random index for enum selection
   uint8_t generate_random_index(size_t size)
   {
-    std::uniform_int_distribution<uint8_t> index_dist(0, size - 1);
+    // uniform_int_distribution does not permit char-sized types (MSVC enforces
+    // this); use int and narrow on return.
+    std::uniform_int_distribution<int> index_dist(0, static_cast<int>(size) - 1);
     return index_dist(rng_);
   }
 
@@ -879,8 +881,9 @@ private:
   /// \brief Distribution for unsigned 32-bit integers
   std::uniform_int_distribution<uint32_t> uint_dist_;
 
-  /// \brief Distribution for signed 8-bit integers
-  std::uniform_int_distribution<int8_t> int_dist_;
+  /// \brief Distribution for signed 8-bit integers (int-typed; char-sized
+  /// distribution types are not permitted by the standard / MSVC)
+  std::uniform_int_distribution<int> int_dist_;
 
   /// \brief Distribution for 64-bit floating-point numbers
   std::uniform_real_distribution<double> float_dist_;
@@ -894,8 +897,9 @@ private:
   /// \brief Distribution for milliseconds from epoch
   std::uniform_int_distribution<int64_t> milliseconds_dist_;
 
-  /// \brief Distribution for random vector size
-  std::uniform_int_distribution<uint8_t> size_dist_;
+  /// \brief Distribution for random vector size (int-typed; char-sized
+  /// distribution types are not permitted by the standard / MSVC)
+  std::uniform_int_distribution<int> size_dist_;
 
   /// \brief Distribution for random percentage values
   std::uniform_real_distribution<double> percentage_dist_;

--- a/vda5050_core/test/json_utils/generator/generator_ros2.hpp
+++ b/vda5050_core/test/json_utils/generator/generator_ros2.hpp
@@ -185,7 +185,8 @@ public:
   {
     // uniform_int_distribution does not permit char-sized types (MSVC enforces
     // this); use int and narrow on return.
-    std::uniform_int_distribution<int> index_dist(0, static_cast<int>(size) - 1);
+    std::uniform_int_distribution<int> index_dist(
+      0, static_cast<int>(size) - 1);
     return index_dist(rng_);
   }
 

--- a/vda5050_core/test/layout/test_unit_loader.cpp
+++ b/vda5050_core/test/layout/test_unit_loader.cpp
@@ -16,7 +16,11 @@
  * limitations under the License.
  */
 
+#if defined(_WIN32)
+#include <process.h>
+#else
 #include <unistd.h>
+#endif
 
 #include <gtest/gtest.h>
 
@@ -33,6 +37,17 @@
 namespace vda5050_core::layout::test {
 
 namespace {
+
+// Portable current process id, used to make temp file names unique across
+// concurrently running test executables.
+int current_pid()
+{
+#if defined(_WIN32)
+  return _getpid();
+#else
+  return getpid();
+#endif
+}
 
 nlohmann::json minimal_valid_json()
 {
@@ -91,7 +106,7 @@ TEST(LayoutLoaderTest, LoadFromFile_MalformedJson_ReturnsParseError)
 {
   const std::string path = std::string(testing::TempDir()) +
                            "/vda5050_malformed_layout_" +
-                           std::to_string(::getpid()) + ".json";
+                           std::to_string(current_pid()) + ".json";
   {
     std::ofstream out(path);
     out << R"({ "metaInformation": { "projectIdentification": )";

--- a/vda5050_core/vcpkg-configuration.json
+++ b/vda5050_core/vcpkg-configuration.json
@@ -1,0 +1,7 @@
+{
+	"default-registry": {
+		"kind": "git",
+		"baseline": "56bb2411609227288b70117ead2c47585ba07713",
+		"repository": "https://github.com/microsoft/vcpkg"
+	}
+}

--- a/vda5050_core/vcpkg.json
+++ b/vda5050_core/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "vda5050-core",
+  "version": "0.0.0",
+  "description": "VDA5050 library and support tools",
+  "dependencies": [
+    "paho-mqttpp3",
+    "fmt",
+    "nlohmann-json",
+    "gtest"
+  ]
+}


### PR DESCRIPTION
This is an initial attempt to support Windows build.

Key fixes:
- add windows compatible `time` APIs
- Migrate to pure CMake for windows support
- Minor fixes in `fmt` include path for `format` function
- `vcpkg` linker error fixes for `paho-cpp` (workaround mentioned in https://github.com/microsoft/vcpkg/issues/52261)

Although the build passes, there are still more things to investigate.
- [ ] Different Windows versions
- [ ] Another CMake package utilize this package
- [ ] Test with `rmf2-unreal`
- [ ] Cleanup AI generated comments
- [ ] Cleanup or ignore CMake warnings
- [ ] Build time & cache optimization for CI