### PR TITLE
feat(pybind): add cibuildwheel support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -85,6 +85,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: "Install UV"
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
       - name: Install package and test dependencies
         run: uv sync --group dev
 
@@ -100,7 +103,7 @@ jobs:
 
   wheels:
     name: Build wheels ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-    needs: [lint, test]
+    needs: [lint, test, stub-test]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -107,12 +107,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["cp312"]
+        python: ["cp310", "cp312"]
         buildplat:
           - [ubuntu-latest, manylinux_x86_64]
-          - [ubuntu-latest, musllinux_x86_64]
           - [ubuntu-24.04-arm, manylinux_aarch64]
-          - [ubuntu-24.04-arm, musllinux_aarch64]
           - [macos-15-intel, macosx_x86_64]
           - [macos-15, macosx_arm64]
     runs-on: ${{ matrix.buildplat[0] }}
@@ -127,11 +125,7 @@ jobs:
       - name: Setup macOS
         if: startsWith(matrix.buildplat[1], 'macosx_')
         run: |
-          if [[ "${{ matrix.buildplat[1] }}" == "macosx_arm64" ]]; then
-            CIBW="MACOSX_DEPLOYMENT_TARGET=14.0"
-          else
-            CIBW="MACOSX_DEPLOYMENT_TARGET=15.0"
-          fi
+          CIBW="MACOSX_DEPLOYMENT_TARGET=15.0"
           echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -114,7 +114,7 @@ jobs:
           - [ubuntu-24.04-arm, manylinux_aarch64]
           - [ubuntu-24.04-arm, musllinux_aarch64]
           - [macos-15-intel, macosx_x86_64]
-          - [macos-14, macosx_arm64]
+          - [macos-15, macosx_arm64]
     runs-on: ${{ matrix.buildplat[0] }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,9 +64,6 @@ jobs:
   stub-test:
     name: Check Stale Stubs
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: vda5050_core
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,13 +8,14 @@ on:
       - main
       - develop
 
+defaults:
+  run:
+    working-directory: vda5050_core
+
 jobs:
   lint:
     name: Ruff Lint
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: vda5050_core
     steps:
       - uses: actions/checkout@v6
 
@@ -30,13 +31,10 @@ jobs:
   test:
     name: UV Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: vda5050_core
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v6
 
@@ -90,9 +88,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: "Install UV"
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-
       - name: Install package and test dependencies
         run: uv sync --group dev
 
@@ -105,3 +100,47 @@ jobs:
           fi
           echo "Stubs are stale!!"
           exit 1
+
+  wheels:
+    name: Build wheels ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+    needs: [lint, test]
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["cp312"]
+        buildplat:
+          - [ubuntu-latest, manylinux_x86_64]
+          - [ubuntu-latest, musllinux_x86_64]
+          - [ubuntu-24.04-arm, manylinux_aarch64]
+          - [ubuntu-24.04-arm, musllinux_aarch64]
+          - [macos-15-intel, macosx_x86_64]
+          - [macos-14, macosx_arm64]
+    runs-on: ${{ matrix.buildplat[0] }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: "Install UV"
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Setup macOS
+        if: startsWith(matrix.buildplat[1], 'macosx_')
+        run: |
+          if [[ "${{ matrix.buildplat[1] }}" == "macosx_arm64" ]]; then
+            CIBW="MACOSX_DEPLOYMENT_TARGET=14.0"
+          else
+            CIBW="MACOSX_DEPLOYMENT_TARGET=15.0"
+          fi
+          echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
+
+      - name: Build wheels
+        run: >
+          uvx cibuildwheel
+          --only "${{ matrix.python }}-${{ matrix.buildplat[1] }}"
+          --output-dir ../wheelhouse
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          path: wheelhouse/*.whl

--- a/vda5050_core/include/vda5050_core/execution/handler.hpp
+++ b/vda5050_core/include/vda5050_core/execution/handler.hpp
@@ -19,8 +19,8 @@
 #ifndef VDA5050_CORE__EXECUTION__HANDLER_HPP_
 #define VDA5050_CORE__EXECUTION__HANDLER_HPP_
 
-#include <atomic>
 #include <algorithm>
+#include <atomic>
 #include <condition_variable>
 #include <memory>
 #include <vector>

--- a/vda5050_core/include/vda5050_core/execution/handler.hpp
+++ b/vda5050_core/include/vda5050_core/execution/handler.hpp
@@ -20,6 +20,7 @@
 #define VDA5050_CORE__EXECUTION__HANDLER_HPP_
 
 #include <atomic>
+#include <algorithm>
 #include <condition_variable>
 #include <memory>
 #include <vector>

--- a/vda5050_core/include/vda5050_core/logger/logger.hpp
+++ b/vda5050_core/include/vda5050_core/logger/logger.hpp
@@ -19,7 +19,7 @@
 #ifndef VDA5050_CORE__LOGGER__LOGGER_HPP_
 #define VDA5050_CORE__LOGGER__LOGGER_HPP_
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/vda5050_core/pyproject.toml
+++ b/vda5050_core/pyproject.toml
@@ -67,12 +67,12 @@ extend-exclude = ["*.pyi"]
 build-frontend = "build[uv]"
 test-command = "pytest {project}/python/tests"
 test-groups = ["test"]
+before-build = [
+  "bash ./scripts/install-native-deps.sh",
+]
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 musllinux-x86_64-image = "musllinux_1_2"
 musllinux-aarch64-image = "musllinux_1_2"
-before-build = [
-  "bash ./scripts/install-native-deps.sh",
-]

--- a/vda5050_core/pyproject.toml
+++ b/vda5050_core/pyproject.toml
@@ -62,3 +62,17 @@ cache-keys = [
 
 [tool.ruff]
 extend-exclude = ["*.pyi"]
+
+[tool.cibuildwheel]
+build-frontend = "build[uv]"
+test-command = "pytest {project}/python/tests"
+test-groups = ["test"]
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+musllinux-x86_64-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"
+before-build = [
+  "bash ./scripts/install-native-deps.sh",
+]

--- a/vda5050_core/scripts/install-native-deps.sh
+++ b/vda5050_core/scripts/install-native-deps.sh
@@ -91,7 +91,7 @@ install_json_from_source() {
 
 # Header-only pybind11 CMake package for hosts without a distro package
 # (manylinux). PYBIND11_NOPYTHON avoids baking the container interpreter;
-# the wheel build still gets pybind11 from the build-system requires.
+# the wheel build still gets pybind11 from the build-system requires (v3 instead).
 install_pybind11_from_source() {
   local work
   work="$(mktemp -d)"
@@ -110,9 +110,6 @@ install_pybind11_from_source() {
 }
 
 # pybind11_json: header-only bridge between nlohmann::json and pybind11.
-# Not on PyPI/Homebrew; install from source so the SKBUILD wheel build
-# can find_package(pybind11_json). Requires pybind11's CMake config
-# discoverable via CMAKE_PREFIX_PATH or system paths.
 install_pybind11_json_from_source() {
   local work
   work="$(mktemp -d)"
@@ -211,4 +208,4 @@ case "$(uname -s)" in
     ;;
 esac
 
-echo "Native dependencies installed (Paho MQTT C++ $PAHO_CPP_TAG)."
+echo "All Native dependencies installed!"

--- a/vda5050_core/scripts/install-native-deps.sh
+++ b/vda5050_core/scripts/install-native-deps.sh
@@ -2,24 +2,27 @@
 # Install native build deps for vda5050 (fmt, nlohmann_json, Paho MQTT C++).
 set -euo pipefail
 
-PAHO_CPP_TAG="${PAHO_CPP_TAG:-v1.6.0}"
-FMT_TAG="${FMT_TAG:-11.2.0}"
-NLOHMANN_JSON_TAG="${NLOHMANN_JSON_TAG:-v3.11.3}"
-PYBIND11_TAG="${PYBIND11_TAG:-v2.13.6}"
-PYBIND11_JSON_TAG="${PYBIND11_JSON_TAG:-0.2.13}"
+PAHO_CPP_TAG="${PAHO_CPP_TAG:-c0b43a49d7b7e7b5e7009658ca22f19ac1112c83}"  # v1.6.0
+FMT_TAG="${FMT_TAG:-40626af88bd7df9a5fb80be7b25ac85b122d6c21}"  # 11.2.0
+NLOHMANN_JSON_TAG="${NLOHMANN_JSON_TAG:-9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03}"  # v3.11.3
+PYBIND11_TAG="${PYBIND11_TAG:-a2e59f0e7065404b44dfe92a28aca47ba1378dc4}"  # v2.13.6
+PYBIND11_JSON_TAG="${PYBIND11_JSON_TAG:-b02a2ad597d224c3faee1f05a56d81d4c4453092}"  # 0.2.13
 INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-/usr/local}"
 
 install_linux() {
   if command -v yum >/dev/null 2>&1; then
     # manylinux / Alma Linux images
-    yum install -y cmake git openssl-devel fmt-devel paho-c-devel paho-cpp-devel
+    yum install -y cmake git openssl-devel
+    install_fmt_from_source
     install_json_from_source
     install_pybind11_from_source
     install_pybind11_json_from_source
+    install_paho_from_source
   elif command -v apk >/dev/null 2>&1; then
     # musllinux / Alpine images
     apk add --no-cache \
       cmake git openssl-dev fmt-dev
+    install_fmt_from_source
     install_json_from_source
     install_pybind11_from_source
     install_pybind11_json_from_source
@@ -28,6 +31,23 @@ install_linux() {
     echo "Unsupported Linux package manager" >&2
     exit 1
   fi
+}
+
+install_fmt_from_source() {
+  local work
+  work="$(mktemp -d)"
+
+  git clone --depth 1 --branch "$FMT_TAG" \
+    https://github.com/fmtlib/fmt.git "$work/fmt"
+  cmake -S "$work/fmt" -B "$work/fmt/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DFMT_TEST=OFF
+  cmake --build "$work/fmt/build" --parallel
+  cmake --install "$work/fmt/build"
+
+  rm -rf "$work"
 }
 
 install_json_from_source() {
@@ -118,13 +138,16 @@ ensure_single_macos_paho_prefix() {
 }
 
 install_macos() {
-  brew install cmake ninja fmt nlohmann-json openssl@3 pybind11
+  brew install cmake openssl@3
 
   INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-$(brew --prefix)}"
   ensure_single_macos_paho_prefix "$INSTALL_PREFIX"
   export CMAKE_PREFIX_PATH="$INSTALL_PREFIX"
   export REPAIR_LIBRARY_PATH="$INSTALL_PREFIX/lib:$(brew --prefix openssl@3)/lib"
 
+  install_fmt_from_source
+  install_json_from_source
+  install_pybind11_from_source
   install_pybind11_json_from_source
   install_paho_from_source
 }

--- a/vda5050_core/scripts/install-native-deps.sh
+++ b/vda5050_core/scripts/install-native-deps.sh
@@ -35,7 +35,8 @@ install_linux() {
 
 git_shallow_clone() {
   if [ $# -lt 3 ]; then
-    echo "Error: git_shallow_clone $@"
+    echo "Error: git_shallow_clone"
+    echo "Bad parameters: $*"
     echo "Usage: git_shallow_clone <repo_url> <repo_dir> <repo_tag>"
     exit 1
   fi
@@ -43,17 +44,17 @@ git_shallow_clone() {
   local repo_dir=$1; shift
   local repo_tag=$1; shift
 
-  mkdir $repo_dir
-  git -C $repo_dir init -q
-  git -C $repo_dir remote add origin $repo_url
-  git -C $repo_dir fetch --depth 1 origin $repo_tag
-  git -C $repo_dir checkout -q $repo_tag
+  mkdir "$repo_dir"
+  git -C "$repo_dir" init -q
+  git -C "$repo_dir" remote add origin "$repo_url"
+  git -C "$repo_dir" fetch --depth 1 origin "$repo_tag"
+  git -C "$repo_dir" checkout -q "$repo_tag"
 }
 
 git_shallow_clone_recursive() {
   git_shallow_clone "$@"
   local repo_dir=${2:-.}
-  git -C $repo_dir submodule update --init --recursive --depth 1
+  git -C "$repo_dir" submodule update --init --recursive --depth 1
 }
 
 install_fmt_from_source() {
@@ -166,7 +167,7 @@ install_macos() {
   INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-$(brew --prefix)}"
   ensure_single_macos_paho_prefix "$INSTALL_PREFIX"
   export CMAKE_PREFIX_PATH="$INSTALL_PREFIX"
-  export REPAIR_LIBRARY_PATH="$INSTALL_PREFIX/lib:$(brew --prefix openssl@3)/lib"
+  REPAIR_LIBRARY_PATH="$INSTALL_PREFIX/lib:$(brew --prefix openssl@3)/lib"; export REPAIR_LIBRARY_PATH
 
   install_fmt_from_source
   install_json_from_source

--- a/vda5050_core/scripts/install-native-deps.sh
+++ b/vda5050_core/scripts/install-native-deps.sh
@@ -33,12 +33,35 @@ install_linux() {
   fi
 }
 
+git_shallow_clone() {
+  if [ $# -lt 3 ]; then
+    echo "Error: git_shallow_clone $@"
+    echo "Usage: git_shallow_clone <repo_url> <repo_dir> <repo_tag>"
+    exit 1
+  fi
+  local repo_url=$1; shift
+  local repo_dir=$1; shift
+  local repo_tag=$1; shift
+
+  mkdir $repo_dir
+  git -C $repo_dir init -q
+  git -C $repo_dir remote add origin $repo_url
+  git -C $repo_dir fetch --depth 1 origin $repo_tag
+  git -C $repo_dir checkout -q $repo_tag
+}
+
+git_shallow_clone_recursive() {
+  git_shallow_clone "$@"
+  local repo_dir=${2:-.}
+  git -C $repo_dir submodule update --init --recursive --depth 1
+}
+
 install_fmt_from_source() {
   local work
   work="$(mktemp -d)"
 
-  git clone --depth 1 --branch "$FMT_TAG" \
-    https://github.com/fmtlib/fmt.git "$work/fmt"
+  git_shallow_clone \
+    https://github.com/fmtlib/fmt.git "$work/fmt" "$FMT_TAG"
   cmake -S "$work/fmt" -B "$work/fmt/build" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
@@ -54,8 +77,8 @@ install_json_from_source() {
   local work
   work="$(mktemp -d)"
 
-  git clone --depth 1 --branch "$NLOHMANN_JSON_TAG" \
-    https://github.com/nlohmann/json.git "$work/json"
+  git_shallow_clone \
+    https://github.com/nlohmann/json.git "$work/json" "$NLOHMANN_JSON_TAG"
   cmake -S "$work/json" -B "$work/json/build" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
@@ -72,8 +95,8 @@ install_pybind11_from_source() {
   local work
   work="$(mktemp -d)"
 
-  git clone --depth 1 --branch "$PYBIND11_TAG" \
-    https://github.com/pybind/pybind11.git "$work/pybind11"
+  git_shallow_clone \
+    https://github.com/pybind/pybind11.git "$work/pybind11" "$PYBIND11_TAG"
   cmake -S "$work/pybind11" -B "$work/pybind11/build" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
@@ -93,8 +116,8 @@ install_pybind11_json_from_source() {
   local work
   work="$(mktemp -d)"
 
-  git clone --depth 1 --branch "$PYBIND11_JSON_TAG" \
-    https://github.com/pybind/pybind11_json.git "$work/pb11j"
+  git_shallow_clone \
+    https://github.com/pybind/pybind11_json.git "$work/pb11j" "$PYBIND11_JSON_TAG"
   # pybind11_json 0.2.13 still declares cmake_minimum_required(< 3.5);
   # CMake 4+ rejects that unless CMAKE_POLICY_VERSION_MINIMUM is set.
   # Empty PYTHON_INCLUDE_DIRS so the INTERFACE target does not bake the
@@ -155,11 +178,9 @@ install_macos() {
 install_paho_from_source() {
   local work
   work="$(mktemp -d)"
-  # shellcheck disable=SC2064
-  trap "rm -rf '$work'" EXIT
 
-  git clone --depth 1 --branch "$PAHO_CPP_TAG" --recursive \
-    https://github.com/eclipse/paho.mqtt.cpp.git "$work/paho.mqtt.cpp"
+  git_shallow_clone_recursive \
+    https://github.com/eclipse/paho.mqtt.cpp.git "$work/paho.mqtt.cpp" "$PAHO_CPP_TAG"
 
   cmake -S "$work/paho.mqtt.cpp" -B "$work/paho.mqtt.cpp/build" \
     -DCMAKE_BUILD_TYPE=Release \
@@ -172,6 +193,8 @@ install_paho_from_source() {
 
   cmake --build "$work/paho.mqtt.cpp/build" --parallel
   cmake --install "$work/paho.mqtt.cpp/build"
+
+  rm -rf "$work"
 }
 
 case "$(uname -s)" in

--- a/vda5050_core/scripts/install-native-deps.sh
+++ b/vda5050_core/scripts/install-native-deps.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Install native build deps for vda5050 (fmt, nlohmann_json, Paho MQTT C++).
+set -euo pipefail
+
+PAHO_CPP_TAG="${PAHO_CPP_TAG:-v1.6.0}"
+FMT_TAG="${FMT_TAG:-11.2.0}"
+NLOHMANN_JSON_TAG="${NLOHMANN_JSON_TAG:-v3.11.3}"
+PYBIND11_TAG="${PYBIND11_TAG:-v2.13.6}"
+PYBIND11_JSON_TAG="${PYBIND11_JSON_TAG:-0.2.13}"
+INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-/usr/local}"
+
+install_linux() {
+  if command -v yum >/dev/null 2>&1; then
+    # manylinux / Alma Linux images
+    yum install -y cmake git openssl-devel fmt-devel paho-c-devel paho-cpp-devel
+    install_json_from_source
+    install_pybind11_from_source
+    install_pybind11_json_from_source
+  elif command -v apk >/dev/null 2>&1; then
+    # musllinux / Alpine images
+    apk add --no-cache \
+      cmake git openssl-dev fmt-dev
+    install_json_from_source
+    install_pybind11_from_source
+    install_pybind11_json_from_source
+    install_paho_from_source
+  else
+    echo "Unsupported Linux package manager" >&2
+    exit 1
+  fi
+}
+
+install_json_from_source() {
+  local work
+  work="$(mktemp -d)"
+
+  git clone --depth 1 --branch "$NLOHMANN_JSON_TAG" \
+    https://github.com/nlohmann/json.git "$work/json"
+  cmake -S "$work/json" -B "$work/json/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DJSON_BuildTests=OFF
+  cmake --install "$work/json/build"
+
+  rm -rf "$work"
+}
+
+# Header-only pybind11 CMake package for hosts without a distro package
+# (manylinux). PYBIND11_NOPYTHON avoids baking the container interpreter;
+# the wheel build still gets pybind11 from the build-system requires.
+install_pybind11_from_source() {
+  local work
+  work="$(mktemp -d)"
+
+  git clone --depth 1 --branch "$PYBIND11_TAG" \
+    https://github.com/pybind/pybind11.git "$work/pybind11"
+  cmake -S "$work/pybind11" -B "$work/pybind11/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DPYBIND11_TEST=OFF \
+    -DPYBIND11_NOPYTHON=ON
+  cmake --build "$work/pybind11/build" --parallel
+  cmake --install "$work/pybind11/build"
+
+  rm -rf "$work"
+}
+
+# pybind11_json: header-only bridge between nlohmann::json and pybind11.
+# Not on PyPI/Homebrew; install from source so the SKBUILD wheel build
+# can find_package(pybind11_json). Requires pybind11's CMake config
+# discoverable via CMAKE_PREFIX_PATH or system paths.
+install_pybind11_json_from_source() {
+  local work
+  work="$(mktemp -d)"
+
+  git clone --depth 1 --branch "$PYBIND11_JSON_TAG" \
+    https://github.com/pybind/pybind11_json.git "$work/pb11j"
+  # pybind11_json 0.2.13 still declares cmake_minimum_required(< 3.5);
+  # CMake 4+ rejects that unless CMAKE_POLICY_VERSION_MINIMUM is set.
+  # Empty PYTHON_INCLUDE_DIRS so the INTERFACE target does not bake the
+  # host interpreter's include path (wheel builds use a different Python).
+  cmake -S "$work/pb11j" -B "$work/pb11j/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_PREFIX_PATH="${INSTALL_PREFIX}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}" \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DPYTHON_INCLUDE_DIRS=
+  cmake --build "$work/pb11j/build" --parallel
+  cmake --install "$work/pb11j/build"
+
+  rm -rf "$work"
+}
+
+# Paho is built from source with PAHO_WITH_MQTT_C=ON into PREFIX.
+# A second copy of the same dylib basename (Homebrew formula, leftover
+# /usr/local install, etc.) makes delocate fail with:
+#   Already planning to copy library with same basename as: libpaho-mqtt3as...
+ensure_single_macos_paho_prefix() {
+  local prefix="$1"
+  local other
+
+  if brew list --formula libpaho-mqtt >/dev/null 2>&1; then
+    echo "Uninstalling Homebrew libpaho-mqtt (conflicts with source Paho install)."
+    brew uninstall --ignore-dependencies libpaho-mqtt || true
+  fi
+
+  for other in /usr/local /opt/homebrew; do
+    [[ "${other}" == "${prefix}" ]] && continue
+    if compgen -G "${other}/lib/libpaho-mqtt*" >/dev/null 2>&1; then
+      echo "error: found conflicting Paho libs under ${other}/lib while PREFIX=${prefix}" >&2
+      echo "delocate cannot vendor two dylibs with the same basename." >&2
+      echo "Remove the extras, e.g.:" >&2
+      echo "  sudo rm -f ${other}/lib/libpaho-mqtt*" >&2
+      echo "  sudo rm -rf ${other}/include/mqtt ${other}/lib/cmake/PahoMqttCpp" >&2
+      exit 1
+    fi
+  done
+}
+
+install_macos() {
+  brew install cmake ninja fmt nlohmann-json openssl@3 pybind11
+
+  INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-$(brew --prefix)}"
+  ensure_single_macos_paho_prefix "$INSTALL_PREFIX"
+  export CMAKE_PREFIX_PATH="$INSTALL_PREFIX"
+  export REPAIR_LIBRARY_PATH="$INSTALL_PREFIX/lib:$(brew --prefix openssl@3)/lib"
+
+  install_pybind11_json_from_source
+  install_paho_from_source
+}
+
+install_paho_from_source() {
+  local work
+  work="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$work'" EXIT
+
+  git clone --depth 1 --branch "$PAHO_CPP_TAG" --recursive \
+    https://github.com/eclipse/paho.mqtt.cpp.git "$work/paho.mqtt.cpp"
+
+  cmake -S "$work/paho.mqtt.cpp" -B "$work/paho.mqtt.cpp/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_INSTALL_NAME_DIR="$INSTALL_PREFIX/lib" \
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+    -DPAHO_WITH_MQTT_C=ON \
+    -DPAHO_BUILD_EXAMPLES=OFF \
+    -DPAHO_WITH_SSL=ON
+
+  cmake --build "$work/paho.mqtt.cpp/build" --parallel
+  cmake --install "$work/paho.mqtt.cpp/build"
+}
+
+case "$(uname -s)" in
+  Linux)
+    install_linux
+    ;;
+  Darwin)
+    install_macos
+    ;;
+  *)
+    echo "Unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+echo "Native dependencies installed (Paho MQTT C++ $PAHO_CPP_TAG)."


### PR DESCRIPTION
Depend on #88 

~~Meanwhile you can check the diff from below~~
~~https://github.com/Briancbn/vda5050_client/compare/feat/bn/pybind-packaging...Briancbn:vda5050_client:feat/bn/add-cibw-support~~

The pipeline takes heavy inspiration from [numpy](https://github.com/numpy/numpy/blob/main/.github/workflows/wheels.yml)

- I can clean up the comments later, but this is ready for review.
- Let me know if I should separate the MacOS support into a different PR.

I only select 1 job for each architecture
We will probably make another repo for releases pipeline similar to [numpy/numpy-release](https://github.com/numpy/numpy-release) for all the architectures. 

> side note, they also release nightly version into conda-forge, which we can also consider.

How to run `cibuildwheel` locally

```sh
cd <repo-root>/vda5050_core
uvx cibuildwheel
```

After completion, you can find the `.whl` files under `wheelhouse` folder