### PR TITLE
fix(master): order rejection callback

### DIFF
--- a/vda5050_core/examples/master/master_example.cpp
+++ b/vda5050_core/examples/master/master_example.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <vda5050_core/logger/logger.hpp>
 
@@ -190,6 +191,17 @@ int main()
       }
       next_order();
     });
+
+  // An order discarded before it reached the AGV never completes, so a
+  // scheduler driven only by on_order_complete would stall here.
+  master->on_order_rejected([](
+                              const std::string& agv_id,
+                              const std::string& order_id,
+                              const std::vector<types::Error>& errors) {
+    VDA5050_WARN(
+      "[{}] order [{}] rejected ({} error(s))", agv_id, order_id,
+      errors.size());
+  });
 
   master->on_offline([](const std::string& agv_id) {
     VDA5050_WARN("[{}] went offline", agv_id);

--- a/vda5050_core/include/vda5050_core/master/master.hpp
+++ b/vda5050_core/include/vda5050_core/master/master.hpp
@@ -250,6 +250,17 @@ public:
     std::function<void(const std::string& agv_id, const std::string& order_id)>
       callback);
 
+  /// \brief Register the handler invoked when a queued order is discarded
+  ///        before publish, after assign_order already returned ASSIGNED.
+  ///
+  /// \param callback receives the errors that caused the rejection. Pairs with
+  ///        on_order_complete: every accepted order ends in one or the other.
+  void on_order_rejected(
+    std::function<void(
+      const std::string& agv_id, const std::string& order_id,
+      const std::vector<vda5050_core::types::Error>& errors)>
+      callback);
+
   /// \brief Register the handler invoked when the error list gains entries.
   /// \param callback receives only the newly-appeared errors.
   void on_errors_appeared(
@@ -357,6 +368,9 @@ private:
   void dispatch_state_resumed(const std::string& agv_id);
   void dispatch_order_complete(
     const std::string& agv_id, const std::string& order_id);
+  void dispatch_order_rejected(
+    const std::string& agv_id, const std::string& order_id,
+    const std::vector<vda5050_core::types::Error>& errors);
 
   // --- Internal AGV lookup ---
 
@@ -433,6 +447,10 @@ private:
     on_node_reached_cb_;
   std::function<void(const std::string&, const std::string&)>
     on_order_complete_cb_;
+  std::function<void(
+    const std::string&, const std::string&,
+    const std::vector<vda5050_core::types::Error>&)>
+    on_order_rejected_cb_;
   std::function<void(
     const std::string&, const std::vector<vda5050_core::types::Error>&)>
     on_errors_appeared_cb_;

--- a/vda5050_core/include/vda5050_core/master/order/order_lifecycle_manager.hpp
+++ b/vda5050_core/include/vda5050_core/master/order/order_lifecycle_manager.hpp
@@ -101,6 +101,10 @@ public:
   /// \return false if the queue is at capacity.
   bool enqueue_pending_update(const vda5050_core::types::Order& update);
 
+  /// \brief The error describing an update dropped for want of queue room.
+  static vda5050_core::types::Error pending_queue_full_error(
+    const std::string& order_id);
+
   /// \brief Return drained-but-unsent updates to the front of the pending
   ///        queue, preserving order, so a congested outbound queue can't
   ///        reorder the stitch chain.

--- a/vda5050_core/src/master/agv.cpp
+++ b/vda5050_core/src/master/agv.cpp
@@ -22,6 +22,8 @@
 #include <utility>
 
 #include "nlohmann/json.hpp"
+#include "vda5050_core/errors/error_codes.hpp"
+#include "vda5050_core/errors/error_factory.hpp"
 #include "vda5050_core/execution/protocol_adapter.hpp"
 #include "vda5050_core/json_utils/serialization.hpp"
 #include "vda5050_core/logger/logger.hpp"
@@ -1111,6 +1113,15 @@ void AGV::publish_order(
           VDA5050_WARN(
             "Pending queue full for [{}]; dropping order [{}] (update {})",
             agv_id_, order.order_id, order.order_update_id);
+          if (auto p = parent_.lock())
+          {
+            p->dispatch_order_rejected(
+              agv_id_, order.order_id,
+              {vda5050_core::errors::create_error(
+                vda5050_core::errors::OrderUpdateError,
+                "Pending update queue is full; order dropped.",
+                {{vda5050_core::errors::RefOrderId, order.order_id}})});
+          }
         }
         else
         {
@@ -1125,6 +1136,10 @@ void AGV::publish_order(
           "Stitch validation rejected order [{}] (update {}) for [{}]: "
           "{} error(s)",
           order.order_id, order.order_update_id, agv_id_, stitch.errors.size());
+        if (auto p = parent_.lock())
+        {
+          p->dispatch_order_rejected(agv_id_, order.order_id, stitch.errors);
+        }
         return;
     }
   }
@@ -1175,6 +1190,11 @@ void AGV::publish_order(
         err.error_level == vda5050_core::types::ErrorLevel::FATAL ? "FATAL"
                                                                   : "WARNING",
         err.error_description.value_or(""));
+    }
+    if (auto p = parent_.lock())
+    {
+      p->dispatch_order_rejected(
+        agv_id_, order.order_id, result.fatal_errors());
     }
     return;
   }

--- a/vda5050_core/src/master/agv.cpp
+++ b/vda5050_core/src/master/agv.cpp
@@ -22,8 +22,6 @@
 #include <utility>
 
 #include "nlohmann/json.hpp"
-#include "vda5050_core/errors/error_codes.hpp"
-#include "vda5050_core/errors/error_factory.hpp"
 #include "vda5050_core/execution/protocol_adapter.hpp"
 #include "vda5050_core/json_utils/serialization.hpp"
 #include "vda5050_core/logger/logger.hpp"
@@ -1117,10 +1115,8 @@ void AGV::publish_order(
           {
             p->dispatch_order_rejected(
               agv_id_, order.order_id,
-              {vda5050_core::errors::create_error(
-                vda5050_core::errors::OrderUpdateError,
-                "Pending update queue is full; order dropped.",
-                {{vda5050_core::errors::RefOrderId, order.order_id}})});
+              {OrderLifecycleManager::pending_queue_full_error(
+                order.order_id)});
           }
         }
         else

--- a/vda5050_core/src/master/master.cpp
+++ b/vda5050_core/src/master/master.cpp
@@ -1027,6 +1027,15 @@ void VDA5050Master::on_order_complete(
   on_order_complete_cb_ = std::move(callback);
 }
 
+void VDA5050Master::on_order_rejected(
+  std::function<void(
+    const std::string&, const std::string&,
+    const std::vector<vda5050_core::types::Error>&)>
+    callback)
+{
+  on_order_rejected_cb_ = std::move(callback);
+}
+
 void VDA5050Master::on_errors_appeared(
   std::function<
     void(const std::string&, const std::vector<vda5050_core::types::Error>&)>
@@ -1176,6 +1185,18 @@ void VDA5050Master::dispatch_order_complete(
   {
     fire_hook(agv_id, "on_order_complete", [&] {
       on_order_complete_cb_(agv_id, order_id);
+    });
+  }
+}
+
+void VDA5050Master::dispatch_order_rejected(
+  const std::string& agv_id, const std::string& order_id,
+  const std::vector<vda5050_core::types::Error>& errors)
+{
+  if (on_order_rejected_cb_)
+  {
+    fire_hook(agv_id, "on_order_rejected", [&] {
+      on_order_rejected_cb_(agv_id, order_id, errors);
     });
   }
 }

--- a/vda5050_core/src/master/order/order_lifecycle_manager.cpp
+++ b/vda5050_core/src/master/order/order_lifecycle_manager.cpp
@@ -383,6 +383,13 @@ std::vector<vda5050_core::types::Order> OrderLifecycleManager::on_state_update(
   return drain_pending_locked(state);
 }
 
+vda5050_core::types::Error OrderLifecycleManager::pending_queue_full_error(
+  const std::string& order_id)
+{
+  return make_combine_error(
+    "Pending update queue is full; order dropped.", order_id);
+}
+
 bool OrderLifecycleManager::enqueue_pending_update(
   const vda5050_core::types::Order& update)
 {

--- a/vda5050_core/test/master/test_integration_master_assign_order.cpp
+++ b/vda5050_core/test/master/test_integration_master_assign_order.cpp
@@ -415,6 +415,44 @@ TEST_F(MasterAssignOrderTest, OrderComplete_FiresOnceWhenAgvParksAtLastNode)
   EXPECT_EQ(complete_calls.load(), 1);
 }
 
+TEST_F(MasterAssignOrderTest, OrderRejected_FiresWhenPublishStageRejects)
+{
+  std::atomic<int> rejected_calls{0};
+  std::string rejected_id;
+  std::size_t error_count = 0;
+  master_->on_order_rejected(
+    [&](
+      const std::string&, const std::string& order_id,
+      const std::vector<vda5050_core::types::Error>& errors) {
+      rejected_calls.fetch_add(1);
+      rejected_id = order_id;
+      error_count = errors.size();
+    });
+
+  make_agv_ready();
+
+  // Passes the pre-flight, fails content validation on the queue thread:
+  // the pre-flight never inspects node actions.
+  auto bad = make_minimal_order(0);
+  vda5050_core::types::Action a;
+  a.action_id = "";
+  a.action_type = "";
+  bad.nodes[0].actions = {a};
+
+  ASSERT_EQ(
+    master_->assign_order(kManufacturer, kSerial, bad).decision,
+    OrderAssignmentDecision::ASSIGNED);
+
+  ASSERT_TRUE(wait_for(
+    [&] { return rejected_calls.load() > 0; }, std::chrono::milliseconds(500)))
+    << "on_order_rejected did not fire within 500ms";
+
+  EXPECT_EQ(rejected_calls.load(), 1);
+  EXPECT_EQ(rejected_id, kOrderId);
+  // Empty action_id and empty action_type: one content error each.
+  EXPECT_EQ(error_count, 2u);
+}
+
 TEST_F(MasterAssignOrderTest, AssignOrder_FilledHeaderEnablesPublish)
 {
   make_agv_ready();

--- a/vda5050_core/test/master/test_integration_master_assign_order.cpp
+++ b/vda5050_core/test/master/test_integration_master_assign_order.cpp
@@ -424,9 +424,11 @@ TEST_F(MasterAssignOrderTest, OrderRejected_FiresWhenPublishStageRejects)
     [&](
       const std::string&, const std::string& order_id,
       const std::vector<vda5050_core::types::Error>& errors) {
-      rejected_calls.fetch_add(1);
+      // Publish the plain fields before the counter the waiter polls, so
+      // the main thread cannot read them mid-write.
       rejected_id = order_id;
       error_count = errors.size();
+      rejected_calls.fetch_add(1);
     });
 
   make_agv_ready();


### PR DESCRIPTION
## Summary
  `assign_order` returns `ASSIGNED` once the order is queued. The rest of the
  validation runs afterwards on the AGV's outbound worker, and if it rejects
  there the errors are logged and dropped: no callback, no state change, nothing
  to query. The order never reaches the AGV, so nothing comes back in State
  either.

  This adds `on_order_rejected(agv_id, order_id, errors)`, pairing with
  `on_order_complete` so both endings of an assigned order arrive the same way.