### PR TITLE
fix(client): fix execution lifecycle handling for navigation and actions

### DIFF
--- a/vda5050_core/include/vda5050_core/client/adapter/action_execution.hpp
+++ b/vda5050_core/include/vda5050_core/client/adapter/action_execution.hpp
@@ -46,9 +46,11 @@ public:
 
   void paused(std::optional<std::string> result_description = std::nullopt);
 
-  void finished(std::optional<std::string> result_description = std::nullopt);
+  void finished() override;
 
-  void failed(const std::string& reason);
+  void finished(std::optional<std::string> result_description);
+
+  void failed(const std::string& reason) override;
 
 private:
   ActionExecution(

--- a/vda5050_core/include/vda5050_core/client/adapter/execution.hpp
+++ b/vda5050_core/include/vda5050_core/client/adapter/execution.hpp
@@ -35,9 +35,9 @@ class Execution : public std::enable_shared_from_this<Execution>
 public:
   virtual ~Execution();
 
-  void finished();
+  virtual void finished();
 
-  void failed(const std::string& reason);
+  virtual void failed(const std::string& reason);
 
   bool okay() const;
 
@@ -48,10 +48,10 @@ public:
 protected:
   Execution();
 
+  void deactivate();
+
 private:
   friend class Adapter;
-
-  void deactivate();
 
   std::optional<std::string> failure_reason_;
 

--- a/vda5050_core/include/vda5050_core/client/adapter/order_execution.hpp
+++ b/vda5050_core/include/vda5050_core/client/adapter/order_execution.hpp
@@ -43,9 +43,9 @@ public:
 
   uint32_t order_update_id() const;
 
-  void finished();
+  void finished() override;
 
-  void failed(const std::string& reason);
+  void failed(const std::string& reason) override;
 
 private:
   OrderExecution(

--- a/vda5050_core/src/client/adapter/action_execution.cpp
+++ b/vda5050_core/src/client/adapter/action_execution.cpp
@@ -57,6 +57,12 @@ void ActionExecution::paused(std::optional<std::string> result_description)
 }
 
 //=============================================================================
+void ActionExecution::finished()
+{
+  finished(std::nullopt);
+}
+
+//=============================================================================
 void ActionExecution::finished(std::optional<std::string> result_description)
 {
   if (is_finished()) return;

--- a/vda5050_core/src/client/adapter/state_manager.cpp
+++ b/vda5050_core/src/client/adapter/state_manager.cpp
@@ -158,6 +158,7 @@ void StateManager::clear_action_states()
 {
   std::lock_guard<std::mutex> lock(mutex_);
   state_.action_states.clear();
+  publish_requested_ = true;
 }
 
 //=============================================================================


### PR DESCRIPTION
## Summary

`CommandExecution` under `rmf_migration` holds the underlying `Execution` as a base-class pointer. Because the completion methods were implemented differently across the base and derived navigation and action execution classes, calling them from Python would result in the base class function being invoked due to downcasting behavior.

This caused executions that were successfully completed by the Python callback to remain active or be reported incorrectly as failed.

### Solution

Changed the execution API so that completion is handled through the appropriate virtual interface on the base `Execution` class, while the derived `ActionExecution`/`OrderExecution` classes perform their VDA5050 status callback before marking the underlying execution as complete.