### PR TITLE
refactor(layout): use nested namespaces in headers for C++14 compatibility

### DIFF
--- a/vda5050_core/include/vda5050_core/json_utils/layout_serialization.hpp
+++ b/vda5050_core/include/vda5050_core/json_utils/layout_serialization.hpp
@@ -37,7 +37,9 @@
 #include "vda5050_core/layout/vehicle_type_node_property.hpp"
 #include "vda5050_core/types/blocking_type.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 inline std::string to_string(RequirementType v)
 {
@@ -670,6 +672,7 @@ inline void from_json(const nlohmann::json& j, LIF& v)
   lif_detail::from_json(j, v);
 }
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__JSON_UTILS__LAYOUT_SERIALIZATION_HPP_

--- a/vda5050_core/include/vda5050_core/layout/edge.hpp
+++ b/vda5050_core/include/vda5050_core/layout/edge.hpp
@@ -25,7 +25,9 @@
 
 #include "vda5050_core/layout/vehicle_type_edge_property.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 struct Edge
 {
@@ -53,6 +55,7 @@ struct Edge
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__EDGE_HPP_

--- a/vda5050_core/include/vda5050_core/layout/graph.hpp
+++ b/vda5050_core/include/vda5050_core/layout/graph.hpp
@@ -30,7 +30,9 @@
 
 #include "vda5050_core/layout/lif.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 /// \brief Master-side wrapper over a validated LIF.
 ///
@@ -312,6 +314,7 @@ void Graph::for_each_station_ordered(V&& visitor) const
   }
 }
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__GRAPH_HPP_

--- a/vda5050_core/include/vda5050_core/layout/layout.hpp
+++ b/vda5050_core/include/vda5050_core/layout/layout.hpp
@@ -27,7 +27,9 @@
 #include "vda5050_core/layout/node.hpp"
 #include "vda5050_core/layout/station.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 struct Layout
 {
@@ -56,6 +58,7 @@ struct Layout
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__LAYOUT_HPP_

--- a/vda5050_core/include/vda5050_core/layout/layout_action.hpp
+++ b/vda5050_core/include/vda5050_core/layout/layout_action.hpp
@@ -25,7 +25,9 @@
 
 #include "vda5050_core/types/blocking_type.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 enum class RequirementType
 {
@@ -76,6 +78,7 @@ struct Action
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__LAYOUT_ACTION_HPP_

--- a/vda5050_core/include/vda5050_core/layout/layout_loader.hpp
+++ b/vda5050_core/include/vda5050_core/layout/layout_loader.hpp
@@ -28,7 +28,9 @@
 #include "vda5050_core/layout/lif.hpp"
 #include "vda5050_core/layout/validate_layout.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 /// \brief Result of a layout load: a valid LIF, or the load errors.
 ///
@@ -60,6 +62,7 @@ struct LayoutLoadResult
 LayoutLoadResult load_from_file(const std::string& path);
 LayoutLoadResult load_from_json(const nlohmann::json& json);
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__LAYOUT_LOADER_HPP_

--- a/vda5050_core/include/vda5050_core/layout/lif.hpp
+++ b/vda5050_core/include/vda5050_core/layout/lif.hpp
@@ -24,7 +24,9 @@
 
 #include "vda5050_core/layout/layout.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 struct MetaInformation
 {
@@ -62,6 +64,7 @@ struct LIF
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__LIF_HPP_

--- a/vda5050_core/include/vda5050_core/layout/load_restriction.hpp
+++ b/vda5050_core/include/vda5050_core/layout/load_restriction.hpp
@@ -23,7 +23,9 @@
 #include <string>
 #include <vector>
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 /// \brief Load-traversability rule on an edge (per vehicle-type bucket).
 ///
@@ -46,6 +48,7 @@ struct LoadRestriction
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__LOAD_RESTRICTION_HPP_

--- a/vda5050_core/include/vda5050_core/layout/node.hpp
+++ b/vda5050_core/include/vda5050_core/layout/node.hpp
@@ -25,7 +25,9 @@
 
 #include "vda5050_core/layout/vehicle_type_node_property.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 struct NodePosition
 {
@@ -67,6 +69,7 @@ struct Node
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__NODE_HPP_

--- a/vda5050_core/include/vda5050_core/layout/station.hpp
+++ b/vda5050_core/include/vda5050_core/layout/station.hpp
@@ -23,7 +23,9 @@
 #include <string>
 #include <vector>
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 struct StationPosition
 {
@@ -66,6 +68,7 @@ struct Station
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__STATION_HPP_

--- a/vda5050_core/include/vda5050_core/layout/trajectory.hpp
+++ b/vda5050_core/include/vda5050_core/layout/trajectory.hpp
@@ -22,7 +22,9 @@
 #include <optional>
 #include <vector>
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 struct ControlPoint
 {
@@ -59,6 +61,7 @@ struct Trajectory
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__TRAJECTORY_HPP_

--- a/vda5050_core/include/vda5050_core/layout/validate_layout.hpp
+++ b/vda5050_core/include/vda5050_core/layout/validate_layout.hpp
@@ -25,7 +25,9 @@
 
 #include "vda5050_core/layout/lif.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 enum class LayoutLoadErrorType : std::uint8_t
 {
@@ -53,6 +55,7 @@ struct LayoutLoadError
 /// \return Errors found; empty if the layout is valid.
 std::vector<LayoutLoadError> validate_layout(const LIF& lif);
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__VALIDATE_LAYOUT_HPP_

--- a/vda5050_core/include/vda5050_core/layout/vehicle_type_edge_property.hpp
+++ b/vda5050_core/include/vda5050_core/layout/vehicle_type_edge_property.hpp
@@ -27,7 +27,9 @@
 #include "vda5050_core/layout/load_restriction.hpp"
 #include "vda5050_core/layout/trajectory.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 enum class OrientationType
 {
@@ -86,6 +88,7 @@ struct VehicleTypeEdgeProperty
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__VEHICLE_TYPE_EDGE_PROPERTY_HPP_

--- a/vda5050_core/include/vda5050_core/layout/vehicle_type_node_property.hpp
+++ b/vda5050_core/include/vda5050_core/layout/vehicle_type_node_property.hpp
@@ -25,7 +25,9 @@
 
 #include "vda5050_core/layout/layout_action.hpp"
 
-namespace vda5050_core::layout {
+namespace vda5050_core {
+
+namespace layout {
 
 struct VehicleTypeNodeProperty
 {
@@ -44,6 +46,7 @@ struct VehicleTypeNodeProperty
   }
 };
 
-}  // namespace vda5050_core::layout
+}  // namespace layout
+}  // namespace vda5050_core
 
 #endif  // VDA5050_CORE__LAYOUT__VEHICLE_TYPE_NODE_PROPERTY_HPP_


### PR DESCRIPTION
## Summary

Fixes C++14 compatibility in the layout headers.

Collapsed namespace syntax (`namespace vda5050_core::layout`) is C++17-only, so this PR converts the 14 affected headers to expanded nested namespaces.

## What's included

- Updated 13 `layout/` headers + `layout_serialization.hpp`
- Header-only change
- No `.cpp` changes