### PR TITLE
Add unsubscribe_all() to ProtocolAdapter

### DIFF
--- a/vda5050_core/include/vda5050_core/execution/protocol_adapter.hpp
+++ b/vda5050_core/include/vda5050_core/execution/protocol_adapter.hpp
@@ -31,6 +31,7 @@
 #include <type_traits>
 #include <typeindex>
 #include <unordered_map>
+#include <vector>
 
 #include "vda5050_core/logger/logger.hpp"
 #include "vda5050_core/transport/mqtt_client_interface.hpp"

--- a/vda5050_core/include/vda5050_core/execution/protocol_adapter.hpp
+++ b/vda5050_core/include/vda5050_core/execution/protocol_adapter.hpp
@@ -225,6 +225,8 @@ public:
     return "v" + major;
   }
 
+  void unsubscribe_all();
+
 private:
   ProtocolAdapter(
     std::shared_ptr<transport::MqttClientInterface> mqtt_client,

--- a/vda5050_core/include/vda5050_core/execution/protocol_adapter.hpp
+++ b/vda5050_core/include/vda5050_core/execution/protocol_adapter.hpp
@@ -31,7 +31,6 @@
 #include <type_traits>
 #include <typeindex>
 #include <unordered_map>
-#include <vector>
 
 #include "vda5050_core/logger/logger.hpp"
 #include "vda5050_core/transport/mqtt_client_interface.hpp"

--- a/vda5050_core/src/execution/protocol_adapter.cpp
+++ b/vda5050_core/src/execution/protocol_adapter.cpp
@@ -109,5 +109,28 @@ ProtocolAdapter::ProtocolAdapter(
     {std::type_index(typeid(vda5050_core::types::Visualization)), 0}};
 }
 
+//=============================================================================
+void ProtocolAdapter::unsubscribe_all()
+{
+  // Deactivate all wrapper flags so any in-flight or post-unsubscribe
+  // dispatches become a no-op at the adapter layer.
+  {
+    std::lock_guard<std::mutex> lock(active_flags_mutex_);
+    for (auto& entry : active_flags_)
+    {
+      *(entry.second) = false;
+    }
+    active_flags_.clear();
+  }
+
+  if (mqtt_client_)
+  {
+    for (const auto& entry : topic_names_)
+    {
+      mqtt_client_->unsubscribe(entry.second);
+    }
+  }
+}
+
 }  // namespace execution
 }  // namespace vda5050_core

--- a/vda5050_core/src/execution/protocol_adapter.cpp
+++ b/vda5050_core/src/execution/protocol_adapter.cpp
@@ -112,22 +112,31 @@ ProtocolAdapter::ProtocolAdapter(
 //=============================================================================
 void ProtocolAdapter::unsubscribe_all()
 {
-  // Deactivate all wrapper flags so any in-flight or post-unsubscribe
-  // dispatches become a no-op at the adapter layer.
+  // Deactivate the wrapper flags for currently active subscriptions
+  // so any in-flight or post-unsubscribe dispatches become a no-op
+  // at the adapter layer, and collect their topics to unsubscribe
+  // from below, outside the lock.
+  std::vector<std::string> topics_to_unsubscribe;
   {
     std::lock_guard<std::mutex> lock(active_flags_mutex_);
     for (auto& entry : active_flags_)
     {
       *(entry.second) = false;
+
+      auto topic_it = topic_names_.find(entry.first);
+      if (topic_it != topic_names_.end())
+      {
+        topics_to_unsubscribe.push_back(topic_it->second);
+      }
     }
     active_flags_.clear();
   }
 
   if (mqtt_client_)
   {
-    for (const auto& entry : topic_names_)
+    for (const auto& topic : topics_to_unsubscribe)
     {
-      mqtt_client_->unsubscribe(entry.second);
+      mqtt_client_->unsubscribe(topic);
     }
   }
 }

--- a/vda5050_core/src/execution/protocol_adapter.cpp
+++ b/vda5050_core/src/execution/protocol_adapter.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <utility>
+#include <vector>
 
 #include "vda5050_core/execution/protocol_adapter.hpp"
 

--- a/vda5050_core/test/execution/test_protocol_adapter.cpp
+++ b/vda5050_core/test/execution/test_protocol_adapter.cpp
@@ -266,3 +266,65 @@ TYPED_TEST(ProtocolAdapterTest, HeaderIncrement)
   this->adapter_->template publish<TypeParam>(msg, this->qos_, this->retained_);
   this->adapter_->template publish<TypeParam>(msg, this->qos_, this->retained_);
 }
+
+class ProtocolAdapterUnsubscribeAllTest : public testing::Test
+{
+protected:
+  std::shared_ptr<MockMqttClient> mock_;
+  std::shared_ptr<ProtocolAdapter> adapter_;
+  std::string topic_prefix_;
+
+  void SetUp()
+  {
+    mock_ = std::make_shared<MockMqttClient>();
+    adapter_ =
+      ProtocolAdapter::make(mock_, "uagv", "v2", "ROS-I", "S001");
+    topic_prefix_ = "uagv/v2/ROS-I/S001/";
+  }
+
+  void TearDown()
+  {
+    mock_.reset();
+    adapter_.reset();
+  }
+};
+
+TEST_F(ProtocolAdapterUnsubscribeAllTest, UnsubscribeAllCallsMqttForAllTopics)
+{
+  EXPECT_CALL(*mock_, unsubscribe(testing::StartsWith(topic_prefix_)))
+    .Times(6);
+
+  adapter_->unsubscribe_all();
+}
+
+TEST_F(ProtocolAdapterUnsubscribeAllTest, UnsubscribeAllSilencesActiveCallbacks)
+{
+  MqttClientInterface::MessageHandler captured_handler;
+
+  EXPECT_CALL(
+    *mock_, subscribe(testing::StartsWith(topic_prefix_), testing::_, 0))
+    .WillOnce(testing::SaveArg<1>(&captured_handler));
+
+  std::atomic_bool callback_invoked = false;
+  adapter_->subscribe<Connection>(
+    [&](Connection /*msg*/, std::optional<Error> err) {
+      if (!err.has_value()) callback_invoked = true;
+    },
+    0);
+
+  // While subscribed, the captured wrapper should dispatch to the
+  // user callback.
+  Connection msg{};
+  nlohmann::json j = msg;
+  captured_handler(topic_prefix_, j.dump());
+  EXPECT_TRUE(callback_invoked);
+
+  // After unsubscribe_all, the wrapper should be inert.
+  EXPECT_CALL(*mock_, unsubscribe(testing::StartsWith(topic_prefix_)))
+    .Times(6);
+  adapter_->unsubscribe_all();
+
+  callback_invoked = false;
+  captured_handler(topic_prefix_, j.dump());
+  EXPECT_FALSE(callback_invoked);
+}

--- a/vda5050_core/test/execution/test_protocol_adapter.cpp
+++ b/vda5050_core/test/execution/test_protocol_adapter.cpp
@@ -267,64 +267,44 @@ TYPED_TEST(ProtocolAdapterTest, HeaderIncrement)
   this->adapter_->template publish<TypeParam>(msg, this->qos_, this->retained_);
 }
 
-class ProtocolAdapterUnsubscribeAllTest : public testing::Test
+TYPED_TEST(ProtocolAdapterTest, UnsubscribeAllOnlyUnsubscribesActiveTopics)
 {
-protected:
-  std::shared_ptr<MockMqttClient> mock_;
-  std::shared_ptr<ProtocolAdapter> adapter_;
-  std::string topic_prefix_;
+  // Nothing subscribed — unsubscribe_all() must not touch mqtt_client_.
+  EXPECT_CALL(*this->mock_, unsubscribe(testing::_)).Times(0);
 
-  void SetUp()
-  {
-    mock_ = std::make_shared<MockMqttClient>();
-    adapter_ =
-      ProtocolAdapter::make(mock_, "uagv", "v2", "ROS-I", "S001");
-    topic_prefix_ = "uagv/v2/ROS-I/S001/";
-  }
-
-  void TearDown()
-  {
-    mock_.reset();
-    adapter_.reset();
-  }
-};
-
-TEST_F(ProtocolAdapterUnsubscribeAllTest, UnsubscribeAllCallsMqttForAllTopics)
-{
-  EXPECT_CALL(*mock_, unsubscribe(testing::StartsWith(topic_prefix_)))
-    .Times(6);
-
-  adapter_->unsubscribe_all();
+  this->adapter_->unsubscribe_all();
 }
 
-TEST_F(ProtocolAdapterUnsubscribeAllTest, UnsubscribeAllSilencesActiveCallbacks)
+TYPED_TEST(ProtocolAdapterTest, UnsubscribeAllSilencesActiveCallbacks)
 {
   MqttClientInterface::MessageHandler captured_handler;
 
   EXPECT_CALL(
-    *mock_, subscribe(testing::StartsWith(topic_prefix_), testing::_, 0))
+    *this->mock_,
+    subscribe(testing::StartsWith(this->topic_prefix_), testing::_, this->qos_))
     .WillOnce(testing::SaveArg<1>(&captured_handler));
 
   std::atomic_bool callback_invoked = false;
-  adapter_->subscribe<Connection>(
-    [&](Connection /*msg*/, std::optional<Error> err) {
+  this->adapter_->template subscribe<TypeParam>(
+    [&](TypeParam /*msg*/, std::optional<Error> err) {
       if (!err.has_value()) callback_invoked = true;
     },
-    0);
+    this->qos_);
 
   // While subscribed, the captured wrapper should dispatch to the
   // user callback.
-  Connection msg{};
+  TypeParam msg = make_valid_message<TypeParam>();
   nlohmann::json j = msg;
-  captured_handler(topic_prefix_, j.dump());
+  captured_handler(this->topic_prefix_, j.dump());
   EXPECT_TRUE(callback_invoked);
 
   // After unsubscribe_all, the wrapper should be inert.
-  EXPECT_CALL(*mock_, unsubscribe(testing::StartsWith(topic_prefix_)))
-    .Times(6);
-  adapter_->unsubscribe_all();
+  EXPECT_CALL(
+    *this->mock_, unsubscribe(testing::StartsWith(this->topic_prefix_)))
+    .Times(1);
+  this->adapter_->unsubscribe_all();
 
   callback_invoked = false;
-  captured_handler(topic_prefix_, j.dump());
+  captured_handler(this->topic_prefix_, j.dump());
   EXPECT_FALSE(callback_invoked);
 }


### PR DESCRIPTION
Closes #72

## Summary
This PR adds a new \unsubscribe_all()\ method to \ProtocolAdapter\ that unsubscribes from all registered protocol topics in a single call, eliminating the need to manually call \unsubscribe<T>()\ for each message type before disconnecting. The implementation deactivates all active subscription wrappers atomically under the existing mutex before calling \mqtt_client_->unsubscribe()\ on each known topic, following the same locking pattern and coding style as the existing \unsubscribe<T>()\ method. Two unit tests are included: one verifying that \unsubscribe_all()\ triggers an MQTT unsubscribe call for all six registered topics, and another verifying that any previously active callbacks become inert after \unsubscribe_all()\ is called.