### PR TITLE
fix(client): pass action execution param as json

### DIFF
--- a/vda5050_core/include/vda5050_core/client/adapter/transformation.hpp
+++ b/vda5050_core/include/vda5050_core/client/adapter/transformation.hpp
@@ -27,9 +27,9 @@ namespace adapter {
 
 struct Pose2D
 {
-  double x;
-  double y;
-  double theta;
+  double x{0.0};
+  double y{0.0};
+  double theta{0.0};
 };
 
 class Transformation

--- a/vda5050_core/package.xml
+++ b/vda5050_core/package.xml
@@ -21,6 +21,7 @@
   <depend>libpaho-mqttpp-dev</depend>
   <depend>fmt</depend>
   <depend>pybind11-dev</depend>
+  <depend>pybind11-json-dev</depend>
 
   <exec_depend>python3</exec_depend>
   <exec_depend>python3-paho-mqtt</exec_depend>

--- a/vda5050_core/python/bindings.cpp
+++ b/vda5050_core/python/bindings.cpp
@@ -19,8 +19,10 @@
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11_json/pybind11_json.hpp>
 
 #include "vda5050_core/client/adapter/state_manager.hpp"
+#include "vda5050_core/client/adapter/transformation.hpp"
 #include "vda5050_core/types/action_state.hpp"
 #include "vda5050_core/types/action_status.hpp"
 #include "vda5050_core/types/agv_position.hpp"
@@ -55,7 +57,9 @@ using vda5050_core::python::rmf_migration::RobotState;
 using vda5050_core::python::rmf_migration::RobotUpdateHandle;
 using vda5050_core::python::rmf_migration::StopRequest;
 
+using vda5050_core::client::adapter::Pose2D;
 using vda5050_core::client::adapter::StateManager;
+using vda5050_core::client::adapter::Transformation;
 using vda5050_core::types::ActionState;
 using vda5050_core::types::ActionStatus;
 using vda5050_core::types::AGVPosition;
@@ -186,6 +190,17 @@ PYBIND11_MODULE(vda5050_core_python, m)
     .def("__eq__", &Info::operator==)
     .def("__ne__", &Info::operator!=);
 
+  py::class_<Pose2D>(m_client, "Pose2D")
+    .def(py::init<>())
+    .def_readwrite("x", &Pose2D::x)
+    .def_readwrite("y", &Pose2D::y)
+    .def_readwrite("theta", &Pose2D::theta);
+
+  py::class_<Transformation>(m_client, "Transformation")
+    .def_static("calibrate", &Transformation::calibrate)
+    .def("to_world_pose", &Transformation::to_world_pose)
+    .def("to_agv_pose", &Transformation::to_agv_pose);
+
   py::class_<StateManager, std::shared_ptr<StateManager>>(
     m_client, "StateManager")
     .def("set_position", &StateManager::set_position)
@@ -207,17 +222,15 @@ PYBIND11_MODULE(vda5050_core_python, m)
     .def("clear_errors", &StateManager::clear_errors)
     .def("add_information", &StateManager::add_information)
     .def("set_information", &StateManager::set_information)
-    .def("remove_information", &StateManager::remove_information);
+    .def("remove_information", &StateManager::remove_information)
+    .def("initialize_position", &StateManager::initialize_position)
+    .def("set_transformation", &StateManager::set_transformation);
 
   auto m_rmf_migration =
     m.def_submodule("rmf_migration", "Open-RMF style migration API");
 
-  py::class_<ActivityIdentifier>(m_rmf_migration, "ActivityIdentifier")
-    .def(
-      py::init<std::optional<std::string>, std::optional<std::string>>(),
-      py::arg("order_id") = std::nullopt, py::arg("action_id") = std::nullopt)
-    .def_property_readonly("order_id", &ActivityIdentifier::order_id)
-    .def_property_readonly("action_id", &ActivityIdentifier::action_id)
+  py::class_<ActivityIdentifier, std::shared_ptr<ActivityIdentifier>>(
+    m_rmf_migration, "ActivityIdentifier")
     .def("__eq__", &ActivityIdentifier::operator==)
     .def("__ne__", &ActivityIdentifier::operator!=);
 

--- a/vda5050_core/python/include/rmf_migration.hpp
+++ b/vda5050_core/python/include/rmf_migration.hpp
@@ -123,22 +123,19 @@ private:
 class ActivityIdentifier
 {
 public:
-  ActivityIdentifier(
-    std::optional<std::string> order_id = std::nullopt,
-    std::optional<std::string> action_id = std::nullopt);
-
-  const std::optional<std::string>& order_id() const;
-
-  const std::optional<std::string>& action_id() const;
-
   bool operator==(const ActivityIdentifier& other) const;
 
   bool operator!=(const ActivityIdentifier& other) const;
 
 private:
-  std::optional<std::string> order_id_;
-  std::optional<std::string> action_id_;
+  friend class FleetUpdateHandle;
+
+  explicit ActivityIdentifier(uint64_t identifier);
+
+  uint64_t identifier_;
 };
+using ActivityIdentifierPtr = std::shared_ptr<ActivityIdentifier>;
+using ConstActivityIdentifierPtr = std::shared_ptr<const ActivityIdentifier>;
 
 class CommandExecution
 {
@@ -151,25 +148,25 @@ public:
 
   void failed(const std::string& reason);
 
-  const ActivityIdentifier& identifier() const;
+  ConstActivityIdentifierPtr identifier() const;
 
 private:
   friend class FleetUpdateHandle;
 
   CommandExecution(
     std::shared_ptr<client::adapter::Execution> execution,
-    ActivityIdentifier identifier);
+    ConstActivityIdentifierPtr identifier);
 
   std::shared_ptr<client::adapter::Execution> execution_;
-  ActivityIdentifier identifier_;
+  ConstActivityIdentifierPtr identifier_;
 };
 
 using NavigationRequest = std::function<void(Destination, CommandExecution)>;
 
-using StopRequest = std::function<void()>;
+using StopRequest = std::function<void(ConstActivityIdentifierPtr)>;
 
 using ActionExecutor =
-  std::function<void(std::string, std::string, CommandExecution)>;
+  std::function<void(std::string, nlohmann::json, CommandExecution)>;
 
 using LocalizationRequest = std::function<void(Destination, CommandExecution)>;
 
@@ -200,7 +197,7 @@ private:
 class RobotUpdateHandle
 {
 public:
-  void update(RobotState state, ActivityIdentifier identifier);
+  void update(RobotState state, ConstActivityIdentifierPtr identifier);
 
   std::shared_ptr<client::adapter::StateManager> more();
 
@@ -274,6 +271,8 @@ private:
 
   std::unordered_map<std::string, std::shared_ptr<client::adapter::Adapter>>
     robots_;
+
+  std::atomic_uint64_t activity_count_{0};
 };
 
 class Adapter

--- a/vda5050_core/python/src/rmf_migration.cpp
+++ b/vda5050_core/python/src/rmf_migration.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 
 #include "vda5050_core/execution/protocol_adapter.hpp"
+#include "vda5050_core/json_utils/serialization.hpp"
 #include "vda5050_core/transport/mqtt_client_interface.hpp"
 #include "vda5050_core/types/agv_position.hpp"
 
@@ -166,29 +167,16 @@ Destination::Destination(
 }
 
 //=============================================================================
-ActivityIdentifier::ActivityIdentifier(
-  std::optional<std::string> order_id, std::optional<std::string> action_id)
-: order_id_(std::move(order_id)), action_id_(std::move(action_id))
+ActivityIdentifier::ActivityIdentifier(uint64_t identifier)
+: identifier_(identifier)
 {
   // Nothing to do here ...
 }
 
 //=============================================================================
-const std::optional<std::string>& ActivityIdentifier::order_id() const
-{
-  return order_id_;
-}
-
-//=============================================================================
-const std::optional<std::string>& ActivityIdentifier::action_id() const
-{
-  return action_id_;
-}
-
-//=============================================================================
 bool ActivityIdentifier::operator==(const ActivityIdentifier& other) const
 {
-  return order_id_ == other.order_id_ && action_id_ == other.action_id_;
+  return identifier_ == other.identifier_;
 }
 
 //=============================================================================
@@ -237,7 +225,7 @@ bool CommandExecution::is_finished() const
 }
 
 //=============================================================================
-const ActivityIdentifier& CommandExecution::identifier() const
+ConstActivityIdentifierPtr CommandExecution::identifier() const
 {
   return identifier_;
 }
@@ -245,7 +233,7 @@ const ActivityIdentifier& CommandExecution::identifier() const
 //=============================================================================
 CommandExecution::CommandExecution(
   std::shared_ptr<client::adapter::Execution> execution,
-  ActivityIdentifier identifier)
+  ConstActivityIdentifierPtr identifier)
 : execution_(std::move(execution)), identifier_(std::move(identifier))
 {
   // Nothing to do here ...
@@ -296,7 +284,7 @@ LocalizationRequest RobotCallbacks::localize() const
 
 //=============================================================================
 void RobotUpdateHandle::update(
-  RobotState state, ActivityIdentifier /*identifier*/)
+  RobotState state, ConstActivityIdentifierPtr /*identifier*/)
 {
   adapter_->state_manager()->set_position(
     state.position()[0], state.position()[1], state.position()[2], state.map());
@@ -444,7 +432,7 @@ std::shared_ptr<RobotUpdateHandle> FleetUpdateHandle::add_robot(
     RobotState::to_battery_state(initial_state.battery_state_of_charge()));
 
   adapter->on_navigate(
-    [callbacks](
+    [callbacks, this](
       client::adapter::NodeRequest node_request,
       std::optional<client::adapter::EdgeRequest> /*edge_request*/,
       std::shared_ptr<client::adapter::OrderExecution> execution) {
@@ -453,29 +441,48 @@ std::shared_ptr<RobotUpdateHandle> FleetUpdateHandle::add_robot(
         node_request.node_position().value().map_id,
         {node_position.x, node_position.y, node_position.theta.value_or(0.0)},
         node_request.sequence_id(), node_request.node_id());
-      auto command =
-        CommandExecution(execution, ActivityIdentifier(execution->order_id()));
+      auto command = CommandExecution(
+        execution, std::shared_ptr<ActivityIdentifier>(
+                     new ActivityIdentifier(activity_count_++)));
 
       callbacks.navigate()(std::move(destination), std::move(command));
     });
 
   adapter->on_action(
-    [callbacks](client::adapter::ActionRequest request, auto execution) {
+    [callbacks, this](
+      client::adapter::ActionRequest request,
+      std::shared_ptr<client::adapter::ActionExecution> execution) {
       auto command = CommandExecution(
-        execution, ActivityIdentifier(request.order_id(), request.action_id()));
-
-      callbacks.action_executor()(
-        request.action_type(), request.action_id(), std::move(command));
+        execution, std::shared_ptr<ActivityIdentifier>(
+                     new ActivityIdentifier(activity_count_++)));
+      if (request.action_type() == "startPause")
+      {
+        callbacks.stop()(command.identifier());
+        command.finished();
+      }
+      else
+      {
+        nlohmann::json description = {};
+        if (request.action_parameters().has_value())
+        {
+          description = request.action_parameters().value();
+        }
+        callbacks.action_executor()(
+          request.action_type(), description, std::move(command));
+      }
     });
 
   if (callbacks.localize())
   {
     adapter->on_localize(
-      [callbacks](
-        client::adapter::LocalizationRequest request, auto execution) {
+      [callbacks, this](
+        client::adapter::LocalizationRequest request,
+        std::shared_ptr<client::adapter::ActionExecution> execution) {
         auto destination = Destination(
           request.map_id(), {request.x(), request.y(), request.theta()});
-        auto command = CommandExecution(execution, ActivityIdentifier());
+        auto command = CommandExecution(
+          execution, std::shared_ptr<ActivityIdentifier>(
+                       new ActivityIdentifier(activity_count_++)));
 
         callbacks.localize()(std::move(destination), std::move(command));
       });


### PR DESCRIPTION
## Summary

This PR adds a few fixes to make the migration follow Open-RMF fleet adapter pattern more closely. 
- Fixes the arguments for the action executor callback
- Changes the activity identifier to make construction and comparison simpler
- Provides bindings for transformation classes
- Exposes the transformation related state manager functions
- Accepts `startPause` as way to invoke the `stop` callback