### PR TITLE
feat(cpp20): add fixes for c++20 to allow external packages utilize INTERFACE targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - develop
-      - test/bn/cpp20-error-fix
 
 jobs:
   industrial_ci:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
       - develop
-      - test/bn/cpp20-error
+      - test/bn/cpp20-error-fix
 
 jobs:
   industrial_ci:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
         include:
           - {distro: jazzy, test_type: gcc-asan}
           - {distro: jazzy, test_type: gcc-tsan}
+          - {distro: jazzy, test_type: gcc-cpp20}
+          - {distro: jazzy, test_type: clang-cpp20}
     env:
       ISOLATION: "shell"
       UPSTREAM_WORKSPACE: 'github:ros-industrial/vda5050_interfaces#main github:eclipse-paho/paho.mqtt.cpp#v1.5.0'
@@ -55,6 +57,21 @@ jobs:
         uses: 'ros-industrial/industrial_ci@master'
         env:
           TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_C_FLAGS="-fsanitize=thread -O2 -g -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -O2 -g -fno-omit-frame-pointer"'
+
+      # GCC with C++20
+      - if: ${{ matrix.test_type == 'gcc-cpp20' }}
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
+          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_CXX_STANDARD=20'
+
+      # Clang with C++20
+      - if: ${{ matrix.test_type == 'clang-cpp20' }}
+        uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ADDITIONAL_DEBS: clang lld
+          CC: "clang"
+          CXX: "clang++"
+          TARGET_CMAKE_ARGS: '-DENABLE_ROS2=ON -DCMAKE_CXX_STANDARD=20'
 
       # Clang
       - if: ${{ matrix.test_type == 'clang' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - develop
+      - test/bn/cpp20-error
 
 jobs:
   industrial_ci:

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(vda5050_core)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/vda5050_core/CMakeLists.txt
+++ b/vda5050_core/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(vda5050_core)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/vda5050_core/include/vda5050_core/json_utils/serialization.hpp
+++ b/vda5050_core/include/vda5050_core/json_utils/serialization.hpp
@@ -877,7 +877,7 @@ void from_json(const nlohmann::json& j, EdgeT& msg)
   msg.start_node_id = j.at("startNodeId").get<std::string>();
   msg.end_node_id = j.at("endNodeId").get<std::string>();
   msg.released = j.at("released").get<bool>();
-  msg.actions = j.at("actions");
+  j.at("actions").get_to(msg.actions);
 
   if (j.contains("edgeDescription"))
   {
@@ -1368,7 +1368,7 @@ void from_json(const nlohmann::json& j, InstantActionsT& msg)
 {
   from_json(j, msg.header);
 
-  msg.actions = j.at("actions");
+  j.at("actions").get_to(msg.actions);
 }
 
 }  // namespace instant_actions_detail
@@ -2244,7 +2244,7 @@ void from_json(const nlohmann::json& j, NodeT& msg)
   msg.node_id = j.at("nodeId").get<std::string>();
   msg.sequence_id = j.at("sequenceId").get<uint32_t>();
   msg.released = j.at("released").get<bool>();
-  msg.actions = j.at("actions");
+  j.at("actions").get_to(msg.actions);
 
   if (j.contains("nodePosition"))
   {
@@ -2481,8 +2481,8 @@ void from_json(const nlohmann::json& j, OrderT& msg)
 
   msg.order_id = j.at("orderId").get<std::string>();
   msg.order_update_id = j.at("orderUpdateId").get<uint32_t>();
-  msg.nodes = j.at("nodes");
-  msg.edges = j.at("edges");
+  j.at("nodes").get_to(msg.nodes);
+  j.at("edges").get_to(msg.edges);
 
   if (j.contains("zoneSetId"))
   {
@@ -2633,8 +2633,8 @@ void to_json(nlohmann::json& j, const ProtocolFeaturesT& msg)
 template <typename ProtocolFeaturesT>
 void from_json(const nlohmann::json& j, ProtocolFeaturesT& msg)
 {
-  msg.optional_parameters = j.at("optionalParameters");
-  msg.agv_actions = j.at("agvActions");
+  j.at("optionalParameters").get_to(msg.optional_parameters);
+  j.at("agvActions").get_to(msg.agv_actions);
 }
 
 }  // namespace protocol_features_detail
@@ -2799,10 +2799,10 @@ void from_json(const nlohmann::json& j, StateT& msg)
     operating_mode_traits<decltype(msg.operating_mode)>::from_string(
       j.at("operatingMode").get<std::string>());
 
-  msg.node_states = j.at("nodeStates");
-  msg.edge_states = j.at("edgeStates");
-  msg.action_states = j.at("actionStates");
-  msg.errors = j.at("errors");
+  j.at("nodeStates").get_to(msg.node_states);
+  j.at("edgeStates").get_to(msg.edge_states);
+  j.at("actionStates").get_to(msg.action_states);
+  j.at("errors").get_to(msg.errors);
   msg.battery_state = j.at("batteryState");
   msg.safety_state = j.at("safetyState");
 

--- a/vda5050_core/src/master/heartbeat.cpp
+++ b/vda5050_core/src/master/heartbeat.cpp
@@ -44,7 +44,7 @@ HeartbeatListener::HeartbeatListener(
 HeartbeatListener::~HeartbeatListener()
 {
   stop_connection_heartbeat();
-  VDA5050_INFO("[" + id_ + "] Deconstructing HeartbeatListener");
+  VDA5050_INFO("[{}] Deconstructing HeartbeatListener", id_);
 }
 
 //=============================================================================
@@ -109,7 +109,7 @@ void HeartbeatListener::received_connection()
   }
   std::lock_guard<std::mutex> lock(last_connection_report_mutex_);
   last_connection_report_ = get_current_time();
-  VDA5050_INFO("[" + id_ + "] Received connection heartbeat");
+  VDA5050_INFO("[{}] Received connection heartbeat", id_);
   message_received_.notify_all();
 }
 
@@ -163,9 +163,8 @@ bool HeartbeatListener::is_timeout()
   if (std::abs(time_since_last_connection_report) > heartbeat_interval_)
   {
     VDA5050_WARN(
-      "[" + id_ + "] Connection heartbeat timeout after " +
-      std::to_string(time_since_last_connection_report) + " seconds " +
-      "(max: " + std::to_string(heartbeat_interval_) + "s)");
+      "[{}] Connection heartbeat timeout after {} seconds (max: {}s)",
+      id_, time_since_last_connection_report, heartbeat_interval_);
     return true;
   }
   return false;
@@ -183,14 +182,14 @@ void HeartbeatListener::listen()
     // Check if shutdown was requested while waiting
     if (is_stop_requested())
     {
-      VDA5050_DEBUG("[" + id_ + "] Shutdown requested, exiting listen loop");
+      VDA5050_DEBUG("[{}] Shutdown requested, exiting listen loop", id_);
       return;
     }
 
     if (is_timeout())
     {
       disconnection_callback_();
-      VDA5050_INFO("[" + id_ + "] Heartbeat monitoring stopped after timeout");
+      VDA5050_INFO("[{}] Heartbeat monitoring stopped after timeout", id_);
       return;
     }
   }

--- a/vda5050_core/src/master/heartbeat.cpp
+++ b/vda5050_core/src/master/heartbeat.cpp
@@ -163,8 +163,8 @@ bool HeartbeatListener::is_timeout()
   if (std::abs(time_since_last_connection_report) > heartbeat_interval_)
   {
     VDA5050_WARN(
-      "[{}] Connection heartbeat timeout after {} seconds (max: {}s)",
-      id_, time_since_last_connection_report, heartbeat_interval_);
+      "[{}] Connection heartbeat timeout after {} seconds (max: {}s)", id_,
+      time_since_last_connection_report, heartbeat_interval_);
     return true;
   }
   return false;

--- a/vda5050_core/test/master/test_integration_heartbeat.cpp
+++ b/vda5050_core/test/master/test_integration_heartbeat.cpp
@@ -122,7 +122,8 @@ TEST(HeartbeatListenerTest, HeartbeatNotReceivedTimeout)
     [&heartbeat_failed]() {
       // Timeout callback
       VDA5050_INFO("Timeout callback");
-      VDA5050_INFO("Heartbeat_failed before store: {}", heartbeat_failed.load());
+      VDA5050_INFO(
+        "Heartbeat_failed before store: {}", heartbeat_failed.load());
       heartbeat_failed.store(true);
       VDA5050_INFO("Heartbeat_failed after store: {}", heartbeat_failed.load());
       // ASSERT_TRUE(heartbeat_failed->load());

--- a/vda5050_core/test/master/test_integration_heartbeat.cpp
+++ b/vda5050_core/test/master/test_integration_heartbeat.cpp
@@ -47,8 +47,7 @@ public:
 
   std::chrono::system_clock::time_point get_current_time() override
   {
-    VDA5050_INFO(
-      "get_current_time with skip of " + std::to_string(time_to_skip_));
+    VDA5050_INFO("get_current_time with skip of {}", time_to_skip_);
     return std::chrono::system_clock::now() +
            std::chrono::seconds(time_to_skip_);
   }
@@ -123,13 +122,9 @@ TEST(HeartbeatListenerTest, HeartbeatNotReceivedTimeout)
     [&heartbeat_failed]() {
       // Timeout callback
       VDA5050_INFO("Timeout callback");
-      VDA5050_INFO(
-        "Heartbeat_failed before store: " +
-        std::to_string(heartbeat_failed.load()));
+      VDA5050_INFO("Heartbeat_failed before store: {}", heartbeat_failed.load());
       heartbeat_failed.store(true);
-      VDA5050_INFO(
-        "Heartbeat_failed after store: " +
-        std::to_string(heartbeat_failed.load()));
+      VDA5050_INFO("Heartbeat_failed after store: {}", heartbeat_failed.load());
       // ASSERT_TRUE(heartbeat_failed->load());
     },
     ConnectionHeartbeatInterval + 1);


### PR DESCRIPTION
This PR is primarily for 3rd party `c++20` based applications built on the `vda5050_core` headers.
I encounter this problem when I try to utilize the serialization within the `VDA5050Wrapper` Unreal Plugin Module.
This can temporarily solved in `Unreal` the same way we address the RTTI problem (#42).

Key issues for C++20
- [ambiguous overload error log](https://github.com/Briancbn/vda5050_client/actions/runs/28568655917/job/84701238906)
- [string joining error](https://github.com/Briancbn/vda5050_client/actions/runs/28568655917/job/84701238889)

Key changes made
- use `get_to` for ambiguous type such as `std::vector<T>`
- use `fmt` pattern for string joining

I also added a pipeline to test building for c++20