### PR TITLE
fix(client): transform node positions if a transformation is available

### DIFF
--- a/vda5050_core/include/vda5050_core/client/adapter/node_request.hpp
+++ b/vda5050_core/include/vda5050_core/client/adapter/node_request.hpp
@@ -23,6 +23,7 @@
 #include <optional>
 #include <string>
 
+#include "vda5050_core/client/adapter/transformation.hpp"
 #include "vda5050_core/types/node.hpp"
 #include "vda5050_core/types/node_position.hpp"
 
@@ -46,7 +47,9 @@ public:
 private:
   friend class Adapter;
 
-  static NodeRequest from_node(const types::Node& node);
+  static NodeRequest from_node(
+    const types::Node& node,
+    std::optional<Transformation> transformation = std::nullopt);
 
   NodeRequest(
     const std::string& node_id, uint32_t sequence_id,

--- a/vda5050_core/src/client/adapter/adapter.cpp
+++ b/vda5050_core/src/client/adapter/adapter.cpp
@@ -264,7 +264,14 @@ void Adapter::Implementation::process_navigation()
   const auto& next_node = order.nodes[node_it->second];
   if (!next_node.released) return;
 
-  auto node_request = NodeRequest::from_node(next_node);
+  std::optional<Transformation> map_transformation = std::nullopt;
+  if (next_node.node_position.has_value())
+  {
+    map_transformation =
+      state_manager->transformation(next_node.node_position->map_id);
+  }
+
+  auto node_request = NodeRequest::from_node(next_node, map_transformation);
 
   uint32_t next_edge_seq = next_node_seq - 1;
 

--- a/vda5050_core/src/client/adapter/node_request.cpp
+++ b/vda5050_core/src/client/adapter/node_request.cpp
@@ -51,10 +51,28 @@ const std::optional<std::string>& NodeRequest::node_description() const
 }
 
 //=============================================================================
-NodeRequest NodeRequest::from_node(const types::Node& node)
+NodeRequest NodeRequest::from_node(
+  const types::Node& node, std::optional<Transformation> transformation)
 {
-  return NodeRequest(
+  auto request = NodeRequest(
     node.node_id, node.sequence_id, node.node_position, node.node_description);
+
+  if (request.node_position_.has_value() && transformation.has_value())
+  {
+    const auto& pos = request.node_position_.value();
+
+    auto agv_pose =
+      transformation->to_agv_pose({pos.x, pos.y, pos.theta.value_or(0.0)});
+
+    request.node_position_->x = agv_pose.x;
+    request.node_position_->y = agv_pose.y;
+    if (pos.theta.has_value())
+    {
+      request.node_position_->theta = agv_pose.theta;
+    }
+  }
+
+  return request;
 }
 
 //=============================================================================

--- a/vda5050_core/src/client/adapter/state_manager.cpp
+++ b/vda5050_core/src/client/adapter/state_manager.cpp
@@ -53,6 +53,7 @@ void StateManager::set_position(
     state_.agv_position->x = world_pose.x;
     state_.agv_position->y = world_pose.y;
     state_.agv_position->theta = world_pose.theta;
+    state_.agv_position->position_initialized = true;
   }
   else
   {

--- a/vda5050_core/test/client/test_adapter_navigation.cpp
+++ b/vda5050_core/test/client/test_adapter_navigation.cpp
@@ -279,3 +279,121 @@ TEST_F(AdapterNavigationTest, NavigationExceptionHandled)
 
   adapter->stop();
 }
+TEST_F(AdapterNavigationTest, TransformsCoordinatesUsingInitializePosition)
+{
+  std::mutex mutex;
+  std::optional<NodeRequest> received_request;
+  std::atomic_bool nav_called = false;
+
+  adapter->on_navigate([&](
+                         NodeRequest node_request,
+                         std::optional<EdgeRequest> /*edge_request*/,
+                         std::shared_ptr<OrderExecution> execution) {
+    std::lock_guard<std::mutex> lock(mutex);
+    received_request = std::move(node_request);
+    nav_called = true;
+    execution->finished();
+  });
+
+  const std::string map_id = "floor_1";
+
+  adapter->state_manager()->initialize_position(10.0, 5.0, M_PI_2, map_id);
+
+  EXPECT_TRUE(adapter->state_manager()->position_initialized());
+
+  adapter->start();
+
+  auto order = make_order("order_id", 0, 1, 0);
+  order.nodes[0].node_position = vda5050_core::types::NodePosition{};
+  order.nodes[0].node_position->map_id = map_id;
+  order.nodes[0].node_position->x = 10.0;
+  order.nodes[0].node_position->y = 15.0;
+  order.nodes[0].node_position->theta = M_PI_2;
+
+  inject_message(
+    fmt::format("{}/order", protocol_adapter->get_topic_prefix()),
+    nlohmann::json(order).dump());
+
+  ASSERT_TRUE(wait_until([&] { return nav_called.load(); }));
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    ASSERT_TRUE(received_request.has_value());
+    const auto& pos = received_request->node_position();
+    ASSERT_TRUE(pos.has_value());
+
+    EXPECT_DOUBLE_EQ(pos->x, 10.0);
+    EXPECT_DOUBLE_EQ(pos->y, 15.0);
+    ASSERT_TRUE(pos->theta.has_value());
+    EXPECT_DOUBLE_EQ(pos->theta.value(), M_PI_2);
+  }
+
+  adapter->stop();
+}
+
+TEST_F(AdapterNavigationTest, TransformsCoordinatesUsingSetTransform)
+{
+  std::mutex mutex;
+  std::optional<NodeRequest> received_request;
+  std::atomic_bool nav_called = false;
+
+  adapter->on_navigate([&](
+                         NodeRequest node_request,
+                         std::optional<EdgeRequest> /*edge_request*/,
+                         std::shared_ptr<OrderExecution> execution) {
+    std::lock_guard<std::mutex> lock(mutex);
+    received_request = std::move(node_request);
+    nav_called = true;
+    execution->finished();
+  });
+
+  const std::string map_id = "floor_1";
+
+  vda5050_core::client::adapter::Pose2D world_ref{10.0, 5.0, M_PI_2};
+  vda5050_core::client::adapter::Pose2D agv_ref{0.0, 0.0, 0.0};
+
+  auto tf = vda5050_core::client::adapter::Transformation::calibrate(
+    world_ref, agv_ref);
+
+  adapter->state_manager()->set_transformation(tf, map_id);
+  adapter->state_manager()->set_position(0.0, 0.0, 0.0, map_id);
+
+  EXPECT_TRUE(adapter->state_manager()->position_initialized());
+
+  adapter->start();
+
+  auto order = make_order("order_id", 0, 1, 0);
+  order.nodes[0].node_position = vda5050_core::types::NodePosition{};
+  order.nodes[0].node_position->map_id = map_id;
+  order.nodes[0].node_position->x = 10.0;
+  order.nodes[0].node_position->y = 15.0;
+  order.nodes[0].node_position->theta = M_PI_2;
+
+  inject_message(
+    fmt::format("{}/order", protocol_adapter->get_topic_prefix()),
+    nlohmann::json(order).dump());
+
+  ASSERT_TRUE(wait_until([&] { return nav_called.load(); }));
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    ASSERT_TRUE(received_request.has_value());
+    const auto& pos = received_request->node_position();
+    ASSERT_TRUE(pos.has_value());
+
+    EXPECT_NEAR(pos->x, 10.0, 1e-4);
+    EXPECT_NEAR(pos->y, 0.0, 1e-4);
+    ASSERT_TRUE(pos->theta.has_value());
+    EXPECT_NEAR(pos->theta.value(), 0.0, 1e-4);
+  }
+
+  adapter->state_manager()->set_position(5.0, 0.0, 0.0, map_id);
+
+  auto current_state = adapter->state_manager()->state();
+  ASSERT_TRUE(current_state.agv_position.has_value());
+  EXPECT_NEAR(current_state.agv_position->x, 10.0, 1e-4);
+  EXPECT_NEAR(current_state.agv_position->y, 10.0, 1e-4);
+  EXPECT_NEAR(current_state.agv_position->theta, M_PI_2, 1e-4);
+
+  adapter->stop();
+}


### PR DESCRIPTION
## Summary

There is a bug where the node positions do not get transformed into AGV frame before being sent to user's navigation callback. This PR implements a check for the presence of transformations before sending a navigation request.